### PR TITLE
feat: Add logic to list open Reviewed Pull Requests in Active Workbench

### DIFF
--- a/scripts/generators/html/community-html-generator.js
+++ b/scripts/generators/html/community-html-generator.js
@@ -7,7 +7,6 @@ const { createFooterHtml } = require('../../components/footer');
 const { BASE_DIR } = require('../../config/config');
 const { COLORS, FAVICON_SVG_ENCODED, SPARKLES_SVG } = require('../../config/constants');
 const { getCommunityStyleCss } = require('../css/style-generator');
-const leadershipData = require('../../../metadata/leadership');
 const { getColorValue } = require('../../utils/color-helpers');
 const { sanitizeAttribute } = require('../../utils/html-helpers');
 
@@ -24,16 +23,21 @@ async function createCommunityHtml(contributions, rolesData) {
   const footerHtml = createFooterHtml();
   const communityCss = getCommunityStyleCss();
 
-  const { pullRequests } = contributions;
-  const openPRs = pullRequests
-    .filter((pr) => pr.status === 'open' || pr.status === 'draft')
-    .sort((a, b) => new Date(b.date) - new Date(a.date));
+  // --- WORKBENCH LOGIC: Strictly Reviewed PRs ---
+  const { reviewedPrs = [] } = contributions;
+
+  const activeReviews = reviewedPrs
+    .filter((pr) => (pr.state || '').toLowerCase() === 'open')
+    .map((pr) => ({
+      ...pr,
+      workbenchType: 'To Review',
+      sortDate: pr.date,
+    }))
+    .sort((a, b) => new Date(b.sortDate || b.date) - new Date(a.sortDate || a.date));
 
   const indigoColor = '#4338ca';
   const softIndigoBg = '#eef2ff';
-
-  // High-contrast accessibility overrides
-  const highContrastRed = '#b91c1c'; // Red-700 for AA contrast
+  const highContrastRed = '#b91c1c';
 
   // --- 1. Honors & Recognition Cards ---
   const achievementCards = rolesData.achievements
@@ -87,18 +91,27 @@ async function createCommunityHtml(contributions, rolesData) {
     .join('');
 
   // --- 3. Active Workbench Rows ---
-  const workbenchRows = openPRs
+  const workbenchRows = activeReviews
     .map((pr) => {
       const repoName = pr.repo.split('/')[1];
+      const isDraft = (pr.status || pr.state || '').toLowerCase() === 'draft';
       return dedent`
         <tr class="table-row-hover border-b border-slate-100 last:border-0 transition-colors">
-          <td class="px-6 py-4 whitespace-nowrap text-sm font-mono text-slate-700">${new Date(pr.date).getFullYear()}</td>
+          <td class="px-6 py-4 whitespace-nowrap text-sm font-mono text-slate-700">${new Date(pr.sortDate || pr.date).getFullYear()}</td>
           <td class="px-6 py-4 text-sm font-bold text-slate-800">${repoName}</td>
-          <td class="px-6 py-4 text-sm min-w-[200px] break-words">
-            <a href="${pr.url}" target="_blank" title="${sanitizeAttribute(pr.title)}" class="hover:underline font-bold inline-flex items-center group" style="color: ${indigoColor};">
-              ${pr.status === 'draft' ? `<span class="mr-2 px-1.5 py-0.5 rounded text-[10px] bg-slate-100 text-slate-700 border border-slate-200 uppercase font-black shrink-0">Draft</span>` : ''}
+          <td class="px-6 py-4 min-w-[200px] break-words">
+            <div class="flex flex-wrap items-center gap-2 mb-2">
+               <span class="text-[10px] px-2 py-0.5 rounded font-black uppercase tracking-wider border bg-amber-50 text-amber-700 border-amber-200">
+                To Review
+              </span>
+              ${isDraft ? `<span class="px-2 py-0.5 rounded text-[10px] bg-slate-100 text-slate-600 border border-slate-200 uppercase font-black shrink-0">Draft</span>` : ''}
+            </div>
+            <a href="${pr.url}" 
+               target="_blank" 
+               class="hover:underline font-bold text-base inline-flex items-center group leading-snug" 
+               style="color: ${indigoColor};">
               <span>${pr.title}</span>
-              <svg class="w-4 h-4 ml-1 opacity-0 group-hover:opacity-100 transition-opacity" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <svg class="w-4 h-4 ml-1.5 opacity-0 group-hover:opacity-100 transition-opacity shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                 <path d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
               </svg>
             </a>
@@ -108,8 +121,9 @@ async function createCommunityHtml(contributions, rolesData) {
     })
     .join('');
 
-  // --- Logic for Task-specific Colors ---
-  const hasTasks = openPRs.length > 0;
+  // UI Status Colors
+  const reviewCount = activeReviews.length;
+  const hasTasks = reviewCount > 0;
   const badgeBg = hasTasks ? COLORS.status.green.bg : COLORS.status.red.bg;
   const badgeTextColor = hasTasks ? COLORS.status.green.text : highContrastRed;
   const badgeBorderColor = hasTasks ? 'border-green-200' : 'border-red-200';
@@ -168,7 +182,7 @@ async function createCommunityHtml(contributions, rolesData) {
                   </h2>
                   <span class="px-3 py-1 rounded-full text-xs font-black uppercase tracking-widest border ${badgeBorderColor} text-center transition-all"
                         style="background-color: ${badgeBg}; color: ${badgeTextColor};">
-                    ${openPRs.length} Ongoing Tasks
+                    ${reviewCount} Ongoing Tasks
                   </span>
                 </div>
 
@@ -179,7 +193,7 @@ async function createCommunityHtml(contributions, rolesData) {
                       <tr>
                         <th scope="col" class="px-6 py-4 text-left text-xs font-black text-slate-700 uppercase tracking-widest">Year</th>
                         <th scope="col" class="px-6 py-4 text-left text-xs font-black text-slate-700 uppercase tracking-widest">Repo</th>
-                        <th scope="col" class="px-6 py-4 text-left text-xs font-black text-slate-700 uppercase tracking-widest">Pull Request</th>
+                        <th scope="col" class="px-6 py-4 text-left text-xs font-black text-slate-700 uppercase tracking-widest">Task</th>
                       </tr>
                     </thead>
                     <tbody class="divide-y divide-slate-100">

--- a/scripts/generators/html/community-html-generator.js
+++ b/scripts/generators/html/community-html-generator.js
@@ -95,20 +95,22 @@ async function createCommunityHtml(contributions, rolesData) {
     .map((pr) => {
       const repoName = pr.repo.split('/')[1];
       const isDraft = (pr.status || pr.state || '').toLowerCase() === 'draft';
+      const labelText = pr.workbenchType || 'To Review';
+
       return dedent`
         <tr class="table-row-hover border-b border-slate-100 last:border-0 transition-colors">
-          <td class="px-6 py-4 whitespace-nowrap text-sm font-mono text-slate-700">${new Date(pr.sortDate || pr.date).getFullYear()}</td>
+          <td class="px-6 py-4 whitespace-nowrap text-sm font-mono text-slate-700">${new Date(pr.date).getFullYear()}</td>
           <td class="px-6 py-4 text-sm font-bold text-slate-800">${repoName}</td>
           <td class="px-6 py-4 min-w-[200px] break-words">
             <div class="flex flex-wrap items-center gap-2 mb-2">
-               <span class="text-[10px] px-2 py-0.5 rounded font-black uppercase tracking-wider border bg-amber-50 text-amber-700 border-amber-200">
-                To Review
+              <span class="text-xs px-2.5 py-0.5 rounded font-black uppercase tracking-wider border bg-amber-50 text-amber-900 border-amber-200">
+                ${labelText}
               </span>
               ${isDraft ? `<span class="px-2 py-0.5 rounded text-[10px] bg-slate-100 text-slate-600 border border-slate-200 uppercase font-black shrink-0">Draft</span>` : ''}
             </div>
             <a href="${pr.url}" 
                target="_blank" 
-               class="hover:underline font-bold text-base inline-flex items-center group leading-snug" 
+               class="hover:underline font-bold text-sm sm:text-base inline-flex items-center group leading-snug"
                style="color: ${indigoColor};">
               <span>${pr.title}</span>
               <svg class="w-4 h-4 ml-1.5 opacity-0 group-hover:opacity-100 transition-opacity shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">

--- a/scripts/generators/html/community-html-generator.js
+++ b/scripts/generators/html/community-html-generator.js
@@ -97,9 +97,18 @@ async function createCommunityHtml(contributions, rolesData) {
       const isDraft = (pr.status || pr.state || '').toLowerCase() === 'draft';
       const labelText = pr.workbenchType || 'To Review';
 
+      // Format date to DD-MM-YYYY
+      const formattedDate = (() => {
+        const d = new Date(pr.date);
+        const day = String(d.getDate()).padStart(2, '0');
+        const month = String(d.getMonth() + 1).padStart(2, '0');
+        const year = d.getFullYear();
+        return `${day}-${month}-${year}`;
+      })();
+
       return dedent`
         <tr class="table-row-hover border-b border-slate-100 last:border-0 transition-colors">
-          <td class="px-6 py-4 whitespace-nowrap text-sm font-mono text-slate-700">${new Date(pr.date).getFullYear()}</td>
+          <td class="px-6 py-4 whitespace-nowrap text-sm font-mono text-slate-700">${formattedDate}</td>
           <td class="px-6 py-4 text-sm font-bold text-slate-800">${repoName}</td>
           <td class="px-6 py-4 min-w-[200px] break-words">
             <div class="flex flex-wrap items-center gap-2 mb-2">
@@ -110,13 +119,10 @@ async function createCommunityHtml(contributions, rolesData) {
             </div>
             <a href="${pr.url}" 
                target="_blank" 
-               class="hover:underline font-bold text-sm sm:text-base inline-flex items-center group leading-snug"
+               class="hover:underline font-bold text-sm sm:text-base inline-flex items-center leading-snug"
                style="color: ${indigoColor};">
               <span>${pr.title}</span>
-              <svg class="w-4 h-4 ml-1.5 opacity-0 group-hover:opacity-100 transition-opacity shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                <path d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-              </svg>
-            </a>
+              </a>
           </td>
         </tr>
       `;
@@ -193,8 +199,8 @@ async function createCommunityHtml(contributions, rolesData) {
                     <caption class="sr-only">List of active maintenance tasks and pull requests</caption>
                     <thead class="bg-slate-50/80">
                       <tr>
-                        <th scope="col" class="px-6 py-4 text-left text-xs font-black text-slate-700 uppercase tracking-widest">Year</th>
-                        <th scope="col" class="px-6 py-4 text-left text-xs font-black text-slate-700 uppercase tracking-widest">Repo</th>
+                        <th scope="col" class="px-6 py-4 text-left text-xs font-black text-slate-700 uppercase tracking-widest">Last Activity</th>
+                        <th scope="col" class="px-6 py-4 text-left text-xs font-black text-slate-700 uppercase tracking-widest">Repository</th>
                         <th scope="col" class="px-6 py-4 text-left text-xs font-black text-slate-700 uppercase tracking-widest">Task</th>
                       </tr>
                     </thead>

--- a/scripts/generators/html/community-html-generator.js
+++ b/scripts/generators/html/community-html-generator.js
@@ -28,16 +28,20 @@ async function createCommunityHtml(contributions, rolesData) {
 
   const activeReviews = reviewedPrs
     .filter((pr) => (pr.state || '').toLowerCase() === 'open')
-    .map((pr) => ({
-      ...pr,
-      workbenchType: 'To Review',
-      sortDate: pr.date,
-    }))
-    .sort((a, b) => new Date(b.sortDate || b.date) - new Date(a.sortDate || a.date));
+    .sort((a, b) => new Date(b.date) - new Date(a.date));
 
   const indigoColor = '#4338ca';
   const softIndigoBg = '#eef2ff';
   const highContrastRed = '#b91c1c';
+
+  function getToReviewBadgeHtml() {
+    const bgColor = '#fffbeb';
+    const textColor = '#92400e';
+    const borderColor = '#fde68a';
+
+    const style = `background-color: ${bgColor}; color: ${textColor}; border: 1px solid ${borderColor};`;
+    return `<span class="inline-block px-2.5 py-0.5 text-[10px] font-bold rounded-full uppercase tracking-wider" style="${style}">To Review</span>`;
+  }
 
   // --- 1. Honors & Recognition Cards ---
   const achievementCards = rolesData.achievements
@@ -94,42 +98,37 @@ async function createCommunityHtml(contributions, rolesData) {
   const workbenchRows = activeReviews
     .map((pr) => {
       const repoName = pr.repo.split('/')[1];
-      const isDraft = (pr.status || pr.state || '').toLowerCase() === 'draft';
-      const labelText = pr.workbenchType || 'To Review';
 
-      // Format date to DD-MM-YYYY
       const formattedDate = (() => {
         const d = new Date(pr.date);
         const day = String(d.getDate()).padStart(2, '0');
         const month = String(d.getMonth() + 1).padStart(2, '0');
-        const year = d.getFullYear();
-        return `${day}-${month}-${year}`;
+        return `${day}-${month}-${d.getFullYear()}`;
       })();
+
+      const statusBadge = getToReviewBadgeHtml();
 
       return dedent`
         <tr class="table-row-hover border-b border-slate-100 last:border-0 transition-colors">
-          <td class="px-6 py-4 whitespace-nowrap text-sm font-mono text-slate-700">${formattedDate}</td>
+          <td class="px-6 py-4 whitespace-nowrap text-sm font-mono text-slate-600">${formattedDate}</td>
           <td class="px-6 py-4 text-sm font-bold text-slate-800">${repoName}</td>
           <td class="px-6 py-4 min-w-[200px] break-words">
-            <div class="flex flex-wrap items-center gap-2 mb-2">
-              <span class="text-xs px-2.5 py-0.5 rounded font-black uppercase tracking-wider border bg-amber-50 text-amber-900 border-amber-200">
-                ${labelText}
-              </span>
-              ${isDraft ? `<span class="px-2 py-0.5 rounded text-[10px] bg-slate-100 text-slate-600 border border-slate-200 uppercase font-black shrink-0">Draft</span>` : ''}
+            <div class="mb-1.5">
+              ${statusBadge}
             </div>
             <a href="${pr.url}" 
                target="_blank" 
-               class="hover:underline font-bold text-sm sm:text-base inline-flex items-center leading-snug"
+               class="hover:underline font-medium text-sm sm:text-base inline-flex items-center leading-snug"
                style="color: ${indigoColor};">
               <span>${pr.title}</span>
-              </a>
+            </a>
           </td>
         </tr>
       `;
     })
     .join('');
 
-  // UI Status Colors
+  // UI Status Count Badge
   const reviewCount = activeReviews.length;
   const hasTasks = reviewCount > 0;
   const badgeBg = hasTasks ? COLORS.status.green.bg : COLORS.status.red.bg;

--- a/scripts/generators/markdown/community-markdown-generator.js
+++ b/scripts/generators/markdown/community-markdown-generator.js
@@ -13,9 +13,11 @@ async function createCommunityMarkdown(contributions, rolesData) {
 
   await fs.mkdir(mdBaseDir, { recursive: true });
 
-  const { pullRequests } = contributions;
-  const openPRs = pullRequests
-    .filter((pr) => pr.status === 'open' || pr.status === 'draft')
+  // --- WORKBENCH LOGIC: Strictly Reviewed PRs ---
+  const { reviewedPrs = [] } = contributions;
+
+  const activeReviews = reviewedPrs
+    .filter((pr) => (pr.state || '').toLowerCase() === 'open')
     .sort((a, b) => new Date(b.date) - new Date(a.date));
 
   // 1. Build Header
@@ -38,20 +40,23 @@ async function createCommunityMarkdown(contributions, rolesData) {
   md += `\n`;
 
   // 4. Active Workbench
-  md += `## 🛠️ Active Workbench (${openPRs.length})\n\n`;
+  md += `## 🛠️ Active Workbench (${activeReviews.length})\n\n`;
   md += `*A live list of open pull requests and ongoing maintenance tasks.*\n\n`;
 
-  if (openPRs.length === 0) {
-    md += `_No active maintenance tasks at the moment._\n`;
+  if (activeReviews.length === 0) {
+    md += `_No active maintenance tasks._\n`;
   } else {
     // Table format for cleaner workbench view in Markdown
     md += `| Year | Repository | Task |\n`;
     md += `| :--- | :--- | :--- |\n`;
-    openPRs.forEach((pr) => {
+    activeReviews.forEach((pr) => {
       const year = new Date(pr.date).getFullYear();
       const repoName = pr.repo.split('/')[1];
-      const statusLabel = pr.status === 'draft' ? '`Draft` ' : '';
-      md += `| ${year} | **${repoName}** | ${statusLabel}[${pr.title}](${pr.url}) |\n`;
+      const isDraft = (pr.status || pr.state || '').toLowerCase() === 'draft';
+      const draftLabel = isDraft ? '`Draft` ' : '';
+      const typeLabel = '`To Review` ';
+
+      md += `| ${year} | **${repoName}** | ${typeLabel}${draftLabel}[${pr.title}](${pr.url}) |\n`;
     });
   }
 

--- a/scripts/generators/markdown/community-markdown-generator.js
+++ b/scripts/generators/markdown/community-markdown-generator.js
@@ -46,17 +46,29 @@ async function createCommunityMarkdown(contributions, rolesData) {
   if (activeReviews.length === 0) {
     md += `_No active maintenance tasks._\n`;
   } else {
-    // Table format for cleaner workbench view in Markdown
-    md += `| Year | Repository | Task |\n`;
-    md += `| :--- | :--- | :--- |\n`;
-    activeReviews.forEach((pr) => {
-      const year = new Date(pr.date).getFullYear();
-      const repoName = pr.repo.split('/')[1];
-      const isDraft = (pr.status || pr.state || '').toLowerCase() === 'draft';
-      const draftLabel = isDraft ? '`Draft` ' : '';
-      const typeLabel = '`To Review` ';
+    md += `| Last Activity | Repository | Status | Task |\n`;
+    md += `| :--- | :--- | :--- | :--- |\n`;
 
-      md += `| ${year} | **${repoName}** | ${typeLabel}${draftLabel}[${pr.title}](${pr.url}) |\n`;
+    activeReviews.forEach((pr) => {
+      // Format date to DD-MM-YYYY
+      const formattedDate = (() => {
+        const d = new Date(pr.date);
+        const day = String(d.getDate()).padStart(2, '0');
+        const month = String(d.getMonth() + 1).padStart(2, '0');
+        const year = d.getFullYear();
+        return `${day}-${month}-${year}`;
+      })();
+
+      const repoName = pr.repo.split('/')[1];
+
+      // Determine Status Labels
+      const isDraft = (pr.status || pr.state || '').toLowerCase() === 'draft';
+      const statusLabels = isDraft ? '`To Review` `Draft`' : '`To Review`';
+
+      // Task is the linked PR Title
+      const taskLink = `[${pr.title}](${pr.url})`;
+
+      md += `| ${formattedDate} | **${repoName}** | ${statusLabels} | ${taskLink} |\n`;
     });
   }
 


### PR DESCRIPTION
## Description

This PR implements the logic for the **Active Workbench** section within the Community & Activity page. The primary update enables the dynamic listing of open Reviewed PRs by filtering the `reviewedPrs` data set.

### Key Changes

* **Active Workbench Logic**: Added filtering to identify and display strictly "open" PRs from the `reviewedPrs` data, ensuring the workbench reflects current maintenance tasks.
* **Markdown Synchronization**: Updated the Markdown generator to include the same table structure, ensuring consistency across both HyperText Markup Language (HTML) and static report exports.

### UI Result

The Active Workbench now displays a clean, scannable table with:
* **Last Activity**: Standardized to `DD-MM-YYYY` format.
* **Status Labels**: Pill-shaped "To Review" badges (Amber theme) replacing the previous boxed style.