### PR TITLE
refactor: Centralize persona definitions to metadata

### DIFF
--- a/metadata/personas.js
+++ b/metadata/personas.js
@@ -1,0 +1,41 @@
+/**
+ * Defines the open source persona categories and their ranking priority.
+ * Priority 1 is the highest rank.
+ */
+const personaCategories = [
+  {
+    title: 'Community Mentor',
+    desc: 'Expert advocate for code quality and peer development. Code review and technical guidance ensure high standards across the community.',
+    priority: 1,
+  },
+  {
+    title: 'Core Contributor',
+    desc: 'Main driver of project development. Responsible for moving features from concept to production through robust code and resolving complex bugs to ensure software stability.',
+    priority: 2,
+  },
+  {
+    title: 'Project Architect',
+    desc: 'Strategic problem-solver focused on technical discovery. Skilled at identifying critical system issues and defining feature planning that shapes the long-term technical roadmap.',
+    priority: 3,
+  },
+  {
+    title: 'Collaborative Partner',
+    desc: 'Focused on shared project success. Pair programming and co-authoring code delivers high-impact value through collective development effort.',
+    priority: 4,
+  },
+  {
+    title: 'Ecosystem Partner',
+    desc: 'Community builder focused on technical discussion and engagement. Facilitates collaboration through project discussions to ensure the open source ecosystem remains vibrant and interconnected.',
+    priority: 5,
+  },
+];
+
+const DEFAULT_PERSONA = {
+  title: 'Open Source Contributor',
+  desc: 'Active member of the global open source community.',
+};
+
+module.exports = {
+  personaCategories,
+  DEFAULT_PERSONA,
+};

--- a/scripts/generators/html/contributions-report-html-generator.js
+++ b/scripts/generators/html/contributions-report-html-generator.js
@@ -1,21 +1,11 @@
 const fs = require('fs/promises');
 const path = require('path');
 const prettier = require('prettier');
-
-// Import the dedent utility
 const { dedent } = require('../../utils/dedent');
-
-// Import configuration
 const { GITHUB_USERNAME, BASE_DIR } = require('../../config/config');
-
-// Import navbar and footer
 const { createNavHtml } = require('../../components/navbar');
 const { createFooterHtml } = require('../../components/footer');
-
-// Import favicon svg
 const { FAVICON_SVG_ENCODED, COLORS } = require('../../config/constants');
-
-// Import the new style generator function
 const { getReportsListStyleCss } = require('../css/style-generator');
 
 const HTML_OUTPUT_DIR_NAME = 'html-generated';

--- a/scripts/generators/html/landing-page-html-generator.js
+++ b/scripts/generators/html/landing-page-html-generator.js
@@ -1,18 +1,11 @@
 const fs = require('fs/promises');
 const path = require('path');
 const prettier = require('prettier');
-
-// Import the dedent utility
 const { dedent } = require('../../utils/dedent');
-
-// Import configuration
 const { GITHUB_USERNAME, BASE_DIR } = require('../../config/config');
-
-// Import navbar and footer
 const { createNavHtml } = require('../../components/navbar');
 const { createFooterHtml } = require('../../components/footer');
-
-// Import constants and SVGs
+const { personaCategories, DEFAULT_PERSONA } = require('../../../metadata/personas');
 const {
   RIGHT_ARROW_SVG,
   FAVICON_SVG_ENCODED,
@@ -20,8 +13,6 @@ const {
   PULL_REQUEST_LARGE_SVG,
   INFO_ICON_SVG,
 } = require('../../config/constants');
-
-// Import style generators and helpers
 const { getIndexStyleCss } = require('../css/style-generator');
 const { getColorValue } = require('../../utils/color-helpers');
 
@@ -39,48 +30,21 @@ function determinePersona(counts) {
   const grandTotal =
     prCount + issueCount + reviewedPrCount + coAuthoredPrCount + collaborationCount;
 
-  const personaCategories = [
-    {
-      title: 'Community Mentor',
-      desc: 'Expert advocate for code quality and peer development. Code review and technical guidance ensure high standards across the community.',
-      count: reviewedPrCount,
-      priority: 1,
-    },
-    {
-      title: 'Core Contributor',
-      desc: 'Main driver of project development. Responsible for moving features from concept to production through robust code and resolving complex bugs to ensure software stability.',
-      count: prCount,
-      priority: 2,
-    },
-    {
-      title: 'Project Architect',
-      desc: 'Strategic problem-solver focused on technical discovery. Skilled at identifying critical system issues and defining feature planning that shapes the long-term technical roadmap.',
-      count: issueCount,
-      priority: 3,
-    },
-    {
-      title: 'Collaborative Partner',
-      desc: 'Focused on shared project success. Pair programming and co-authoring code delivers high-impact value through collective development effort.',
-      count: coAuthoredPrCount,
-      priority: 4,
-    },
-    {
-      title: 'Ecosystem Partner',
-      desc: 'Community builder focused on technical discussion and engagement. Facilitates collaboration through project discussions to ensure the open source ecosystem remains vibrant and interconnected.',
-      count: collaborationCount,
-      priority: 5,
-    },
-  ];
-
   // Default fallback for new users
   if (grandTotal === 0) {
-    return {
-      title: 'Open Source Contributor',
-      desc: 'Active member of the global open source community.',
-    };
+    return DEFAULT_PERSONA;
   }
 
-  return personaCategories.reduce((prev, curr) => {
+  // Map the dynamic counts to the static metadata categories
+  const categoriesWithCounts = [
+    { ...personaCategories.find(p => p.title === 'Community Mentor'), count: reviewedPrCount },
+    { ...personaCategories.find(p => p.title === 'Core Contributor'), count: prCount },
+    { ...personaCategories.find(p => p.title === 'Project Architect'), count: issueCount },
+    { ...personaCategories.find(p => p.title === 'Collaborative Partner'), count: coAuthoredPrCount },
+    { ...personaCategories.find(p => p.title === 'Ecosystem Partner'), count: collaborationCount },
+  ];
+
+  return categoriesWithCounts.reduce((prev, curr) => {
     if (curr.count > prev.count) return curr;
     if (curr.count === prev.count && curr.priority < prev.priority) return curr;
     return prev;
@@ -402,4 +366,4 @@ async function createIndexHtml(finalContributions = {}, articles = []) {
   console.log('Generated landing page successfully at: ' + HTML_OUTPUT_PATH);
 }
 
-module.exports = { createIndexHtml };
+module.exports = { createIndexHtml, determinePersona };

--- a/scripts/generators/html/quarterly-reports-html-generator.js
+++ b/scripts/generators/html/quarterly-reports-html-generator.js
@@ -9,11 +9,8 @@ const {
   getPrStatusContent,
   getCollaborationStatusContent,
 } = require('../../utils/contribution-formatters');
-
-// Import navbar and footer
 const { createNavHtml } = require('../../components/navbar');
 const { createFooterHtml } = require('../../components/footer');
-
 const { getReportStyleCss } = require('../css/style-generator');
 const {
   LEFT_ARROW_SVG,

--- a/scripts/generators/markdown/contributions-readme-generator.js
+++ b/scripts/generators/markdown/contributions-readme-generator.js
@@ -1,9 +1,8 @@
 const fs = require('fs/promises');
 const path = require('path');
-
-// Import configuration
 const { BASE_DIR, GITHUB_USERNAME } = require('../../config/config');
 const { GLOSSARY_CONTENT } = require('../../../metadata/glossary');
+const { personaCategories, DEFAULT_PERSONA } = require('../../../metadata/personas');
 
 const MARKDOWN_OUTPUT_DIR_NAME = 'markdown-generated';
 const MARKDOWN_README_FILENAME = 'README.md';
@@ -18,47 +17,26 @@ function determinePersona(counts) {
   const grandTotal =
     prCount + issueCount + reviewedPrCount + coAuthoredPrCount + collaborationCount;
 
-  const personaCategories = [
+  if (grandTotal === 0) {
+    return DEFAULT_PERSONA;
+  }
+
+  // Map the dynamic counts to the static metadata categories imported from personas.js
+  const categoriesWithCounts = [
+    { ...personaCategories.find((p) => p.title === 'Community Mentor'), count: reviewedPrCount },
+    { ...personaCategories.find((p) => p.title === 'Core Contributor'), count: prCount },
+    { ...personaCategories.find((p) => p.title === 'Project Architect'), count: issueCount },
     {
-      title: 'Community Mentor',
-      desc: 'Expert advocate for code quality and peer development. Code review and technical guidance ensure high standards across the community.',
-      count: reviewedPrCount,
-      priority: 1,
-    },
-    {
-      title: 'Core Contributor',
-      desc: 'Main driver of project development. Responsible for moving features from concept to production through robust code and resolving complex bugs to ensure software stability.',
-      count: prCount,
-      priority: 2,
-    },
-    {
-      title: 'Project Architect',
-      desc: 'Strategic problem-solver focused on technical discovery. Skilled at identifying critical system issues and defining feature planning that shapes the long-term technical roadmap.',
-      count: issueCount,
-      priority: 3,
-    },
-    {
-      title: 'Collaborative Partner',
-      desc: 'Focused on shared project success. Pair programming and co-authoring code delivers high-impact value through collective development effort.',
+      ...personaCategories.find((p) => p.title === 'Collaborative Partner'),
       count: coAuthoredPrCount,
-      priority: 4,
     },
     {
-      title: 'Ecosystem Partner',
-      desc: 'Community builder focused on technical discussion and engagement. Facilitates collaboration through project discussions to ensure the open source ecosystem remains vibrant and interconnected.',
+      ...personaCategories.find((p) => p.title === 'Ecosystem Partner'),
       count: collaborationCount,
-      priority: 5,
     },
   ];
 
-  if (grandTotal === 0) {
-    return {
-      title: 'Open Source Contributor',
-      desc: 'Active member of the global open source community.',
-    };
-  }
-
-  return personaCategories.reduce((prev, curr) => {
+  return categoriesWithCounts.reduce((prev, curr) => {
     if (curr.count > prev.count) return curr;
     if (curr.count === prev.count && curr.priority < prev.priority) return curr;
     return prev;
@@ -223,7 +201,6 @@ async function createStatsReadme(finalContributions, articles = []) {
   let glossarySectionsMd = '';
 
   groups.forEach((group) => {
-    // Determine the label for the third column based on the items in this group
     let noteHeader = 'Glossary Note';
     const hasEntryMethod = group.items.some((i) => i.entryMethod);
     const hasCalculation = group.items.some((i) => i.howItIsCalculated);
@@ -258,7 +235,7 @@ ${glossarySectionsMd}
   // 8. Build Markdown Content for README.md
   let markdownContent = `# 📈 Open Source Contributions Report
 
-Organized by year and quarter, these reports track contributions made by **[${GITHUB_USERNAME}](https://github.com/${GITHUB_USERNAME})** to repositories owned by others since **${earliestYear}**. This portfolio summarizes all community activity—including merged, reviewed, and co-authored PRs, issues, and collaborations—alongside formal leadership roles, blog posts, and live tasks on the active workbench.
+Organized by year and quarter, these reports track contributions made by **[${GITHUB_USERNAME}](https://github.com/${GITHUB_USERNAME})** to external repositories since **${earliestYear}**. This portfolio summarizes all community activity—including merged, reviewed, and co-authored PRs, issues, and collaborations—alongside formal leadership roles, blog posts, and live tasks on the active workbench.
 
 > [!IMPORTANT]
 > To understand the criteria used for these metrics or to see how specific categories are calculated, please refer to the [**Glossary**](./${MARKDOWN_GLOSSARY_FILENAME}).


### PR DESCRIPTION
## Description

This PR moves the logic and definitions for Personas into a centralized metadata file. This reorganization improves maintainability and allows for consistent Persona determination across different document generators.

## Changes

- **Move persona details to metadata:** Relocated `personaCategories` and `DEFAULT_PERSONA` from generator scripts to a new dedicated file at `metadata/personas.js`.
- **Centralize logic:** Updated the Persona determination logic to ensure priority-based tie-breaking is handled consistently.
- **Update generators:** Refactored the Landing Page and Contributions Readme generators to import Persona data from the shared metadata location.
- **Add validation:** Introduced a test suite in `scripts/tests/test-persona.js` to verify Persona assignment across various activity scenarios and tie-breaker matrices.