### PR TITLE
Fix: Improving Report Accuracy and Context

### DIFF
--- a/scripts/update-contributions.js
+++ b/scripts/update-contributions.js
@@ -552,7 +552,7 @@ ${index + 1}. [**${item[0]}**](${repoUrl}) (${item[1]} contributions)`
 					"Created At",
 					"My First Review",
 					"My First Review Period",
-					"Last Update",
+					"Last Update / State",
 				],
 				widths: ["5%", "20%", "28%", "10%", "15%", "10%", "14%"],
 				keys: [

--- a/scripts/update-contributions.js
+++ b/scripts/update-contributions.js
@@ -208,8 +208,9 @@ async function fetchContributions(startYear, prCache) {
 				title: pr.title,
 				url: pr.html_url,
 				repo: `${owner}/${repoName}`,
-				date: pr.created_at,
+				date: pr.pull_request.merged_at, // 'date' is used for quarterly grouping, which must be the merge date.
 				mergedAt: pr.pull_request.merged_at,
+				createdAt: pr.created_at,
 				reviewPeriod: Math.round(
 					(new Date(pr.pull_request.merged_at) - new Date(pr.created_at)) /
 						(1000 * 60 * 60 * 24)
@@ -600,7 +601,9 @@ ${index + 1}. [**${item[0]}**](${repoUrl}) (${item[1]} contributions)`
 					tableContent += `      <td><a href='${item.url}'>${item.title}</a></td>\n`
 
 					if (section === "pullRequests") {
-						const createdAt = new Date(item.date).toISOString().split("T")[0]
+						const createdAt = new Date(item.createdAt)
+							.toISOString()
+							.split("T")[0]
 						const mergedAt = item.mergedAt
 							? new Date(item.mergedAt).toISOString().split("T")[0]
 							: "N/A"

--- a/scripts/update-contributions.js
+++ b/scripts/update-contributions.js
@@ -346,6 +346,7 @@ async function fetchContributions(startYear, prCache) {
 					mergePeriod,
 					myFirstReviewDate,
 					myFirstReviewPeriod,
+					state: pr.state,
 				})
 				uniqueReviewedPrs.add(pr.html_url)
 			}
@@ -552,7 +553,7 @@ ${index + 1}. [**${item[0]}**](${repoUrl}) (${item[1]} contributions)`
 					"My First Review Period",
 					"Last Update",
 				],
-				widths: ["5%", "20%", "28%", "10%", "15%", "10%", "12%"],
+				widths: ["5%", "20%", "28%", "10%", "15%", "10%", "14%"],
 				keys: [
 					"repo",
 					"title",
@@ -625,9 +626,15 @@ ${index + 1}. [**${item[0]}**](${repoUrl}) (${item[1]} contributions)`
 						const createdAt = new Date(item.createdAt)
 							.toISOString()
 							.split("T")[0]
+
 						const lastUpdateDate = new Date(item.date)
 							.toISOString()
 							.split("T")[0]
+
+						const rawPrState = item.state ? item.state.toUpperCase() : "N/A"
+						const displayState = item.mergedAt ? "MERGED" : rawPrState
+						const lastUpdateContent = `${lastUpdateDate}<br><strong>${displayState}</strong>`
+
 						const myFirstReviewAt = item.myFirstReviewDate
 							? new Date(item.myFirstReviewDate).toISOString().split("T")[0]
 							: "N/A"
@@ -636,7 +643,7 @@ ${index + 1}. [**${item[0]}**](${repoUrl}) (${item[1]} contributions)`
 						tableContent += `      <td>${createdAt}</td>\n`
 						tableContent += `      <td>${myFirstReviewAt}</td>\n`
 						tableContent += `      <td>${myFirstReviewPeriod}</td>\n`
-						tableContent += `      <td>${lastUpdateDate}</td>\n`
+						tableContent += `      <td>${lastUpdateContent}</td>\n`
 					} else if (section === "collaborations") {
 						const createdAt = new Date(item.createdAt)
 							.toISOString()

--- a/scripts/update-contributions.js
+++ b/scripts/update-contributions.js
@@ -383,7 +383,7 @@ async function fetchContributions(startYear, prCache) {
 				title: item.title,
 				url: item.html_url,
 				repo: `${owner}/${repoName}`,
-				date: item.updated_at, // Keeping this for the date grouping logic
+				date: firstCommentDate, // Keeping this for the date grouping logic
 				createdAt: item.created_at,
 				firstCommentedAt: firstCommentDate,
 			})
@@ -550,15 +550,16 @@ ${index + 1}. [**${item[0]}**](${repoUrl}) (${item[1]} contributions)`
 					"Created At",
 					"My First Review",
 					"My First Review Period",
+					"Last Update",
 				],
-				widths: ["5%", "25%", "35%", "15%", "10%", "10%"],
+				widths: ["5%", "20%", "28%", "10%", "15%", "10%", "12%"],
 				keys: [
 					"repo",
 					"title",
 					"createdAt",
-					"date",
 					"myFirstReviewDate",
 					"myFirstReviewPeriod",
+					"date",
 				],
 			},
 			collaborations: {
@@ -624,6 +625,9 @@ ${index + 1}. [**${item[0]}**](${repoUrl}) (${item[1]} contributions)`
 						const createdAt = new Date(item.createdAt)
 							.toISOString()
 							.split("T")[0]
+						const lastUpdateDate = new Date(item.date)
+							.toISOString()
+							.split("T")[0]
 						const myFirstReviewAt = item.myFirstReviewDate
 							? new Date(item.myFirstReviewDate).toISOString().split("T")[0]
 							: "N/A"
@@ -632,6 +636,7 @@ ${index + 1}. [**${item[0]}**](${repoUrl}) (${item[1]} contributions)`
 						tableContent += `      <td>${createdAt}</td>\n`
 						tableContent += `      <td>${myFirstReviewAt}</td>\n`
 						tableContent += `      <td>${myFirstReviewPeriod}</td>\n`
+						tableContent += `      <td>${lastUpdateDate}</td>\n`
 					} else if (section === "collaborations") {
 						const createdAt = new Date(item.createdAt)
 							.toISOString()


### PR DESCRIPTION
## Description

This PR introduces critical fixes to the contribution reporting logic to ensure both chronological accuracy and contextual clarity across all contribution categories.

Specifically, it addresses three key areas:

1.  **Chronology:** Merged PRs are now correctly attributed to the quarter they were merged, not when they were created.
2.  **Context:** Reviewed PRs now display their latest update date and status.
3.  **Stickiness:** Collaboration items remain permanently linked to the quarter of initial activity.

---

## Motivation: Fixing Misplaced Items and Date Confusion

### 1. Merged PR Grouping Problem (Creation vs. Merge Date)

**The Issue:** Authored Pull Requests were previously grouped into the quarter they were **created** (`created_at`), which often led to underreporting in current quarters. A PR created late in Q4 (e.g., December) but merged early in Q1 (e.g., January) would be hidden in the Q4 report, resulting in inaccurate quarterly productivity counts.

**The Goal:** Merged PRs must be grouped by the date they were **merged** to accurately reflect quarterly impact.

### 2. The Reviewed PR Problem (Dates and Final Status)

**The Issue:** When a reviewed PR moved quarters (e.g., from Q1 to Q4) due to a recent merge, the report lacked context, making the reason for its appearance in the Q4 report unclear.

**The Goal:** Provide full context for Reviewed PRs, tracking the historical credit (`My First Review` date), the current movement (`Last Update` date), and the accurate **final merge status** (displaying "OPEN", "MERGED", or "CLOSED").

### 3. The Collaboration Problem (Ensuring "Stickiness")

**The Issue:** The previous logic used the item's latest GitHub `updated_at` timestamp. For collaborations (where I only left a comment), this caused the entry to reappear in later reports if any developer later updated the issue, linking the contribution to unrelated activity.

**The Goal:** Collaborations should be **"sticky"** to the quarter they were first commented on, regardless of later external activity.

---

## Changes Implemented

### 1. Merged PR Grouping Fix (Chronology)

-   **Change:** The grouping date for **authored and merged PRs** (`contributions.pullRequests`) now strictly uses the **`pr.pull_request.merged_at`** timestamp.
-   **Result:** Authored PRs are accurately attributed to the quarter in which they contributed value by being merged.

### 2. Reviewed PR Reporting Fix (Clarity and Status)

-   **Changes:**
    - **Data Capture:** The raw PR status (`state: pr.state`) is now explicitly stored during the fetching process.
    - **Table Logic:** The table logic for **Reviewed PRs** now checks the merge timestamp. If a `merged_at` date exists, it displays **"MERGED"** as the status, overriding the generic "CLOSED" state from the API.
    - **Contextual Column:** The "Last Update / State" column was added to display the `updated_at` timestamp (the Grouping Date) alongside the final status, clarifying why the PR appeared in the current report.
-   **Result:** Reports clearly show if a review effort led to a successful merge.

### 3. Collaboration Grouping Fix (Stickiness)

-   **Change:** The internal grouping date for items categorized as **`collaborations`** has been permanently changed from `item.updated_at` to **`item.firstCommentedAt`**.
-   **Result:** Collaborations are now "sticky," appearing only in the quarter they were first commented on.