### PR TITLE
feat: Implement dynamic repository exclusions for ongoing tasks

### DIFF
--- a/contents/repo-exclusions.js
+++ b/contents/repo-exclusions.js
@@ -1,0 +1,22 @@
+module.exports = {
+  /**
+   * Repository & Organization Exclusion List
+   * ----------------------------------------
+   * The script uses .includes() and .toLowerCase() to match these strings.
+   * HOW TO EXCLUDE:
+   * 1. By Organization: Use the org name with a trailing slash.
+   * Example: 'my-old-org/'
+   * (This matches: 'my-old-org/repo-1', 'my-old-org/repo-2')
+   * 2. By Specific Repository: Use the full 'org/repo' or 'user/repo' string.
+   * Example: 'org-name/repo-name'
+   * (This matches only that specific repository)
+   * 3. By Partial String: Use any unique part of the name.
+   * Example: 'sandbox'
+   * (This matches: 'user/my-sandbox-project', 'sandbox-org/docs')
+   * Note: This is case-insensitive. 'MY-ORG' is the same as 'my-org'.
+   */
+  excludedRepos: [
+    'open-sauced/',
+    'astro-partykit-starter'
+  ],
+};

--- a/scripts/src/main.js
+++ b/scripts/src/main.js
@@ -7,6 +7,15 @@ const { BLOG } = require('../config/config');
 // Import Leadership Metadata
 const leadershipData = require('../../contents/leadership');
 
+// Import Repository Exclusions with safeguard
+let excludedRepos = [];
+try {
+  const repoExclusions = require('../../contents/repo-exclusions');
+  excludedRepos = repoExclusions.excludedRepos || [];
+} catch (e) {
+  // If the file doesn't exist, we proceed with an empty exclusion list
+}
+
 // Import core fetching logic
 const { fetchContributions, fetchOngoingReviews } = require('../api/github-api-fetchers');
 const { fetchStrictOssArticles } = require('../api/articles-api-fetcher');
@@ -78,9 +87,11 @@ async function main() {
 
     const ongoingTasks = rawOngoingTasks.filter((task) => {
       const repoName = task.repo.toLowerCase();
-      const isOpenSauced = repoName.startsWith('open-sauced/');
-      const isAstroStarter = repoName.includes('astro-partykit-starter');
-      return !isOpenSauced && !isAstroStarter;
+      // Dynamically exclude repos based on the exclusions list
+      const isExcluded = excludedRepos.some((excluded) =>
+        repoName.includes(excluded.toLowerCase())
+      );
+      return !isExcluded;
     });
 
     await fs.writeFile(ongoingTasksFile, JSON.stringify(ongoingTasks, null, 2), 'utf8');


### PR DESCRIPTION
## Description

This PR introduces a dynamic way to exclude repositories from the **Active Workbench** (ongoing tasks). Previously, excluded repositories were hard-coded in `main.js`. This change moves that logic to a user-configurable metadata file in the `contents/` directory.

## Changes

* **New Metadata File**: Created `contents/repo-exclusions.js` to store the list of excluded organizations or repositories.
* **Flexible Filtering**: Updated `main.js` to use `.includes()` for matching, allowing users to exclude entire organizations (e.g., `org-name/`) or specific projects.
* **Safeguard Implementation**: Added a `try...catch` block around the exclusion import in `main.js`. This ensures the script continues to run successfully even if a user has not created the `repo-exclusions.js` file.
* **Clean Code**: Removed hard-coded strings from the core logic to improve maintainability and make the project easier for others to adopt.

## How to use

Users can now manage their notifications by adding strings to the `excludedRepos` array in `contents/repo-exclusions.js`. The filter is case-insensitive and supports:
1.  **Orgs**: `'org-name/'`
2.  **Repos**: `'org-name/repo-name'`
3.  **Keywords**: `'sandbox'`