### PR TITLE
fix: Include closed PRs in collaborations

### DIFF
--- a/scripts/update-contributions.js
+++ b/scripts/update-contributions.js
@@ -369,7 +369,7 @@ async function fetchContributions(startYear, prCache) {
 
 		// --- Fetch Collaborations (PRs/Issues commented on by the user) ---
 		const collaborationsPrs = await getAllPages(
-			`is:pr is:open commenter:${GITHUB_USERNAME} -author:${GITHUB_USERNAME} -reviewed-by:${GITHUB_USERNAME} updated:>=${yearStart} updated:<${yearEnd}`
+			`is:pr commenter:${GITHUB_USERNAME} -author:${GITHUB_USERNAME} -reviewed-by:${GITHUB_USERNAME} updated:>=${yearStart} updated:<${yearEnd}`
 		)
 		const collaborationsIssues = await getAllPages(
 			`is:issue commenter:${GITHUB_USERNAME} -author:${GITHUB_USERNAME} updated:>=${yearStart} updated:<${yearEnd}`


### PR DESCRIPTION
## Summary

This PR updates `update-contributions.js` to correct an issue affecting the "Collaborations" section.
 Collaborations now include PRs that user commented on regardless of their state (open/closed/merged).

## Changes made

**Collaborations PR query:** removed the `is:open` filter from the search query, so commented PRs that were later closed are also returned:

- **Before:** `is:pr is:open commenter:<username> ...`
- **After:** `is:pr commenter:<username> ...`

## Why this change

Previously, PRs that user commented on but later closed were not being included in "Collaborations" because the search restricted results to open PRs only. That produced missing collaboration entries for comment-then-close workflows.

The fix is intentionally minimal and defensive. Removing `is:open` fixes missing collaboration entries without changing categorization rules.

## Behavioral notes

Closed PRs that user commented on will now appear in the collaborations list (unless they're captured earlier in reviewed PRs/merged PR queries).
