### PR TITLE
Feature: Enforce Consistent Descending Sort Order for Quarterly Reports (Markdown)

### DIFF
--- a/scripts/quarterly-reports-generator.js
+++ b/scripts/quarterly-reports-generator.js
@@ -149,11 +149,11 @@ ${index + 1}. [**${item[0]}**](${repoUrl}) (${item[1]} contributions)`;
       // Sort reviewed and co-authored PRs by their engagement date (ascending order)
       if (section === 'reviewedPrs' && items && items.length > 0) {
         items = [...items].sort((a, b) => {
-          return new Date(a.myFirstReviewDate) - new Date(b.myFirstReviewDate);
+          return new Date(b.myFirstReviewDate) - new Date(a.myFirstReviewDate);
         });
       } else if (section === 'coAuthoredPrs' && items && items.length > 0) {
         items = [...items].sort((a, b) => {
-          return new Date(a.firstCommitDate) - new Date(b.firstCommitDate);
+          return new Date(b.firstCommitDate) - new Date(a.firstCommitDate);
         });
       }
 


### PR DESCRIPTION
## Summary

This PR addresses an inconsistency in the contribution display order by ensuring that all contribution lists, including **Reviewed PRs** and **Co-Authored PRs**, are sorted from **newest to oldest** (descending) within their respective calendar quarters.

Previously, while merged PRs, issues, and collaborations were generally sorted descendingly (newest to oldest), `reviewedPrs` and `coAuthoredPrs` were incorrectly sorted ascendingly (oldest to newest) based on their engagement date.

## Changes Made

### 1. In `quarterly-reports-generator.js` (The Direct Fix)

* **Modified the sort comparison logic** within the loop that generates the HTML tables for `reviewedPrs` and `coAuthoredPrs`.
    * The sort was changed from the ascending comparison (`new Date(a) - new Date(b)`) to the **descending comparison** (`new Date(b) - new Date(a)`).
* The relevant sort keys used were **`myFirstReviewDate`** (for reviewed PRs) and **`firstCommitDate`** (for co-authored PRs).

## Verification

| Contribution Type | Key Sort Field | New Sort Order |
| :--- | :--- | :--- |
| **Merged PRs** (`pullRequests`) | `mergedAt` / `date` | Newest → Oldest |
| **Issues** (`issues`) | `createdAt` / `date` | Newest → Oldest |
| **Reviewed PRs** (`reviewedPrs`) | **`myFirstReviewDate`** | **Newest → Oldest (Fixed)** |
| **Co-Authored PRs** (`coAuthoredPrs`) | **`firstCommitDate`** | **Newest → Oldest (Fixed)** |
| **Collaborations** (`collaborations`) | `firstCommentedAt` | Newest → Oldest |

This ensures that the most recent activity within a given quarter always appears at the top of its respective table in the generated reports.