### PR TITLE
chore: Update Axios to 1.13.5 and Node.js to v22

### DIFF
--- a/.github/workflows/update-contributions.yml
+++ b/.github/workflows/update-contributions.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '22'
           cache: 'npm'  # Automatically handles node_modules caching
 
       - name: Install dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "curated-oss-portfolio",
       "version": "1.0.0",
       "dependencies": {
-        "axios": "^1.13.1",
+        "axios": "1.13.5",
         "dotenv": "^17.2.3",
         "rss-parser": "^3.13.0"
       },
@@ -23,13 +23,13 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.1.tgz",
-      "integrity": "sha512-hU4EGxxt+j7TQijx1oYdAjw4xuIp1wRQSsbMFwSthCWeBQur1eF+qJ5iQ5sN3Tw8YRzQNKb8jszgBdMDVqwJcw==",
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
+      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -168,9 +168,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "format": "prettier --write \"**/*.js\" \"**/*.json\" \"**/*.html\" \"**/*.md\""
   },
   "dependencies": {
-    "axios": "^1.13.1",
+    "axios": "1.13.5",
     "dotenv": "^17.2.3",
     "rss-parser": "^3.13.0"
   },


### PR DESCRIPTION
## Description

This PR updates the Axios dependency and the Node.js version used in the GitHub Action to improve project security and performance.

### 🔒 Security

* **Updated Axios to 1.13.5:** Patches the **Prototype Pollution** (CVE-2025-58754) vulnerability found in version 1.13.1.
* **Pinned Axios Version:** Removed the caret (`^`) to pin the version to **1.13.5**.

### ⚙️ Continuous Integration

* **Updated Node.js to v22:** Upgraded the GitHub Action environment from Node.js 18 to Node.js 22.
