### PR TITLE
chore: Add `podcast-transcripts` to repo exclusion

### DIFF
--- a/contents/repo-exclusions.js
+++ b/contents/repo-exclusions.js
@@ -15,5 +15,10 @@ module.exports = {
    * (This matches: 'user/my-sandbox-project', 'sandbox-org/docs')
    * Note: This is case-insensitive. 'MY-ORG' is the same as 'my-org'.
    */
-  excludedRepos: ['open-sauced/', 'astro-partykit-starter', 'career-lab-fall-2021'],
+  excludedRepos: [
+    'open-sauced/',
+    'astro-partykit-starter',
+    'career-lab-fall-2021',
+    'podcast-transcripts',
+  ],
 };


### PR DESCRIPTION
## Description

This PR adds `podcast-transcripts` to `contents/repo-exclusions.js` as it's no longer active.