### PR TITLE
fix: Broken link to quarterly reports on navbar

### DIFF
--- a/scripts/quarterly-reports-html-generator.js
+++ b/scripts/quarterly-reports-html-generator.js
@@ -18,9 +18,10 @@ const {
 // Import navbar
 const { navHtml } = require('./navbar');
 
-// Tell the browser to go up one directory (..) to find index.html and reports.html
-let navHtmlForReports = navHtml.replace('href="./"', 'href="../index.html"');
-navHtmlForReports = navHtmlForReports.replace('href="reports.html"', 'href="../reports.html"');
+// 1. Update the link from root (./) to relative root (../index.html)
+let navHtmlForReports = navHtml.replace(/href="\.\/"/g, 'href="../index.html"');
+// 2. Update all instances of 'reports.html' to the relative path '../reports.html'
+navHtmlForReports = navHtmlForReports.replace(/href="reports\.html"/g, 'href="../reports.html"');
 
 /**
  * Generates and writes a separate HTML file for each quarter's contributions.


### PR DESCRIPTION
## Description

This PR resolves a broken link issue in the main navbar where the "Quarterly Reports" link was directing to an incorrect or outdated path.

When navigating to the "Quarterly Reports" link from a quarterly report page, the reports are generated in year-specific subdirectories (e.g., `html-generated/2024/Q2-2024.html`), which means the navbar included in each report file needs to use relative paths like `../reports.html`.

## Changes Made

The fix is applied within `scripts/quarterly-reports-html-generator.js` to ensure the correct relative path is generated when building the report files.

The following regular expression replacement is used to update the path:

```html
/href="reports\.html"/g
```

The regular expression targets all global instances (`g` flag) of the literal string `href="reports.html"` within the imported navbar HTML, replacing it with the corrected relative path `href="../reports.html"`. This ensures consistency across all generated quarterly report files.