### PR TITLE
fix: Collaboration items incorrectly grouped by update date

### DIFF
--- a/scripts/update-contributions.js
+++ b/scripts/update-contributions.js
@@ -431,7 +431,7 @@ async function fetchContributions(startYear, prCache) {
 				title: item.title,
 				url: item.html_url,
 				repo: `${owner}/${repoName}`,
-				date: item.updated_at, // Keeping this for the date grouping logic
+				date: firstCommentDate, // Keeping this for the date grouping logic
 				createdAt: item.created_at,
 				firstCommentedAt: firstCommentDate,
 			})


### PR DESCRIPTION
## Problem

Collaboration entries (Issues/PRs where the user only commented) were being grouped into the wrong quarter/year if the underlying issue or PR was **reopened or recently updated** by someone.

For example, a comment left two years ago on an issue would show up in the current quarter if that issue was reopened yesterday.

## Root Cause

The script used the issue/PR's generic `item.updated_at` property as the primary `date` for grouping and sorting collaboration items:

```javascript
// Original (incorrect) logic in fetchContributions:
date: item.updated_at, 
```

Since the `updated_at` timestamp changes every time the issue is reopened, labeled, or commented on by any user, the item was incorrectly filed into the quarter corresponding to the most recent activity date.

## Solution

This PR changes the collaboration logic to strictly use the date of the user's **first comment** (`firstCommentDate`) for grouping and sorting purposes.

The `firstCommentedAt` date is already being fetched correctly by `getFirstCommentDate()`. The fix is to use this specific date as the primary timestamp for the contribution object:

```javascript
// Corrected logic:
date: firstCommentDate, 
```

## Impact

- **Correct Grouping:** All collaborations will now be grouped into the calendar quarter corresponding to the date the user actually left their first comment.

- **Preserved Optimization:** The GitHub Search API filter (`updated:>=...`) remains in place to ensure efficient data fetching (only pulling recently updated items), but the final output is corrected to reflect the true contribution date.

- **No Duplication:** The existing deduplication logic, which prioritizes a "Reviewed PR" over a "Collaboration," remains intact and unaffected by this change.