### PR TITLE
feat: Implement sticky table headers for quarterly reports

### DIFF
--- a/scripts/generators/css/style-generator.js
+++ b/scripts/generators/css/style-generator.js
@@ -250,15 +250,39 @@ function getReportStyleCss() {
       color: ${COLORS.primary.rgb};
     }
 
+    .report-table {
+      border-collapse: separate;
+      border-spacing: 0;
+      width: 100%;
+    }
+
+    .report-table th {
+      position: sticky;
+      top: 0;
+      z-index: 10;
+      background-color: #ffffff;
+      background-image: linear-gradient(${COLORS.primary[5]}, ${COLORS.primary[5]});
+      font-weight: 700;
+      padding: 12px;
+      text-align: left;
+      border-bottom: none;
+      box-shadow: inset 0 -1px 0 0 ${COLORS.primary.rgb};
+    }
+
+    .report-table td {
+      background-color: #ffffff;
+    }
+
     .report-table th,
     .report-table td {
-      padding: 10px 12px;
-      border-bottom: 1px solid #e5e7eb;
+      padding: 12px;
       text-align: left;
+      border-bottom: 1px solid #e5e7eb;
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
     }
+
     .report-table tbody tr:last-child td {
       border-bottom: none;
     }
@@ -266,6 +290,7 @@ function getReportStyleCss() {
     .table-row-hover {
       background-color: inherit;
     }
+
     .table-row-hover:hover,
     .table-row-hover:focus-visible {
       background-color: ${COLORS.primary[10]} !important;
@@ -275,6 +300,9 @@ function getReportStyleCss() {
       outline: 2px solid ${COLORS.primary.rgb};
       outline-offset: -2px;
     }
+
+    .report-table tbody tr.bg-white { background-color: #ffffff; }
+    .report-table tbody tr.bg-gray-50 { background-color: #f9fafb; }
 
     /* Table Header Sorting Alignment */
     .th-content {

--- a/scripts/generators/html/quarterly-reports-html-generator.js
+++ b/scripts/generators/html/quarterly-reports-html-generator.js
@@ -490,9 +490,9 @@ ${navHtmlForReports}
         `;
 
         // Generate the contribution table.
-        let tableContent = `<div class="overflow-x-auto rounded-lg border border-gray-100">\n`;
+        let tableContent = `<div class="overflow-x-auto rounded-lg border border-gray-100 max-h-[70vh] overflow-y-auto">\n`;
         tableContent += ` <table class="report-table min-w-full divide-y divide-gray-200 bg-white">\n`;
-        tableContent += `  <thead style="background-color: ${COLORS.primary[5]};">\n`;
+        tableContent += `  <thead class="bg-white">\n`;
         tableContent += `   <tr>\n`;
 
         // Generate table headers with sorting attributes (data-type).
@@ -506,7 +506,7 @@ ${navHtmlForReports}
             : `<span class="th-content">${sectionInfo.headers[i]} <span class="sort-icon ml-1">↕</span></span>`;
           const cursorStyle = isStaticColumn ? 'cursor: default;' : 'cursor: pointer;';
 
-          tableContent += `    <th ${thAttributes} style='width:${sectionInfo.widths[i]}; color: ${COLORS.primary.rgb}; ${cursorStyle}'>
+          tableContent += `    <th ${thAttributes} class="py-3 px-4" style="color: ${COLORS.primary.rgb}; ${cursorStyle}">
               ${headerContent}
           </th>\n`;
         }


### PR DESCRIPTION
## Description

This PR improves the usability of the quarterly contribution reports by ensuring table headers remain visible during navigation.

### Changes

Updated the `.report-table th` styles to use `position: sticky`. This ensures that column titles (e.g., Project, Title, Status) remain fixed at the top of the viewport while the user scrolls through large datasets like Merged PRs or Issues, providing constant context for the data being viewed.