### PR TITLE
Feat: Implement Targeted Netlify Deployment via Build Hook

### DIFF
--- a/.github/workflows/update-contributions.yml
+++ b/.github/workflows/update-contributions.yml
@@ -68,6 +68,22 @@ jobs:
                 git commit -m "docs: Daily contributions update [skip ci]"
             fi
             git push
+            # Signal that a push occurred
+            echo "pushed=true" >> $GITHUB_OUTPUT 
           else
             echo "No changes to commit"
+            # Signal no push occurred
+            echo "pushed=false" >> $GITHUB_OUTPUT
           fi
+
+      # Triggers the Netlify build only if new content was committed and pushed
+      - name: Trigger Netlify Deployment
+        # Check the output from the previous step
+        if: steps.commit.outputs.pushed == 'true'
+        run: |
+          echo "Content updated. Triggering Netlify deployment via Build Hook..."
+          # The curl command hits the Netlify API endpoint
+          curl -X POST -d {} ${{ secrets.NETLIFY_BUILD_HOOK }}
+        env:
+          # Reference the Build Hook URL secret
+          NETLIFY_BUILD_HOOK: ${{ secrets.NETLIFY_BUILD_HOOK }}    


### PR DESCRIPTION
## Description

This PR refactors the deployment mechanism for the static contribution files (`contributions/html-generated/`). Instead of relying on Netlify's automatic Continuous Deployment (CD) trigger from Git pushes, this change switches to a targeted deployment signal via a Netlify Build Hook.

This change is only possible if the Netlify project has its Continuous Deployment disabled and the `NETLIFY_BUILD_HOOK` secret is configured in GitHub Actions.

### Why was this change necessary?

The previous setup led to deployment issues:

- **PR Build Failures:** Netlify attempts to run a build (or check the Publish directory) on every Pull Request and code merge. Since the `contributions/html-generated/` folder only contains generated data (not source code), Netlify builds triggered by code-only commits often failed with the error: "Deploy directory '`contributions/html-generated`' does not exist."

- **Inconsistent Deployment:** The actual, working deploys only happened after the scheduled GH Action ran and pushed the generated content, leading to deployment downtime after code merges.

## Solution Implemented

The workflow now follows these steps:

- **Check for Changes:** The existing `Commit and push changes` step now uses GitHub Actions output variables (`pushed=true/false`) to accurately determine if new generated content was pushed to the repository.

- **Disabled CD (Prerequisite):** Stopping builds in Netlify prevents the service from running on non-data-generating commits (PRs/merges).

- **Targeted Deployment:** A new final step, `Trigger Netlify Deployment`, runs only if new data was successfully committed and pushed. This step uses `curl` to call the Netlify Build Hook, signaling Netlify to pull the latest commit (which now includes the generated files) and publish it immediately.

This ensures deployment only occurs when fresh contribution data is available, making the deployment process reliable and immune to code-only commit failures.