### PR TITLE
Chore: Refactor & Standardize HTML Report Styles

### DIFF
--- a/scripts/generators/css/style-generator.js
+++ b/scripts/generators/css/style-generator.js
@@ -58,90 +58,6 @@ function getCommonBaseCss() {
 // --- 2. FUNCTIONS FOR EACH HTML GENERATOR ---
 
 /**
- * Generates the CSS block for the <style> tag in the Quarterly Report HTML head.
- * @returns {string} The CSS string.
- */
-function getReportStyleCss() {
-  return dedent`
-    ${getCommonBaseCss()}
-    summary {
-      cursor: pointer;
-      outline: none;
-      margin: 0.5em 0;
-      padding: 0.5em 0;
-      color: #1f2937;
-    }
-    /* summary:focus-visible uses the primary color for outline */
-    summary:focus-visible {
-      outline: 2px solid ${COLORS.primary.rgb};
-      outline-offset: 2px;
-    }
-    .report-table th,
-    .report-table td {
-      padding: 10px 12px;
-      border-bottom: 1px solid #e5e7eb;
-      text-align: left;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
-    /* .details-section and details:open summary use primary colors */
-    .details-section {
-      background-color: ${COLORS.primary[5]};
-    }
-    .details-section details:open summary {
-      color: ${COLORS.primary.rgb};
-    }
-    .report-table tbody tr:last-child td {
-      border-bottom: none;
-    }
-        
-    /* Table Row Hover/Focus */
-    .table-row-hover {
-      background-color: inherit;
-    }
-    .table-row-hover:hover,
-    .table-row-hover:focus-visible {
-      background-color: ${COLORS.primary[10]} !important;
-    }
-    .table-row-hover:focus-visible {
-      outline: 2px solid ${COLORS.primary.rgb};
-      outline-offset: -2px;
-    }
-        
-    /* Sorting Icons */
-    th .sort-icon {
-      margin-left: 5px;
-      font-size: 0.8em;
-      opacity: 0.5;
-    }
-    th.sort-asc .sort-icon,
-    th.sort-desc .sort-icon {
-      opacity: 1;
-      font-weight: bold;
-    }
-
-    /* --- Icon Input Styles for Search Bar --- */
-    /* Container holds the input and positions the icon */
-    .icon-input-container {
-      position: relative;
-    }
-    /* Style the input to push text away from the icon */
-    .icon-input-container input {
-      padding-left: 36px !important;
-    }
-    /* Position the icon absolutely inside the container */
-    .input-icon {
-      position: absolute;
-      left: 8px;
-      top: 50%;
-      transform: translateY(-50%);
-      pointer-events: none;
-    }
-  `;
-}
-
-/**
  * Generates the CSS block for the <style> tag in the All-Time/Index Report HTML head.
  * @returns {string} The CSS string.
  */
@@ -241,6 +157,90 @@ function getReportsListStyleCss() {
       border-color: ${COLORS.primary.rgb};
       outline: 2px solid ${COLORS.primary.rgb};
       outline-offset: 2px;
+    }
+  `;
+}
+
+/**
+ * Generates the CSS block for the <style> tag in the Quarterly Report HTML head.
+ * @returns {string} The CSS string.
+ */
+function getReportStyleCss() {
+  return dedent`
+    ${getCommonBaseCss()}
+    summary {
+      cursor: pointer;
+      outline: none;
+      margin: 0.5em 0;
+      padding: 0.5em 0;
+      color: #1f2937;
+    }
+    /* summary:focus-visible uses the primary color for outline */
+    summary:focus-visible {
+      outline: 2px solid ${COLORS.primary.rgb};
+      outline-offset: 2px;
+    }
+    .report-table th,
+    .report-table td {
+      padding: 10px 12px;
+      border-bottom: 1px solid #e5e7eb;
+      text-align: left;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    /* .details-section and details:open summary use primary colors */
+    .details-section {
+      background-color: ${COLORS.primary[5]};
+    }
+    .details-section details:open summary {
+      color: ${COLORS.primary.rgb};
+    }
+    .report-table tbody tr:last-child td {
+      border-bottom: none;
+    }
+        
+    /* Table Row Hover/Focus */
+    .table-row-hover {
+      background-color: inherit;
+    }
+    .table-row-hover:hover,
+    .table-row-hover:focus-visible {
+      background-color: ${COLORS.primary[10]} !important;
+    }
+    .table-row-hover:focus-visible {
+      outline: 2px solid ${COLORS.primary.rgb};
+      outline-offset: -2px;
+    }
+        
+    /* Sorting Icons */
+    th .sort-icon {
+      margin-left: 5px;
+      font-size: 0.8em;
+      opacity: 0.5;
+    }
+    th.sort-asc .sort-icon,
+    th.sort-desc .sort-icon {
+      opacity: 1;
+      font-weight: bold;
+    }
+
+    /* --- Icon Input Styles for Search Bar --- */
+    /* Container holds the input and positions the icon */
+    .icon-input-container {
+      position: relative;
+    }
+    /* Style the input to push text away from the icon */
+    .icon-input-container input {
+      padding-left: 36px !important;
+    }
+    /* Position the icon absolutely inside the container */
+    .input-icon {
+      position: absolute;
+      left: 8px;
+      top: 50%;
+      transform: translateY(-50%);
+      pointer-events: none;
     }
   `;
 }

--- a/scripts/generators/css/style-generator.js
+++ b/scripts/generators/css/style-generator.js
@@ -1,0 +1,252 @@
+/**
+ * Centralizes all dynamic, color-dependent styling logic for HTML reports.
+ */
+
+const { dedent } = require('../../utils/dedent');
+const { COLORS } = require('../../config/constants');
+
+// --- 1. BASE STYLES (Shared by all pages) ---
+
+/**
+ * Generates the common foundational CSS (font, body reset, navbar buttons).
+ * @returns {string} The CSS string.
+ */
+function getCommonBaseCss() {
+  return dedent`
+    @import url('https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap');
+    html, body {
+      margin: 0;
+      padding: 0;
+      height: 100%;
+    }
+    body {
+      font-family: 'Inter', sans-serif;
+      min-height: 10vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    /* Navigation Buttons */
+    .nav-report-button {
+      border: 1px solid ${COLORS.border.light} !important;
+      transition: border-color 0.15s ease-in-out !important;
+    }
+    .nav-report-button:hover {
+      border-color: ${COLORS.primary.rgb} !important;
+    }
+    .nav-report-button:focus-visible {
+      border-color: ${COLORS.primary.rgb};
+      outline: 2px solid ${COLORS.primary.rgb};
+      outline-offset: 2px;
+    }
+        
+    .nav-contribution-button {
+      border: 1px solid ${COLORS.border.light} !important;
+      transition: border-color 0.15s ease-in-out !important;
+    }
+    .nav-contribution-button:hover {
+      border-color: ${COLORS.primary.rgb} !important;
+    }
+    .nav-contribution-button:focus-visible { 
+      border-color: ${COLORS.primary.rgb};
+      outline: 2px solid ${COLORS.primary.rgb};
+      outline-offset: 2px;
+    }
+  `;
+}
+
+// --- 2. FUNCTIONS FOR EACH HTML GENERATOR ---
+
+/**
+ * Generates the CSS block for the <style> tag in the Quarterly Report HTML head.
+ * @returns {string} The CSS string.
+ */
+function getReportStyleCss() {
+  return dedent`
+    ${getCommonBaseCss()}
+    summary {
+      cursor: pointer;
+      outline: none;
+      margin: 0.5em 0;
+      padding: 0.5em 0;
+      color: #1f2937;
+    }
+    /* summary:focus-visible uses the primary color for outline */
+    summary:focus-visible {
+      outline: 2px solid ${COLORS.primary.rgb};
+      outline-offset: 2px;
+    }
+    .report-table th,
+    .report-table td {
+      padding: 10px 12px;
+      border-bottom: 1px solid #e5e7eb;
+      text-align: left;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    /* .details-section and details:open summary use primary colors */
+    .details-section {
+      background-color: ${COLORS.primary[5]};
+    }
+    .details-section details:open summary {
+      color: ${COLORS.primary.rgb};
+    }
+    .report-table tbody tr:last-child td {
+      border-bottom: none;
+    }
+        
+    /* Table Row Hover/Focus */
+    .table-row-hover {
+      background-color: inherit;
+    }
+    .table-row-hover:hover,
+    .table-row-hover:focus-visible {
+      background-color: ${COLORS.primary[10]} !important;
+    }
+    .table-row-hover:focus-visible {
+      outline: 2px solid ${COLORS.primary.rgb};
+      outline-offset: -2px;
+    }
+        
+    /* Sorting Icons */
+    th .sort-icon {
+      margin-left: 5px;
+      font-size: 0.8em;
+      opacity: 0.5;
+    }
+    th.sort-asc .sort-icon,
+    th.sort-desc .sort-icon {
+      opacity: 1;
+      font-weight: bold;
+    }
+
+    /* --- Icon Input Styles for Search Bar --- */
+    /* Container holds the input and positions the icon */
+    .icon-input-container {
+      position: relative;
+    }
+    /* Style the input to push text away from the icon */
+    .icon-input-container input {
+      padding-left: 36px !important;
+    }
+    /* Position the icon absolutely inside the container */
+    .input-icon {
+      position: absolute;
+      left: 8px;
+      top: 50%;
+      transform: translateY(-50%);
+      pointer-events: none;
+    }
+  `;
+}
+
+/**
+ * Generates the CSS block for the <style> tag in the All-Time/Index Report HTML head.
+ * @returns {string} The CSS string.
+ */
+function getIndexStyleCss() {
+  return dedent`
+    ${getCommonBaseCss()}
+    .report-list {
+      list-style: none;
+      padding: 0;
+    }
+    .report-list a {
+      text-decoration: none;
+    }
+        
+    .index-report-link {
+      border: 1px solid ${COLORS.border.light} !important;
+      transition: border-color 0.15s ease-in-out !important;
+    }
+    .index-report-link:hover {
+      border-color: ${COLORS.primary.rgb} !important;
+    }
+    .index-report-link:focus-visible {
+      border-color: ${COLORS.primary.rgb};
+      outline: 2px solid ${COLORS.primary.rgb};
+      outline-offset: 2px;
+    }
+        
+    /* Animation for the progress bars */
+    @keyframes loadBar {
+      from { width: 0; }
+    }
+    .progress-bar {
+      animation: loadBar 1s ease-out forwards;
+    }
+  `;
+}
+
+/**
+ * Generates the CSS block for the <style> tag in the Quarterly Reports List (reports.html) HTML head.
+ * @returns {string} The CSS string.
+ */
+function getReportsListStyleCss() {
+  return dedent`
+    ${getCommonBaseCss()}
+    .report-list {
+      list-style: none;
+    }
+    .report-list a {
+      text-decoration: none;
+    }
+        
+    /* --- Dynamic Styling for Collapsible Year (is-open) --- */
+    details summary {
+      cursor: pointer;
+      outline: none;
+      color: ${COLORS.text.primary};
+      transition: background-color 0.15s ease-in-out;
+    }
+    summary:focus-visible {
+      outline: 2px solid ${COLORS.primary.rgb};
+      outline-offset: 2px;
+    }
+
+    /* Apply primary background to the entire details element when open */
+    details[open] {
+      background-color: ${COLORS.primary[5]};
+    }
+    details[open] summary {
+      background-color: ${COLORS.primary[5]};
+      border-radius: 0.5rem 0.5rem 0 0;
+      color: ${COLORS.primary.rgb};
+    }
+    details[open] summary:hover,
+    details[open] summary:focus-visible {
+      background-color: ${COLORS.primary[10]};
+    }
+    details:not([open]) {
+      background-color: ${COLORS.background.altRows};
+    }
+    details:not([open]) summary {
+      border-bottom: none;
+      border-radius: 0.5rem;
+    }
+    details:not([open]) summary:hover,
+    details:not([open]) summary:focus-visible {
+      background-color: ${COLORS.primary[5]};
+    }
+    /* Accessible styles for report card links */
+    .report-card-link {
+      border: 1px solid ${COLORS.border.light} !important;
+      transition: border-color 0.15s ease-in-out !important;
+    }
+    .report-card-link:hover {
+      border-color: ${COLORS.primary.rgb} !important;
+    }
+    .report-card-link:focus-visible {
+      border-color: ${COLORS.primary.rgb};
+      outline: 2px solid ${COLORS.primary.rgb};
+      outline-offset: 2px;
+    }
+  `;
+}
+
+module.exports = {
+  getReportStyleCss,
+  getIndexStyleCss,
+  getReportsListStyleCss,
+};

--- a/scripts/generators/html/contributions-index-html-generator.js
+++ b/scripts/generators/html/contributions-index-html-generator.js
@@ -15,6 +15,9 @@ const { createFooterHtml } = require('../../components/footer');
 // Import right arrow and favicon svgs
 const { RIGHT_ARROW_SVG, FAVICON_SVG_ENCODED, COLORS } = require('../../config/constants');
 
+// Import style generator function
+const { getIndexStyleCss } = require('../css/style-generator');
+
 const HTML_OUTPUT_DIR_NAME = 'html-generated';
 const HTML_README_FILENAME = 'index.html';
 
@@ -75,8 +78,9 @@ async function createStatsHtmlReadme(finalContributions = []) {
   const currentYear = new Date().getFullYear();
   const yearsTracked = currentYear - SINCE_YEAR + 1;
 
-  // 4. Generate the footer
+  // 4. Generate the footer and dynamic CSS
   const footerHtml = createFooterHtml();
+  const indexCss = getIndexStyleCss();
 
   // 5. Build HTML Content
   const htmlContent = `
@@ -89,30 +93,7 @@ async function createStatsHtmlReadme(finalContributions = []) {
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,${FAVICON_SVG_ENCODED}">
   <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
   <style>
-    @import url('https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap');
-    html, body { margin: 0; padding: 0; height: 100%; }
-    body { font-family: 'Inter', sans-serif; min-height: 100vh; display: flex; flex-direction: column; }
-    .report-list { list-style: none; padding: 0; }
-    .report-list a { text-decoration: none; }
-    
-    .index-report-link {
-      border: 1px solid ${COLORS.border.light} !important;
-      transition: border-color 0.15s ease-in-out !important;
-    }
-    .index-report-link:hover { border-color: ${COLORS.primary.rgb} !important; }
-    .index-report-link:focus-visible {
-      border-color: ${COLORS.primary.rgb};
-      outline: 2px solid ${COLORS.primary.rgb};
-      outline-offset: 2px;
-    }
-    
-    /* Animation for the progress bars */
-    @keyframes loadBar {
-      from { width: 0; }
-    }
-    .progress-bar {
-      animation: loadBar 1s ease-out forwards;
-    }
+    ${indexCss}
   </style>
 </head>
 <body>

--- a/scripts/generators/html/contributions-report-html-generator.js
+++ b/scripts/generators/html/contributions-report-html-generator.js
@@ -2,6 +2,9 @@ const fs = require('fs/promises');
 const path = require('path');
 const prettier = require('prettier');
 
+// Import the dedent utility
+const { dedent } = require('../../utils/dedent');
+
 // Import configuration (SINCE_YEAR is needed for reporting)
 const { BASE_DIR, SINCE_YEAR, GITHUB_USERNAME } = require('../../config/config');
 
@@ -11,6 +14,9 @@ const { createFooterHtml } = require('../../components/footer');
 
 // Import favicon svg
 const { FAVICON_SVG_ENCODED, COLORS } = require('../../config/constants');
+
+// Import the new style generator function
+const { getReportsListStyleCss } = require('../css/style-generator');
 
 const HTML_OUTPUT_DIR_NAME = 'html-generated';
 const HTML_REPORTS_FILENAME = 'reports.html';
@@ -29,8 +35,9 @@ async function createHtmlReports(quarterlyFileLinks = []) {
   // Ensure the output directory exists
   await fs.mkdir(htmlBaseDir, { recursive: true });
 
-  // Generate the footer HTML
+  // Generate the footer HTML and dynamic CSS
   const footerHtml = createFooterHtml();
+  const reportsListCss = getReportsListStyleCss();
 
   // Define the report structure data
   const reportStructure = [
@@ -103,7 +110,7 @@ async function createHtmlReports(quarterlyFileLinks = []) {
         const borderStyle =
           index === totalRows - 1 ? '' : `style="border-bottom: 1px solid ${COLORS.border.light};"`; // Light gray borders
 
-        return `
+        return dedent`
             <tr style="background-color: ${bgColor};" ${borderStyle}>
               <td style="color: ${COLORS.primary.rgb};" class="px-6 py-4 whitespace-nowrap text-sm font-medium">
                 ${item.section}
@@ -169,7 +176,7 @@ async function createHtmlReports(quarterlyFileLinks = []) {
 
     for (const year of sortedYears) {
       // Start a new year section with a dedicated heading
-      linkHtml += `
+      linkHtml += dedent`
             <details ${openAttribute} class="col-span-full mb-8 border rounded-xl transition duration-300" style="border-color: ${COLORS.border.light};">
                 <summary style="color: ${COLORS.text.primary};" class="text-2xl font-bold p-4 sm:p-6 transition duration-150 rounded-xl flex items-center">
                     <span class="mr-3">📅</span> ${year} Reports
@@ -179,7 +186,7 @@ async function createHtmlReports(quarterlyFileLinks = []) {
 
       // Add the quarterly cards for this year
       for (const link of linksByYear[year]) {
-        linkHtml += `
+        linkHtml += dedent`
                 <a href="./${link.relativePath}" style="cursor: pointer; background-color: white; text-decoration: none; display: block;" 
                    class="report-card-link bg-white border rounded-lg shadow-md overflow-hidden w-full hover:shadow-lg transition duration-150 p-4">
                     <p style="color: ${COLORS.primary.rgb};" class="text-sm font-semibold">${link.quarterText}</p>
@@ -190,7 +197,7 @@ async function createHtmlReports(quarterlyFileLinks = []) {
       }
 
       // Close the quarterly list/grid for this year
-      linkHtml += `
+      linkHtml += dedent`
                 </div>
             </details>
             `;
@@ -203,7 +210,7 @@ async function createHtmlReports(quarterlyFileLinks = []) {
   }
 
   // 5. Build HTML Content
-  const htmlContent = `
+  const htmlContent = dedent`
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -213,73 +220,7 @@ async function createHtmlReports(quarterlyFileLinks = []) {
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,${FAVICON_SVG_ENCODED}">
   <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
   <style>
-    @import url('https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap');
-    html, body {
-      margin: 0;
-      padding: 0;
-      height: 100%;
-    }
-    body {
-      font-family: 'Inter', sans-serif;
-      min-height: 100vh; 
-      display: flex;
-      flex-direction: column;
-    }
-    .report-list { 
-      list-style: none; 
-    } 
-    .report-list a { text-decoration: none; }
-        
-    /* --- Dynamic Styling for Collapsible Year (is-open) --- */
-    details summary {
-      cursor: pointer;
-      outline: none;
-      color: ${COLORS.text.primary};
-      transition: background-color 0.15s ease-in-out;
-    }
-    summary:focus-visible {
-      outline: 2px solid ${COLORS.primary.rgb};
-      outline-offset: 2px;
-    }
-
-    /* Apply primary background to the entire details element when open */
-    details.is-open {
-      background-color: ${COLORS.primary[5]}; /* Light primary background */
-    }
-    details.is-open summary {
-      background-color: ${COLORS.primary[5]}; /* Matches the details background */
-      border-radius: 0.5rem 0.5rem 0 0; 
-      color: ${COLORS.primary.rgb}; 
-    }
-    details.is-open summary:hover,
-    details.is-open summary:focus-visible {
-      background-color: ${COLORS.primary[10]}; /* Slightly darker on hover */
-    }
-    details:not(.is-open) {
-      background-color: ${COLORS.background.altRows}; /* Light gray background when closed */
-    }
-    details:not(.is-open) summary {
-      border-bottom: none;
-      border-radius: 0.5rem; 
-    }
-    details:not(.is-open) summary:hover,
-    details:not(.is-open) summary:focus-visible {
-      background-color: ${COLORS.primary[5]}; /* Light primary background on hover when closed */
-    }
-    /* Accessible styles for report card links */
-    .report-card-link {
-      border: 1px solid ${COLORS.border.light} !important;
-      transition: border-color 0.15s ease-in-out !important;
-    }
-    .report-card-link:hover {
-      border-color: ${COLORS.primary.rgb} !important;
-    }
-    .report-card-link:focus-visible {
-      border-color: ${COLORS.primary.rgb};
-      outline: 2px solid ${COLORS.primary.rgb};
-      outline-offset: 2px;
-    }
-    /* --- END Dynamic Styling --- */
+    ${reportsListCss}
   </style>
 </head>
 <body>

--- a/scripts/generators/html/quarterly-reports-html-generator.js
+++ b/scripts/generators/html/quarterly-reports-html-generator.js
@@ -11,6 +11,7 @@ const {
 } = require('../../utils/contribution-formatters');
 const { navHtml } = require('../../components/navbar');
 const { createFooterHtml } = require('../../components/footer');
+const { getReportStyleCss } = require('../css/style-generator');
 const {
   LEFT_ARROW_SVG,
   RIGHT_ARROW_SVG,
@@ -202,6 +203,9 @@ async function writeHtmlFiles(groupedContributions) {
   const quarterlyFileLinks = [];
   await fs.mkdir(htmlBaseDir, { recursive: true });
 
+  // Pre-calculate the styles string to be included in the <style> tag.
+  const dynamicCss = getReportStyleCss();
+
   // Iterate over each quarterly report to generate its dedicated HTML file.
   for (let index = 0; index < allReports.length; index++) {
     const report = allReports[index];
@@ -327,45 +331,7 @@ async function writeHtmlFiles(groupedContributions) {
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,${FAVICON_SVG_ENCODED}">
   <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
   <style>
-    @import url('https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap');
-    html, body { margin: 0; padding: 0; height: 100%; }
-    body { font-family: 'Inter', sans-serif; min-height: 100vh; display: flex; flex-direction: column; }
-    summary { cursor: pointer; outline: none; margin: 0.5em 0; padding: 0.5em 0; color: #1f2937; }
-    summary:focus-visible { outline: 2px solid ${COLORS.primary.rgb}; outline-offset: 2px; }
-    .report-table th, .report-table td { padding: 10px 12px; border-bottom: 1px solid #e5e7eb; text-align: left; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-    .details-section { background-color: ${COLORS.primary[5]}; }
-    .details-section details:open summary { color: ${COLORS.primary.rgb}; }
-    .report-table tbody tr:last-child td { border-bottom: none; }
-    .nav-report-button { border: 1px solid ${COLORS.border.light} !important; transition: border-color 0.15s ease-in-out !important; }
-    .nav-report-button:hover { border-color: ${COLORS.primary.rgb} !important; }
-    .nav-report-button:focus-visible { border-color: ${COLORS.primary.rgb}; outline: 2px solid ${COLORS.primary.rgb}; outline-offset: 2px; }
-    .nav-contribution-button { border: 1px solid ${COLORS.border.light} !important; transition: border-color 0.15s ease-in-out !important; }
-    .nav-contribution-button:hover { border-color: ${COLORS.primary.rgb} !important; }
-    .nav-contribution-button:focus-visible { border-color: ${COLORS.primary.rgb}; outline: 2px solid ${COLORS.primary.rgb}; outline-offset: 2px; }
-    .table-row-hover { background-color: inherit; }
-    .table-row-hover:hover, .table-row-hover:focus-visible { background-color: ${COLORS.primary[10]} !important; }
-    .table-row-hover:focus-visible { outline: 2px solid ${COLORS.primary.rgb}; outline-offset: -2px; }
-    /* Sorting Icons */
-    th .sort-icon { margin-left: 5px; font-size: 0.8em; opacity: 0.5; }
-    th.sort-asc .sort-icon, th.sort-desc .sort-icon { opacity: 1; font-weight: bold; }
-
-    /* --- Icon Input Styles for Search Bar --- */
-    /* Container holds the input and positions the icon */
-    .icon-input-container {
-      position: relative;
-    }
-    /* Style the input to push text away from the icon */
-    .icon-input-container input {
-      padding-left: 36px !important; /* Make room for the 20px icon + padding */
-    }
-    /* Position the icon absolutely inside the container */
-    .input-icon {
-      position: absolute;
-      left: 8px; /* Offset from the left edge */
-      top: 50%;
-      transform: translateY(-50%);
-      pointer-events: none; /* Allows clicks to pass through to the input */
-    }
+    ${dynamicCss}
   </style>
 </head>
 <body>

--- a/scripts/generators/html/quarterly-reports-html-generator.js
+++ b/scripts/generators/html/quarterly-reports-html-generator.js
@@ -47,10 +47,10 @@ function sanitizeAttribute(str) {
  */
 async function writeHtmlFiles(groupedContributions) {
   // Attempt to read the JavaScript file for interactive table features (sorting, filtering).
-  const interactionsScriptPath = path.join(__dirname, '../../utils/table-filters.js');
-  let tableInteractionsScript = '';
+  const filtersScriptPath = path.join(__dirname, '../../utils/table-filters.js');
+  let tableFiltersScript = '';
   try {
-    tableInteractionsScript = await fs.readFile(interactionsScriptPath, 'utf8');
+    tableFiltersScript = await fs.readFile(filtersScriptPath, 'utf8');
   } catch (err) {
     console.warn(
       'Warning: utils/table-filters.js not found. Interactive features will be disabled.'
@@ -590,7 +590,7 @@ ${navHtmlForReports}
       </div>
     </main>
     <script>
-      ${tableInteractionsScript}
+      ${tableFiltersScript}
       
       // Function to open the correct section based on the URL hash, defaulting to 'Merged PRs'.
       function openSectionFromHash() {


### PR DESCRIPTION
## Summary

This PR introduces a major refactoring of the CSS generation logic in `style-generator.js` to **eliminate code duplication**, improve maintainability, and enforce a consistent 2-space coding standard.

The changes consolidate foundational styles and correctly isolate unique styles for each report type, resolving previous conflicts encountered when sharing CSS between the Index page and the Reports List page.

## Key Changes

### Style Refactoring and Deduplication

* **Motivation:** The original script had substantial duplication of foundational CSS (font imports, body resets, and navigation button styling) across `getReportStyleCss`, `getIndexStyleCss`, and `getReportsListStyleCss`.
* **Change:** Extracted all common, shared, site-wide styles into a new function, **`getCommonBaseCss()`**. This function is now the first element injected into all three main style functions, reducing redundancy and making global style updates centralized.
* **Result:** Reduced the total amount of CSS code and simplified maintenance.
