### PR TITLE
Fix: Responsive Layout and Vertical Alignment for All-Time Stats

### DIFF
--- a/scripts/contributions-index-html-generator.js
+++ b/scripts/contributions-index-html-generator.js
@@ -148,7 +148,7 @@ ${navHtml}
               <div class="flex-1 flex flex-col justify-center px-6 py-2 border-b border-gray-100 hover:bg-gray-50 transition-colors duration-200">
                 <div class="flex justify-between items-center mb-2">
                   <span class="text-base sm:text-lg font-medium text-gray-700">Merged PRs</span>
-                  <div class="flex flex-col sm:flex-row sm:items-end">
+                  <div class="flex flex-col sm:flex-row items-end sm:items-baseline">
                     <span style="color: ${COLORS.primary.rgb};" class="font-extrabold sm:font-bold text-xl sm:text-2xl text-right">${prCount}</span>
                     <span class="text-xs sm:text-sm text-gray-400 ml-0 sm:ml-1 font-mono text-right">${stats.prs.pctStr}</span>
                   </div>
@@ -161,7 +161,7 @@ ${navHtml}
               <div class="flex-1 flex flex-col justify-center px-6 py-2 border-b border-gray-100 hover:bg-gray-50 transition-colors duration-200">
                 <div class="flex justify-between items-center mb-2">
                   <span class="text-base sm:text-lg font-medium text-gray-700">Issues</span>
-                  <div class="flex flex-col sm:flex-row items-end">
+                  <div class="flex flex-col sm:flex-row items-end sm:items-baseline">
                     <span style="color: ${COLORS.primary.rgb};" class="font-extrabold sm:font-bold text-xl sm:text-2xl text-right">${issueCount}</span>
                     <span class="text-xs sm:text-sm text-gray-400 ml-0 sm:ml-1 font-mono text-right">${stats.issues.pctStr}</span>
                   </div>
@@ -174,7 +174,7 @@ ${navHtml}
               <div class="flex-1 flex flex-col justify-center px-6 py-2 border-b border-gray-100 hover:bg-gray-50 transition-colors duration-200">
                 <div class="flex justify-between items-center mb-2">
                   <span class="text-base sm:text-lg font-medium text-gray-700">Reviewed PRs</span>
-                  <div class="flex flex-col sm:flex-row items-end">
+                  <div class="flex flex-col sm:flex-row items-end sm:items-baseline">
                     <span style="color: ${COLORS.primary.rgb};" class="font-extrabold sm:font-bold text-xl sm:text-2xl text-right">${reviewedPrCount}</span>
                     <span class="text-xs sm:text-sm text-gray-400 ml-0 sm:ml-1 font-mono text-right">${stats.reviews.pctStr}</span>
                   </div>
@@ -187,7 +187,7 @@ ${navHtml}
               <div class="flex-1 flex flex-col justify-center px-6 py-2 border-b border-gray-100 hover:bg-gray-50 transition-colors duration-200">
                 <div class="flex justify-between items-center mb-2">
                   <span class="text-base sm:text-lg font-medium text-gray-700">Co-Authored PRs</span>
-                  <div class="flex flex-col sm:flex-row items-end">
+                  <div class="flex flex-col sm:flex-row items-end sm:items-baseline">
                     <span style="color: ${COLORS.primary.rgb};" class="font-extrabold sm:font-bold text-xl sm:text-2xl text-right">${coAuthoredPrCount}</span>
                     <span class="text-xs sm:text-sm text-gray-400 ml-0 sm:ml-1 font-mono text-right">${stats.coauth.pctStr}</span>
                   </div>
@@ -200,9 +200,9 @@ ${navHtml}
               <div class="flex-1 flex flex-col justify-center px-6 py-2 hover:bg-gray-50 transition-colors duration-200">
                 <div class="flex justify-between items-center mb-2">
                   <span class="text-base sm:text-lg font-medium text-gray-700">Collaborations</span>
-                  <div class="flex flex-col sm:flex-row items-end">
-                    <span style="color: ${COLORS.primary.rgb};" class="font-extrabold sm:font-bold text-xl sm:text-2xl text-xs sm:text-smght">${collaborationCount}</span>
-                    <span class="text-sm text-gray-400 ml-0 sm:ml-1 font-mono text-right">${stats.collab.pctStr}</span>
+                  <div class="flex flex-col sm:flex-row items-end sm:items-baseline">
+                    <span style="color: ${COLORS.primary.rgb};" class="font-extrabold sm:font-bold text-xl sm:text-2xl text-right">${collaborationCount}</span>
+                    <span class="text-xs sm:text-sm text-gray-400 ml-0 sm:ml-1 font-mono text-right">${stats.collab.pctStr}</span>
                   </div>
                 </div>
                 <div class="w-full bg-gray-100 rounded-full h-2">

--- a/scripts/contributions-index-html-generator.js
+++ b/scripts/contributions-index-html-generator.js
@@ -146,11 +146,11 @@ ${navHtml}
             <div class="col-span-1 md:col-span-2 flex flex-col h-full bg-white rounded-xl shadow-md border border-gray-200 overflow-hidden"> 
               
               <div class="flex-1 flex flex-col justify-center px-6 py-2 border-b border-gray-100 hover:bg-gray-50 transition-colors duration-200">
-                <div class="flex justify-between items-end mb-2">
+                <div class="flex justify-between items-center mb-2">
                   <span class="text-base sm:text-lg font-medium text-gray-700">Merged PRs</span>
-                  <div class="text-right">
-                    <span style="color: ${COLORS.primary.rgb};" class="font-bold text-2xl">${prCount}</span>
-                    <span class="text-sm text-gray-400 ml-1 font-mono">${stats.prs.pctStr}</span>
+                  <div class="flex flex-col sm:flex-row sm:items-end">
+                    <span style="color: ${COLORS.primary.rgb};" class="font-extrabold sm:font-bold text-xl sm:text-2xl text-right">${prCount}</span>
+                    <span class="text-xs sm:text-sm text-gray-400 ml-0 sm:ml-1 font-mono text-right">${stats.prs.pctStr}</span>
                   </div>
                 </div>
                 <div class="w-full bg-gray-100 rounded-full h-2">
@@ -159,11 +159,11 @@ ${navHtml}
               </div>
 
               <div class="flex-1 flex flex-col justify-center px-6 py-2 border-b border-gray-100 hover:bg-gray-50 transition-colors duration-200">
-                <div class="flex justify-between items-end mb-2">
+                <div class="flex justify-between items-center mb-2">
                   <span class="text-base sm:text-lg font-medium text-gray-700">Issues</span>
-                  <div class="text-right">
-                    <span style="color: ${COLORS.primary.rgb};" class="font-bold text-2xl">${issueCount}</span>
-                    <span class="text-sm text-gray-400 ml-1 font-mono">${stats.issues.pctStr}</span>
+                  <div class="flex flex-col sm:flex-row items-end">
+                    <span style="color: ${COLORS.primary.rgb};" class="font-extrabold sm:font-bold text-xl sm:text-2xl text-right">${issueCount}</span>
+                    <span class="text-xs sm:text-sm text-gray-400 ml-0 sm:ml-1 font-mono text-right">${stats.issues.pctStr}</span>
                   </div>
                 </div>
                 <div class="w-full bg-gray-100 rounded-full h-2">
@@ -172,11 +172,11 @@ ${navHtml}
               </div>
 
               <div class="flex-1 flex flex-col justify-center px-6 py-2 border-b border-gray-100 hover:bg-gray-50 transition-colors duration-200">
-                <div class="flex justify-between items-end mb-2">
+                <div class="flex justify-between items-center mb-2">
                   <span class="text-base sm:text-lg font-medium text-gray-700">Reviewed PRs</span>
-                  <div class="text-right">
-                    <span style="color: ${COLORS.primary.rgb};" class="font-bold text-2xl">${reviewedPrCount}</span>
-                    <span class="text-sm text-gray-400 ml-1 font-mono">${stats.reviews.pctStr}</span>
+                  <div class="flex flex-col sm:flex-row items-end">
+                    <span style="color: ${COLORS.primary.rgb};" class="font-extrabold sm:font-bold text-xl sm:text-2xl text-right">${reviewedPrCount}</span>
+                    <span class="text-xs sm:text-sm text-gray-400 ml-0 sm:ml-1 font-mono text-right">${stats.reviews.pctStr}</span>
                   </div>
                 </div>
                 <div class="w-full bg-gray-100 rounded-full h-2">
@@ -185,11 +185,11 @@ ${navHtml}
               </div>
 
               <div class="flex-1 flex flex-col justify-center px-6 py-2 border-b border-gray-100 hover:bg-gray-50 transition-colors duration-200">
-                <div class="flex justify-between items-end mb-2">
+                <div class="flex justify-between items-center mb-2">
                   <span class="text-base sm:text-lg font-medium text-gray-700">Co-Authored PRs</span>
-                  <div class="text-right">
-                    <span style="color: ${COLORS.primary.rgb};" class="font-bold text-2xl">${coAuthoredPrCount}</span>
-                    <span class="text-sm text-gray-400 ml-1 font-mono">${stats.coauth.pctStr}</span>
+                  <div class="flex flex-col sm:flex-row items-end">
+                    <span style="color: ${COLORS.primary.rgb};" class="font-extrabold sm:font-bold text-xl sm:text-2xl text-right">${coAuthoredPrCount}</span>
+                    <span class="text-xs sm:text-sm text-gray-400 ml-0 sm:ml-1 font-mono text-right">${stats.coauth.pctStr}</span>
                   </div>
                 </div>
                 <div class="w-full bg-gray-100 rounded-full h-2">
@@ -198,11 +198,11 @@ ${navHtml}
               </div>
 
               <div class="flex-1 flex flex-col justify-center px-6 py-2 hover:bg-gray-50 transition-colors duration-200">
-                <div class="flex justify-between items-end mb-2">
+                <div class="flex justify-between items-center mb-2">
                   <span class="text-base sm:text-lg font-medium text-gray-700">Collaborations</span>
-                  <div class="text-right">
-                    <span style="color: ${COLORS.primary.rgb};" class="font-bold text-2xl">${collaborationCount}</span>
-                    <span class="text-sm text-gray-400 ml-1 font-mono">${stats.collab.pctStr}</span>
+                  <div class="flex flex-col sm:flex-row items-end">
+                    <span style="color: ${COLORS.primary.rgb};" class="font-extrabold sm:font-bold text-xl sm:text-2xl text-xs sm:text-smght">${collaborationCount}</span>
+                    <span class="text-sm text-gray-400 ml-0 sm:ml-1 font-mono text-right">${stats.collab.pctStr}</span>
                   </div>
                 </div>
                 <div class="w-full bg-gray-100 rounded-full h-2">


### PR DESCRIPTION
This PR addresses layout issues on small screens and corrects the vertical alignment of metrics on wider screens within the generated `index.html` file.

## Key Changes

The responsive behavior of the five core contribution metrics (PRs, Issues, Reviews, Co-Authored, Collaborations) is updated to ensure correct vertical placement in both stacked and inline views.

1.  **Mobile Stacking & Right Alignment (Small Screens):**
    * The containers remain **stacked vertically** (`flex-col`) for small screens, with both count and percentage text right-aligned (`text-right`).

2.  **Perfect Baseline Alignment (Medium/Large Screens):**
    * The inner metric container now uses **`sm:items-baseline`** (in addition to the existing `items-end` for vertical stacking on mobile).
    * **`items-baseline`** ensures that when the count and percentage are displayed inline (`sm:flex-row`), the smaller percentage text is aligned precisely with the bottom of the larger count number, correcting the previous misalignment where the percentage was floating slightly above the bottom line of the count.

### Before & After (Conceptual)

| Alignment | Before (Misaligned) | After (Correct Baseline Alignment) |
| :--- | :--- | :--- |
| **Large Count** | `404` (Baseline high) | `404` (Baseline low) |
| **Small %** | `20.4%` (Baseline low) | `20.4%` (Lined up with 404's baseline) |
