### PR TITLE
feat: Add status badges to Active Workbench contributions

### DIFF
--- a/scripts/generators/markdown/community-markdown-generator.js
+++ b/scripts/generators/markdown/community-markdown-generator.js
@@ -4,6 +4,34 @@ const { BASE_DIR } = require('../../config/config');
 const { WORKBENCH_SUCCESS_MESSAGES } = require('../../metadata/workbench-messages');
 
 /**
+ * Helper to render status labels as HTML badges.
+ */
+function getStatusBadge(task) {
+  if (!task.labels && !task.isDraft) return '';
+
+  const labels = (task.labels || []).map((l) => (typeof l === 'string' ? l : l.name).toLowerCase());
+  const isDraft = task.isDraft === true;
+  const isPendingMerge = task.isApproved && labels.includes('pending-pr-merge');
+  const isBlocked =
+    !isPendingMerge &&
+    labels.some((l) => l.includes('blocked') || l.includes('stalled') || l.includes('wait'));
+
+  let badge = '';
+  const baseStyle =
+    'padding: 2px 6px; border-radius: 4px; font-size: 10px; font-weight: bold; margin-right: 8px; color: white; vertical-align: middle; display: inline-block;';
+
+  if (isDraft) {
+    badge = `<span style='${baseStyle} background-color: #64748b;'>DRAFT</span>`;
+  } else if (isPendingMerge) {
+    badge = `<span style='${baseStyle} background-color: #10b981;'>PENDING MERGE</span>`;
+  } else if (isBlocked) {
+    badge = `<span style='${baseStyle} background-color: #f43f5e;'>BLOCKED</span>`;
+  }
+
+  return badge;
+}
+
+/**
  * Generates the Community & Activity Markdown report.
  */
 async function createCommunityMarkdown(
@@ -42,7 +70,6 @@ async function createCommunityMarkdown(
   md += `*A live list of open pull requests and ongoing maintenance tasks.*\n\n`;
 
   // --- Filtering Logic ---
-
   const isBot = (t) => {
     const username = typeof t.user === 'object' ? t.user?.login : t.user;
     const userStr = String(username || '').toLowerCase();
@@ -54,71 +81,60 @@ async function createCommunityMarkdown(
     );
   };
 
-  // 1. To do issues
   const todoTasks = ongoingIssues.sort((a, b) => new Date(b.updatedAt) - new Date(a.updatedAt));
-
-  // 2. Ongoing PRs
   const submittedPRs = ongoingPRs.sort((a, b) => new Date(b.updatedAt) - new Date(a.updatedAt));
-
-  // 3. Manual Request Review (Exclude Bots)
   const requestReviewTasks = ongoingTasks
     .filter((t) => t.status === 'Request review' && !isBot(t))
     .sort((a, b) => new Date(b.updatedAt) - new Date(a.updatedAt));
-
-  // 4. Review in progress
   const inProgressTasks = ongoingTasks
     .filter((t) => t.status === 'Review in progress')
     .sort((a, b) => new Date(b.updatedAt) - new Date(a.updatedAt));
-
-  // 5. Bot Request Review
   const botRequestReviewTasks = ongoingTasks
     .filter((t) => t.status === 'Request review' && isBot(t))
     .sort((a, b) => new Date(b.updatedAt) - new Date(a.updatedAt));
 
   /**
-   * Helper function to build a collapsible table section.
+   * Helper function to build a collapsible HTML table section.
    */
   const buildCollapsibleSection = (title, icon, tasks) => {
     const count = tasks.length;
-    const displayCount = String(count);
-
     const randomMsg =
       WORKBENCH_SUCCESS_MESSAGES[Math.floor(Math.random() * WORKBENCH_SUCCESS_MESSAGES.length)];
 
     let section = `<details>\n`;
-    section += `  <summary><h3 style="display: inline-block; padding-bottom: 20px; cursor: pointer; margin: 0;">${icon} ${title} (${displayCount})</h3></summary>\n\n`;
+    section += `  <summary><h3 style="display: inline-block; padding-bottom: 20px; cursor: pointer; margin: 0;">${icon} ${title} (${count})</h3></summary>\n\n`;
 
     if (count === 0) {
       section += `> ***${randomMsg}***\n`;
     } else {
-      section += `| Repository | Task |\n`;
-      section += `| :--- | :--- |\n`;
+      section += `<table style='width:100%; table-layout:fixed;'>\n`;
+      section += `  <thead>\n    <tr>\n`;
+      section += `      <th style='width:25%; text-align:left;'>Repository</th>\n`;
+      section += `      <th style='width:75%; text-align:left;'>Task</th>\n`;
+      section += `    </tr>\n  </thead>\n  <tbody>\n`;
+
       tasks.forEach((task) => {
         const repoName = task.repo.split('/')[1] || task.repo;
-        const taskLink = `[${task.title}](${task.url})`;
-        section += `| **${repoName}** | ${taskLink} |\n`;
+        const statusBadge = getStatusBadge(task);
+
+        section += `    <tr>\n`;
+        section += `      <td style='vertical-align: top;'><strong>${repoName}</strong><br />${statusBadge}</td>\n`;
+        section += `      <td style='vertical-align: top;'><a href='${task.url}'>${task.title}</a></td>\n`;
+        section += `    </tr>\n`;
       });
+
+      section += `  </tbody>\n</table>\n`;
     }
 
     section += `\n</details>\n\n`;
     return section;
   };
 
-  // --- Render Sections in Priority Order ---
-
-  // 1. Initiative: Things you started
+  // --- Render Sections ---
   md += buildCollapsibleSection('Ongoing PRs', '📤', submittedPRs);
-
-  // 2. Collaboration: Things you are currently helping with
   md += buildCollapsibleSection('Review in progress', '🔄', inProgressTasks);
-
-  // 3. Intent: Things you have committed to doing
   md += buildCollapsibleSection('To do issues', '📝', todoTasks);
-
-  // 4. Inbox: Things people are asking you to look at
   md += buildCollapsibleSection('Request review', '📥', requestReviewTasks);
-
-  // 5. Maintenance: Automated team-wide tasks
   md += buildCollapsibleSection('Bot request review', '🤖', botRequestReviewTasks);
 
   md += `---\n`;

--- a/scripts/generators/markdown/community-markdown-generator.js
+++ b/scripts/generators/markdown/community-markdown-generator.js
@@ -107,11 +107,13 @@ async function createCommunityMarkdown(
    */
   const buildCollapsibleSection = (title, icon, tasks) => {
     const count = tasks.length;
+    const displayCount = String(count);
+    
     const randomMsg =
       WORKBENCH_SUCCESS_MESSAGES[Math.floor(Math.random() * WORKBENCH_SUCCESS_MESSAGES.length)];
 
     let section = `<details>\n`;
-    section += `  <summary><h3 style="display: inline-block; padding-bottom: 20px; cursor: pointer; margin: 0;">${icon} ${title} (${count})</h3></summary>\n\n`;
+    section += `  <summary><h3 style="display: inline-block; padding-bottom: 20px; cursor: pointer; margin: 0;">${icon} ${title} (${displayCount})</h3></summary>\n\n`;
 
     if (count === 0) {
       section += `> ***${randomMsg}***\n`;

--- a/scripts/generators/markdown/community-markdown-generator.js
+++ b/scripts/generators/markdown/community-markdown-generator.js
@@ -81,20 +81,29 @@ async function createCommunityMarkdown(
     );
   };
 
+  // 1. To do issues
   const todoTasks = ongoingIssues.sort((a, b) => new Date(b.updatedAt) - new Date(a.updatedAt));
+
+  // 2. Ongoing PRs
   const submittedPRs = ongoingPRs.sort((a, b) => new Date(b.updatedAt) - new Date(a.updatedAt));
+
+  // 3. Manual Request Review (Exclude Bots)
   const requestReviewTasks = ongoingTasks
     .filter((t) => t.status === 'Request review' && !isBot(t))
     .sort((a, b) => new Date(b.updatedAt) - new Date(a.updatedAt));
+
+  // 4. Review in progress
   const inProgressTasks = ongoingTasks
     .filter((t) => t.status === 'Review in progress')
     .sort((a, b) => new Date(b.updatedAt) - new Date(a.updatedAt));
+
+  // 5. Bot Request Review
   const botRequestReviewTasks = ongoingTasks
     .filter((t) => t.status === 'Request review' && isBot(t))
     .sort((a, b) => new Date(b.updatedAt) - new Date(a.updatedAt));
 
   /**
-   * Helper function to build a collapsible HTML table section.
+   * Helper function to build a collapsible table section.
    */
   const buildCollapsibleSection = (title, icon, tasks) => {
     const count = tasks.length;
@@ -130,7 +139,7 @@ async function createCommunityMarkdown(
     return section;
   };
 
-  // --- Render Sections ---
+  // --- Render Sections in Priority Order ---
   md += buildCollapsibleSection('Ongoing PRs', '📤', submittedPRs);
   md += buildCollapsibleSection('Review in progress', '🔄', inProgressTasks);
   md += buildCollapsibleSection('To do issues', '📝', todoTasks);


### PR DESCRIPTION
## Description

This PR implements a status badge system for the Active Workbench. It adds visual indicators to help identify the current state of pull requests (Draft, Pending Merge, or Blocked) at a glance.

## Changes

- **Added Status Badge Logic:** Introduced a `getStatusBadge` helper function that generates CSS-styled HTML badges based on PR metadata:
  - `DRAFT`: Gray badge for PRs in draft state.
  - `PENDING MERGE`: Green badge for approved PRs with the `pending-pr-merge` label.
  - `BLOCKED`: Red badge for items containing "blocked", "stalled", or "wait" labels.
- **Updated Repository Column:** Integrated the badge into the first column of the workbench table. The badge now renders directly underneath the **Repository Name**.
