### PR TITLE
fix: Refine Quarterly Report Navigation and Centralize SVGs

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ Open the configuration file (`scripts/config.js`) and edit the following lines t
 // scripts/config.js
 
 // Change this to your GitHub handle
-const GITHUB_USERNAME = "adiati98"
+const GITHUB_USERNAME = 'adiati98';
 // Change this to the earliest year you want to track
-const SINCE_YEAR = 2019
+const SINCE_YEAR = 2019;
 // ...
 ```
 

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -1,0 +1,21 @@
+// constants.js
+
+/**
+ * Shared SVG definitions for consistent styling across multiple report pages.
+ */
+const LEFT_ARROW_SVG = `
+    <svg class="w-4 h-4" width="100%" height="100%" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M18 17L13 12L18 7M11 17L6 12L11 7" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    </svg>
+`;
+
+const RIGHT_ARROW_SVG = `
+    <svg class="w-4 h-4" width="100%" height="100%" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M6 17L11 12L6 7M13 17L18 12L13 7" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    </svg>
+`;
+
+module.exports = {
+  LEFT_ARROW_SVG,
+  RIGHT_ARROW_SVG,
+};

--- a/scripts/contributions-index-html-generator.js
+++ b/scripts/contributions-index-html-generator.js
@@ -12,8 +12,13 @@ const { BASE_DIR, SINCE_YEAR, GITHUB_USERNAME } = require('./config');
 const { navHtml } = require('./navbar');
 const { createFooterHtml } = require('./footer');
 
+// Import right arrow svg
+const { RIGHT_ARROW_SVG } = require('./constants');
+
 const HTML_OUTPUT_DIR_NAME = 'html-generated';
 const HTML_README_FILENAME = 'index.html';
+
+const rightArrowSvg = RIGHT_ARROW_SVG;
 
 /**
  * Calculates aggregate totals from all contribution data and writes the
@@ -135,8 +140,11 @@ ${navHtml}
             </div>
             
             <p class="text-center mt-12">
-                <a href="reports.html" class="inline-flex items-center px-6 py-3 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition duration-150">
-                    View Detailed Quarterly Reports →
+                <a href="reports.html" class="inline-flex items-center flex-col sm:flex-row space-y-2 sm:space-y-0 sm:space-x-2 px-6 py-3 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition duration-150">
+                    <span class="pr-2">
+                        View Detailed Quarterly Reports
+                    </span>
+                    ${rightArrowSvg}
                 </a>
             </p>
         </section>

--- a/scripts/quarterly-reports-html-generator.js
+++ b/scripts/quarterly-reports-html-generator.js
@@ -237,7 +237,7 @@ async function writeHtmlFiles(groupedContributions) {
 ${navHtmlForReports}
 		<div class="mx-auto max-w-7xl bg-white p-6 sm:p-10 rounded-xl shadow-2xl mt-16">
     		<header class="text-center mb-12 pb-4 border-b-2 border-indigo-100">
-        		<h1 class="text-4xl sm:text-5xl font-extrabold text-indigo-700 mb-2">${quarter} ${year}</h1>
+        		<h1 class="text-4xl sm:text-5xl font-extrabold text-indigo-700 mb-2 pt-8">${quarter} ${year}</h1>
         		<p class="text-lg text-gray-500 mt-2">Open Source Contributions Report</p>
     		</header>
 

--- a/scripts/quarterly-reports-html-generator.js
+++ b/scripts/quarterly-reports-html-generator.js
@@ -80,7 +80,7 @@ async function writeHtmlFiles(groupedContributions) {
     } else {
       // Disabled style for the oldest report
       previousButton = dedent`
-                <span class="w-36 h-12 flex justify-center items-center space-x-2 px-4 py-2 bg-indigo-600 text-white font-semibold rounded-lg shadow-md hover:bg-indigo-700 transition duration-150">
+                <span class="w-36 h-12 flex justify-center items-center space-x-2 px-4 py-2 bg-gray-300 text-gray-500 font-semibold rounded-lg shadow-md cursor-not-allowed">
                     <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"></path></svg>
                     <span>First Report</span>
                 </span>
@@ -99,7 +99,7 @@ async function writeHtmlFiles(groupedContributions) {
     } else {
       // Disabled style for the most recent report
       nextButton = `
-                <span class="w-36 h-12 flex justify-center items-center space-x-2 px-4 py-2 bg-indigo-600 text-white font-semibold rounded-lg shadow-md hover:bg-indigo-700 transition duration-150">
+                <span class="w-36 h-12 flex justify-center items-center space-x-2 px-4 py-2 bg-gray-300 text-gray-500 font-semibold rounded-lg shadow-md cursor-not-allowed">
                     <span>Most Recent</span>
                     <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"></path></svg>
                 </span>

--- a/scripts/quarterly-reports-html-generator.js
+++ b/scripts/quarterly-reports-html-generator.js
@@ -78,13 +78,8 @@ async function writeHtmlFiles(groupedContributions) {
                 </a>
             `;
     } else {
-      // Disabled style for the oldest report
-      previousButton = dedent`
-                <span class="w-36 h-12 flex justify-center items-center space-x-2 px-4 py-2 bg-gray-300 text-gray-500 font-semibold rounded-lg shadow-md cursor-not-allowed">
-                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"></path></svg>
-                    <span>First Report</span>
-                </span>
-            `;
+      // Remove previous button
+      previousButton = '<div class="w-36 h-12"></div>';
     }
 
     // --- Next Button Logic ---
@@ -104,6 +99,12 @@ async function writeHtmlFiles(groupedContributions) {
                     <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"></path></svg>
                 </span>
             `;
+    }
+
+    if (!previousReport) {
+      placeholder = '<div class="w-36 h-12"></div>';
+    } else {
+      placeholder = '';
     }
 
     return dedent`

--- a/scripts/quarterly-reports-html-generator.js
+++ b/scripts/quarterly-reports-html-generator.js
@@ -19,6 +19,9 @@ const {
 const { navHtml } = require('./navbar');
 const { createFooterHtml } = require('./footer');
 
+// Import left and right arrow svgs
+const { LEFT_ARROW_SVG, RIGHT_ARROW_SVG } = require('./constants');
+
 // 1. Update the link from root (./) to relative root (../index.html)
 let navHtmlForReports = navHtml.replace(/href="\.\/"/g, 'href="../index.html"');
 // 2. Update all instances of 'reports.html' to the relative path '../reports.html'
@@ -61,6 +64,9 @@ async function writeHtmlFiles(groupedContributions) {
     let previousButton = '';
     let nextButton = '';
 
+    const leftArrowSvg = LEFT_ARROW_SVG;
+    const rightArrowSvg = RIGHT_ARROW_SVG;
+
     // Helper function to build the relative path: ../YEAR/QX-YYYY.html
     const getReportPath = (report) => {
       const fileName = `${report.quarterPrefix}-${report.year}.html`;
@@ -73,7 +79,7 @@ async function writeHtmlFiles(groupedContributions) {
       const prevPath = getReportPath(previousReport);
       previousButton = dedent`
                 <a href="${prevPath}" class="w-36 h-12 flex justify-center items-center space-x-2 px-4 py-2 bg-indigo-600 text-white font-semibold rounded-lg shadow-md hover:bg-indigo-700 transition duration-150">
-                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"></path></svg>
+                    ${leftArrowSvg}
                     <span>Previous</span>
                 </a>
             `;
@@ -88,7 +94,7 @@ async function writeHtmlFiles(groupedContributions) {
       nextButton = dedent`
                 <a href="${nextPath}" class="w-36 h-12 flex justify-center items-center space-x-2 px-4 py-2 bg-indigo-600 text-white font-semibold rounded-lg shadow-md hover:bg-indigo-700 transition duration-150">
                     <span>Next</span>
-                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"></path></svg>
+                    ${rightArrowSvg}
                 </a>
             `;
     } else {

--- a/scripts/quarterly-reports-html-generator.js
+++ b/scripts/quarterly-reports-html-generator.js
@@ -72,15 +72,15 @@ async function writeHtmlFiles(groupedContributions) {
     if (previousReport) {
       const prevPath = getReportPath(previousReport);
       previousButton = dedent`
-                <a href="${prevPath}" class="px-6 py-2 bg-indigo-600 text-white font-semibold rounded-lg shadow-md hover:bg-indigo-700 transition duration-150 flex items-center space-x-2">
+                <a href="${prevPath}" class="w-36 h-12 flex justify-center items-center space-x-2 px-4 py-2 bg-indigo-600 text-white font-semibold rounded-lg shadow-md hover:bg-indigo-700 transition duration-150">
                     <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"></path></svg>
-                    <span>Previous Report</span>
+                    <span>Previous</span>
                 </a>
             `;
     } else {
       // Disabled style for the oldest report
       previousButton = dedent`
-                <span class="px-6 py-2 bg-gray-300 text-gray-500 font-semibold rounded-lg shadow-inner cursor-not-allowed flex items-center space-x-2">
+                <span class="w-36 h-12 flex justify-center items-center space-x-2 px-4 py-2 bg-indigo-600 text-white font-semibold rounded-lg shadow-md hover:bg-indigo-700 transition duration-150">
                     <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"></path></svg>
                     <span>First Report</span>
                 </span>
@@ -91,15 +91,15 @@ async function writeHtmlFiles(groupedContributions) {
     if (nextReport) {
       const nextPath = getReportPath(nextReport);
       nextButton = dedent`
-                <a href="${nextPath}" class="px-6 py-2 bg-indigo-600 text-white font-semibold rounded-lg shadow-md hover:bg-indigo-700 transition duration-150 flex items-center space-x-2">
-                    <span>Next Report</span>
+                <a href="${nextPath}" class="w-36 h-12 flex justify-center items-center space-x-2 px-4 py-2 bg-indigo-600 text-white font-semibold rounded-lg shadow-md hover:bg-indigo-700 transition duration-150">
+                    <span>Next</span>
                     <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"></path></svg>
                 </a>
             `;
     } else {
       // Disabled style for the most recent report
       nextButton = `
-                <span class="px-6 py-2 bg-gray-300 text-gray-500 font-semibold rounded-lg shadow-inner cursor-not-allowed flex items-center space-x-2">
+                <span class="w-36 h-12 flex justify-center items-center space-x-2 px-4 py-2 bg-indigo-600 text-white font-semibold rounded-lg shadow-md hover:bg-indigo-700 transition duration-150">
                     <span>Most Recent</span>
                     <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"></path></svg>
                 </span>
@@ -107,7 +107,7 @@ async function writeHtmlFiles(groupedContributions) {
     }
 
     return dedent`
-            <div class="mt-12 mb-8 mx-auto max-w-7xl flex justify-between items-center px-4 sm:px-6 lg:px-8">
+            <div class="mt-12 mb-8 mx-auto max-w-7xl flex justify-between items-center gap-4">
                 ${previousButton}
                 ${nextButton}
             </div>


### PR DESCRIPTION
This PR improves the visual consistency and responsiveness of the Next/Previous navigation bar in the quarterly report pages and cleans up the codebase by centralizing reusable SVG icons.

## Changes Made

The logic within `generateReportNavButton` has been refactored to ensure a clean, predictable, and professional look across all screen sizes and edge cases (first and last reports).

### 1. Fixed Button Size and Alignment

- The buttons now use fixed dimensions (`w-36 h-12`) to ensure they maintain the same size regardless of the text length ("Previous," "Next," or "Most Recent").

- This eliminates the issue where button size relied on text length, providing a cleaner, grid-like layout.

### 2. Fixed Spacing on Small Screens 

- The container uses `gap-4` and `justify-between` within a `max-w-7xl` wrapper, which now correctly enforces a consistent gap between the previous and next buttons, even on smaller screens, preventing them from touching.

### 3. Boundary Condition Consistency

- The logic for the first and last reports ensures no visual jump or offset when a button is missing.

- When the "Previous" button is absent (on the oldest report — previously was "First Report"), an empty `div class="w-36 h-12"></div>` placeholder is correctly rendered to maintain the structural alignment of the remaining "Next" button.

### 4. Code Cleanup & Modularity

- **New `constants.js` File:** Created a dedicated file to store reusable SVG icons (`LEFT_ARROW_SVG, RIGHT_ARROW_SVG`). This centralizes icon styling and improves the maintainability of the main report generator script.