### PR TITLE
docs: Add guidance for empty repository exclusions

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Manual data and preferences are managed within the `scripts/config/` and `conten
 - **Theming:** Update `COLOR_PALETTE` in `scripts/config/constants.js` to change the look of the generated HTML reports.
 
 > [!TIP]
-> If you do not have articles on freeCodeCamp, leave `contents/fcc-articles.js` as an empty array: `module.exports = [];` to ensure the generator runs smoothly.
+> If you do not have articles on freeCodeCamp or do not wish to exclude any repositories from the Active Workbench, ensure the respective files (`contents/fcc-articles.js` or `contents/repo-exclusions.js`) export an empty array: `module.exports = [];`. This ensures the generator runs smoothly.
 
 ### 4. Deployment
 


### PR DESCRIPTION
## Summary

Updates the documentation to provide clear instructions on handling optional configuration files when no data is present.

### Changes

- Expanded the `[!TIP]` section to include `contents/repo-exclusions.js`.
- Clarified that both `fcc-articles.js` and `repo-exclusions.js` should export an empty array (`module.exports = [];`) if they are not being used.
- Ensures a smoother onboarding experience for new users by preventing potential generator errors due to missing exports.