### PR TITLE
Update contribution workflow schedule for testing

### DIFF
--- a/.github/workflows/update-contributions.yml
+++ b/.github/workflows/update-contributions.yml
@@ -2,10 +2,14 @@ name: Update Contributions
 
 on:
   schedule:
-    # Monthly full sync at 00:01 UTC on the 1st of the month
-    - cron: '1 0 1 * *'
-    # Daily update at 01:00 UTC
-    - cron: '0 1 * * *'
+    # 🛠️ Hourly test run at the 15-minute mark of every hour
+    - cron: '15 * * * *' 
+    
+    # ❌ Temporarily remove or comment out the monthly/daily schedules for testing:
+    # # Monthly full sync at 00:01 UTC on the 1st of the month
+    # - cron: '1 0 1 * *' 
+    # # Daily update at 01:00 UTC
+    # - cron: '0 1 * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This PR temporarily changes the schedule for contribution updates to hourly testing.

This will be reverted later.