### PR TITLE
# fix: Standardize Workbench fetching, UI branding, and commit attribution

### DIFF
--- a/scripts/api/github-api-fetchers.js
+++ b/scripts/api/github-api-fetchers.js
@@ -5,6 +5,20 @@ const axios = require('axios');
 const { GITHUB_USERNAME, BASE_URL } = require('../config/config');
 
 /**
+ * HELPER: Extracts linked issue numbers from PR descriptions.
+ */
+function getLinkedIssueNumbers(prBody) {
+  if (!prBody) return [];
+  const regex = /(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\s+#(\d+)/gi;
+  const matches = [];
+  let match;
+  while ((match = regex.exec(prBody)) !== null) {
+    matches.push(parseInt(match[1], 10));
+  }
+  return matches;
+}
+
+/**
  * HELPER: Determines if a commit was physically authored by the user.
  * This is the gatekeeper for the "Co-authored" category.
  */
@@ -640,7 +654,7 @@ async function fetchOngoingReviews() {
 /**
  * Fetches all open issues assigned to the user.
  */
-async function fetchOngoingIssues() {
+async function fetchOngoingIssues(ongoingPrs = []) {
   const token = process.env.GITHUB_TOKEN;
   if (!token) throw new Error('GITHUB_TOKEN is not set.');
 
@@ -650,6 +664,12 @@ async function fetchOngoingIssues() {
       Authorization: `token ${token}`,
       Accept: 'application/vnd.github.v3+json',
     },
+  });
+
+  const linkedIssueNumbers = new Set();
+  ongoingPrs.forEach((pr) => {
+    const numbers = getLinkedIssueNumbers(pr.body);
+    numbers.forEach((num) => linkedIssueNumbers.add(num));
   });
 
   async function searchAll(query) {
@@ -683,18 +703,20 @@ async function fetchOngoingIssues() {
   const query = `is:issue is:open assignee:${GITHUB_USERNAME} -user:${GITHUB_USERNAME}`;
   const rawIssues = await searchAll(query);
 
-  return rawIssues.map((issue) => {
-    const repoParts = new URL(issue.repository_url).pathname.split('/');
-    return {
-      title: issue.title,
-      url: issue.html_url,
-      repo: `${repoParts[repoParts.length - 2]}/${repoParts[repoParts.length - 1]}`,
-      createdAt: issue.created_at,
-      updatedAt: issue.updated_at,
-      labels: issue.labels.map((l) => l.name),
-      number: issue.number,
-    };
-  });
+  return rawIssues
+    .filter((issue) => !linkedIssueNumbers.has(issue.number))
+    .map((issue) => {
+      const repoParts = new URL(issue.repository_url).pathname.split('/');
+      return {
+        title: issue.title,
+        url: issue.html_url,
+        repo: `${repoParts[repoParts.length - 2]}/${repoParts[repoParts.length - 1]}`,
+        createdAt: issue.created_at,
+        updatedAt: issue.updated_at,
+        labels: issue.labels.map((l) => l.name),
+        number: issue.number,
+      };
+    });
 }
 
 /**
@@ -758,6 +780,7 @@ async function fetchOngoingAuthoredPrs() {
         number: pr.number,
         isDraft: pr.draft === true || !!(pr.pull_request && pr.pull_request.draft),
         labels: pr.labels ? pr.labels.map((l) => l.name) : [],
+        body: pr.body,
       };
     });
 }
@@ -838,6 +861,7 @@ async function fetchOngoingCoAuthoredPrs(commitCache) {
         updatedAt: pr.updated_at,
         labels: pr.labels ? pr.labels.map((l) => l.name) : [],
         isDraft: pr.draft,
+        body: pr.body,
       });
     }
   }

--- a/scripts/api/github-api-fetchers.js
+++ b/scripts/api/github-api-fetchers.js
@@ -1,9 +1,59 @@
 require('dotenv').config();
-
 const axios = require('axios');
 
 // Import configuration
 const { GITHUB_USERNAME, BASE_URL } = require('../config/config');
+
+/**
+ * HELPER: Determines if a commit was physically authored by the user.
+ * This is the gatekeeper for the "Co-authored" category.
+ */
+function isCommitByUser(c, username) {
+  try {
+    const lowerUsername = username.toLowerCase();
+    const commitMessage = c.commit?.message || '';
+
+    // 1. STAGE 1: WEB-UI GATEKEEPER
+    // GitHub uses 'web-flow' as the committer for all Web UI actions.
+    // If you committed a suggestion, the AUTHOR is you, but the COMMITTER is web-flow.
+    const isGitHubWebUI = c.committer?.login === 'web-flow';
+    if (isGitHubWebUI) return false;
+
+    // 2. STAGE 2: MESSAGE-BASED EXCLUSIONS
+    // Catch-all for any variation of suggestions or merges not caught by web-flow.
+    const isExcludedMessage = /suggestion|Merge branch|Merge remote-tracking/i.test(commitMessage);
+    if (isExcludedMessage) return false;
+
+    // 3. STAGE 3: LOCAL AUTHOR CHECK
+    // If we reached here, the commit was pushed via CLI/Local Git.
+    const authorLogin = c.author?.login || '';
+    const authorEmail = c.commit?.author?.email?.toLowerCase() || '';
+    const authorName = c.commit?.author?.name?.toLowerCase() || '';
+
+    const isAuthorMatch =
+      authorLogin === username ||
+      (authorEmail.endsWith('@users.noreply.github.com') &&
+        authorEmail.includes(`+${lowerUsername}@`)) ||
+      authorEmail === `${lowerUsername}@users.noreply.github.com` ||
+      authorEmail.includes(lowerUsername) ||
+      (authorName && authorName.includes(lowerUsername));
+
+    if (isAuthorMatch) return true;
+
+    // 4. STAGE 4: CO-AUTHORED TRAILER CHECK
+    // This handles pair programming where your peer pushes local commits with your credit.
+    if (
+      /Co-authored-by:/i.test(commitMessage) &&
+      commitMessage.toLowerCase().includes(lowerUsername)
+    ) {
+      return true;
+    }
+
+    return false;
+  } catch (e) {
+    return false;
+  }
+}
 
 /**
  * Fetches the very first commit of a PR to check the original author.
@@ -48,37 +98,9 @@ async function getFirstCommitDetails(
       }
     }
 
-    function isCommitByUser(c) {
-      try {
-        const lowerUsername = username.toLowerCase();
-        const commitMessage = c.commit?.message || '';
-        const isBranchUpdate = /^Merge branch '.+' into .+/i.test(commitMessage);
-        if (isBranchUpdate) return false;
-        if (c.author?.login === username) return true;
-        const authorEmail = c.commit?.author?.email?.toLowerCase();
-        if (authorEmail) {
-          if (
-            authorEmail.endsWith('@users.noreply.github.com') &&
-            authorEmail.includes(`+${lowerUsername}@`)
-          )
-            return true;
-          if (authorEmail === `${lowerUsername}@users.noreply.github.com`) return true;
-          if (authorEmail.includes(lowerUsername)) return true;
-        }
-        if (c.commit?.author?.name && c.commit.author.name.toLowerCase().includes(lowerUsername))
-          return true;
-        if (
-          /Co-authored-by:/i.test(commitMessage) &&
-          commitMessage.toLowerCase().includes(lowerUsername)
-        )
-          return true;
-      } catch (e) {
-        return false;
-      }
-      return false;
-    }
+    // Filter commits using the helper logic
+    const userCommits = allCommits.filter((c) => isCommitByUser(c, username));
 
-    const userCommits = allCommits.filter(isCommitByUser);
     if (userCommits.length > 0) {
       userCommits.sort((a, b) => new Date(a.commit.author.date) - new Date(b.commit.author.date));
       result = {
@@ -116,9 +138,7 @@ async function getGitHubJoinYear(axiosInstance) {
  */
 async function fetchContributions(requestedStartYear, prCache, persistentCommitCache) {
   const token = process.env.GITHUB_TOKEN;
-  if (!token) {
-    throw new Error('GITHUB_TOKEN is not set.');
-  }
+  if (!token) throw new Error('GITHUB_TOKEN is not set.');
 
   const axiosInstance = axios.create({
     baseURL: BASE_URL,
@@ -128,7 +148,6 @@ async function fetchContributions(requestedStartYear, prCache, persistentCommitC
     },
   });
 
-  // --- AUTO-DISCOVERY START YEAR ---
   let startYear = requestedStartYear;
   if (!startYear) {
     console.log(`🔍 No start year provided. Discovering first year for ${GITHUB_USERNAME}...`);
@@ -164,7 +183,6 @@ async function fetchContributions(requestedStartYear, prCache, persistentCommitC
           `/search/issues?q=${query}&per_page=100&page=${page}`
         );
         results.push(...response.data.items);
-
         const linkHeader = response.headers.link;
         if (linkHeader && linkHeader.includes('rel="next"')) {
           page++;
@@ -191,14 +209,10 @@ async function fetchContributions(requestedStartYear, prCache, persistentCommitC
       const myReviews = response.data
         .filter((review) => review.user?.login === username)
         .sort((a, b) => new Date(a.submitted_at) - new Date(b.submitted_at));
-      if (myReviews.length > 0) {
-        return myReviews[0].submitted_at;
-      }
+      if (myReviews.length > 0) return myReviews[0].submitted_at;
       return null;
     } catch (err) {
-      if (err.response && (err.response.status === 403 || err.response.status === 404)) {
-        return null;
-      }
+      if (err.response && (err.response.status === 403 || err.response.status === 404)) return null;
       throw err;
     }
   }
@@ -209,9 +223,7 @@ async function fetchContributions(requestedStartYear, prCache, persistentCommitC
       while (true) {
         const response = await axiosInstance.get(`${url}?per_page=100&page=${page}`);
         const myFirstComment = response.data.find((comment) => comment.user?.login === username);
-        if (myFirstComment) {
-          return myFirstComment.created_at;
-        }
+        if (myFirstComment) return myFirstComment.created_at;
         const linkHeader = response.headers.link;
         if (linkHeader && linkHeader.includes('rel="next"')) {
           page++;
@@ -220,9 +232,7 @@ async function fetchContributions(requestedStartYear, prCache, persistentCommitC
         }
       }
     } catch (err) {
-      if (err.response && (err.response.status === 403 || err.response.status === 404)) {
-        return null;
-      }
+      if (err.response && (err.response.status === 403 || err.response.status === 404)) return null;
       throw err;
     }
   }
@@ -500,6 +510,9 @@ async function fetchContributions(requestedStartYear, prCache, persistentCommitC
   return { contributions, prCache, commitCache };
 }
 
+/**
+ * FETCH ONGOING REVIEWS
+ */
 async function fetchOngoingReviews() {
   const token = process.env.GITHUB_TOKEN;
   if (!token) throw new Error('GITHUB_TOKEN is not set.');
@@ -540,8 +553,8 @@ async function fetchOngoingReviews() {
     return results;
   }
 
-  const requestedQuery = `is:pr is:open review-requested:${GITHUB_USERNAME} -reviewed-by:${GITHUB_USERNAME} -author:${GITHUB_USERNAME}`;
-  const underReviewQuery = `is:pr is:open reviewed-by:${GITHUB_USERNAME} -author:${GITHUB_USERNAME}`;
+  const requestedQuery = `is:pr is:open review-requested:${GITHUB_USERNAME} -author:${GITHUB_USERNAME} -user:${GITHUB_USERNAME}`;
+  const underReviewQuery = `is:pr is:open reviewed-by:${GITHUB_USERNAME} -author:${GITHUB_USERNAME} -user:${GITHUB_USERNAME}`;
 
   const [requestedPrs, underReviewPrs] = await Promise.all([
     searchAll(requestedQuery),
@@ -549,6 +562,8 @@ async function fetchOngoingReviews() {
   ]);
 
   const ongoingTasks = [];
+  const seenUrls = new Set(); // This is the fix: tracks processed PRs
+
   const formatTask = (pr, status) => {
     const repoParts = new URL(pr.repository_url).pathname.split('/');
     return {
@@ -565,14 +580,29 @@ async function fetchOngoingReviews() {
     };
   };
 
-  requestedPrs.forEach((pr) => ongoingTasks.push(formatTask(pr, 'Request review')));
-  underReviewPrs.forEach((pr) => ongoingTasks.push(formatTask(pr, 'Review in progress')));
+  // 1. Process "Review in progress" FIRST.
+  // If a PR is here, it means you've already interacted with it.
+  underReviewPrs.forEach((pr) => {
+    if (!seenUrls.has(pr.html_url)) {
+      ongoingTasks.push(formatTask(pr, 'Review in progress'));
+      seenUrls.add(pr.html_url);
+    }
+  });
+
+  // 2. Process "Request review" SECOND.
+  // The 'seenUrls' check prevents it from being added if it was already marked as "Review in progress".
+  requestedPrs.forEach((pr) => {
+    if (!seenUrls.has(pr.html_url)) {
+      ongoingTasks.push(formatTask(pr, 'Request review'));
+      seenUrls.add(pr.html_url);
+    }
+  });
 
   return ongoingTasks;
 }
 
 /**
- * Fetches all open issues assigned to the user in external repositories.
+ * Fetches all open issues assigned to the user.
  */
 async function fetchOngoingIssues() {
   const token = process.env.GITHUB_TOKEN;
@@ -614,7 +644,6 @@ async function fetchOngoingIssues() {
     return results;
   }
 
-  // Query: open issues, assigned to you, excluding your own repositories
   const query = `is:issue is:open assignee:${GITHUB_USERNAME} -user:${GITHUB_USERNAME}`;
   const rawIssues = await searchAll(query);
 
@@ -633,8 +662,7 @@ async function fetchOngoingIssues() {
 }
 
 /**
- * Fetches all open Pull Requests authored by the user in external repositories.
- * Uses the Issues API, which includes Pull Requests (even standalone ones).
+ * FETCH ONGOING AUTHORED PRS
  */
 async function fetchOngoingAuthoredPrs() {
   const token = process.env.GITHUB_TOKEN;
@@ -659,13 +687,12 @@ async function fetchOngoingAuthoredPrs() {
           state: 'open',
           per_page: 100,
           page: page,
-          pulls: true // Encourages the API to include PR-specific metadata
-        }
+        },
       });
 
       if (response.data.length === 0) break;
       allAuthoredItems.push(...response.data);
-      
+
       const link = response.headers.link;
       if (link && link.includes('rel="next"')) {
         page++;
@@ -678,18 +705,14 @@ async function fetchOngoingAuthoredPrs() {
     return [];
   }
 
-  // Filter the results
   return allAuthoredItems
-    .filter(item => {
-      // 1. Must be a Pull Request (GitHub returns PRs in the /issues endpoint)
+    .filter((item) => {
       const isPr = !!item.pull_request;
-      // 2. Must be in an external repository
       const isExternal = !item.repository_url.includes(`repos/${GITHUB_USERNAME}/`);
       return isPr && isExternal;
     })
     .map((pr) => {
       const repoParts = new URL(pr.repository_url).pathname.split('/');
-      
       return {
         title: pr.title,
         url: pr.html_url,
@@ -704,8 +727,7 @@ async function fetchOngoingAuthoredPrs() {
 }
 
 /**
- * Fetches all open Pull Requests in external repositories where the user
- * is a co-author. Address ongoing PRs only, excluding "commitCount" logic.
+ * FETCH ONGOING CO-AUTHORED PRS
  */
 async function fetchOngoingCoAuthoredPrs(commitCache) {
   const token = process.env.GITHUB_TOKEN;
@@ -747,8 +769,7 @@ async function fetchOngoingCoAuthoredPrs(commitCache) {
     return results;
   }
 
-  // Query: open PRs where you commented/pushed, but did not author.
-  const query = `is:pr is:open commenter:${GITHUB_USERNAME} -author:${GITHUB_USERNAME}`;
+  const query = `is:pr is:open commenter:${GITHUB_USERNAME} -author:${GITHUB_USERNAME} -user:${GITHUB_USERNAME}`;
   const rawPrs = await searchAll(query);
 
   const coAuthoredResults = [];
@@ -760,7 +781,6 @@ async function fetchOngoingCoAuthoredPrs(commitCache) {
 
     if (owner === GITHUB_USERNAME) continue;
 
-    // Verify commit authorship using the moved helper
     const commitDetails = await getFirstCommitDetails(
       owner,
       repoName,
@@ -771,7 +791,6 @@ async function fetchOngoingCoAuthoredPrs(commitCache) {
       pr.updated_at
     );
 
-    // Only include if user has commits, but don't return the commitCount
     if (commitDetails && commitDetails.firstCommitDate) {
       coAuthoredResults.push({
         title: pr.title,

--- a/scripts/api/github-api-fetchers.js
+++ b/scripts/api/github-api-fetchers.js
@@ -543,7 +543,7 @@ async function fetchOngoingReviews() {
         }
       } catch (err) {
         if (err.response && err.response.status === 403) {
-          console.log('Rate limit hit in fetchOngoingReviews. Waiting for 60 seconds...');
+          console.log('Rate limit hit. Waiting...');
           await new Promise((resolve) => setTimeout(resolve, 60000));
           continue;
         }
@@ -551,6 +551,38 @@ async function fetchOngoingReviews() {
       }
     }
     return results;
+  }
+
+  // Helper to check if a PR has human activity from someone other than the author
+  async function checkHumanActivity(pr) {
+    const repoParts = new URL(pr.repository_url).pathname.split('/');
+    const owner = repoParts[repoParts.length - 2];
+    const repo = repoParts[repoParts.length - 1];
+    const author = pr.user.login;
+
+    try {
+      // 1. Fetch Reviews
+      const reviewsResp = await axiosInstance.get(
+        `/repos/${owner}/${repo}/pulls/${pr.number}/reviews`
+      );
+      const hasHumanReview = reviewsResp.data.some(
+        (review) => review.user.type === 'User' && review.user.login !== author
+      );
+      if (hasHumanReview) return true;
+
+      // 2. Fetch Comments (Issue comments/Top-level)
+      const commentsResp = await axiosInstance.get(
+        `/repos/${owner}/${repo}/issues/${pr.number}/comments`
+      );
+      const hasHumanComment = commentsResp.data.some(
+        (comment) => comment.user.type === 'User' && comment.user.login !== author
+      );
+      if (hasHumanComment) return true;
+
+      return false;
+    } catch (e) {
+      return false;
+    }
   }
 
   const requestedQuery = `is:pr is:open review-requested:${GITHUB_USERNAME} -author:${GITHUB_USERNAME} -user:${GITHUB_USERNAME}`;
@@ -562,7 +594,7 @@ async function fetchOngoingReviews() {
   ]);
 
   const ongoingTasks = [];
-  const seenUrls = new Set(); // This is the fix: tracks processed PRs
+  const seenUrls = new Set();
 
   const formatTask = (pr, status) => {
     const repoParts = new URL(pr.repository_url).pathname.split('/');
@@ -580,8 +612,7 @@ async function fetchOngoingReviews() {
     };
   };
 
-  // 1. Process "Review in progress" FIRST.
-  // If a PR is here, it means you've already interacted with it.
+  // 1. "Review in progress": already explicitly reviewed by you
   underReviewPrs.forEach((pr) => {
     if (!seenUrls.has(pr.html_url)) {
       ongoingTasks.push(formatTask(pr, 'Review in progress'));
@@ -589,14 +620,19 @@ async function fetchOngoingReviews() {
     }
   });
 
-  // 2. Process "Request review" SECOND.
-  // The 'seenUrls' check prevents it from being added if it was already marked as "Review in progress".
-  requestedPrs.forEach((pr) => {
-    if (!seenUrls.has(pr.html_url)) {
+  // 2. "Request review" vs "Review in progress" for the remaining requested PRs
+  for (const pr of requestedPrs) {
+    if (seenUrls.has(pr.html_url)) continue;
+
+    const isEngaged = await checkHumanActivity(pr);
+
+    if (isEngaged) {
+      ongoingTasks.push(formatTask(pr, 'Review in progress'));
+    } else {
       ongoingTasks.push(formatTask(pr, 'Request review'));
-      seenUrls.add(pr.html_url);
     }
-  });
+    seenUrls.add(pr.html_url);
+  }
 
   return ongoingTasks;
 }

--- a/scripts/api/github-api-fetchers.js
+++ b/scripts/api/github-api-fetchers.js
@@ -634,6 +634,7 @@ async function fetchOngoingIssues() {
 
 /**
  * Fetches all open Pull Requests authored by the user in external repositories.
+ * Uses the Issues API, which includes Pull Requests (even standalone ones).
  */
 async function fetchOngoingAuthoredPrs() {
   const token = process.env.GITHUB_TOKEN;
@@ -647,57 +648,59 @@ async function fetchOngoingAuthoredPrs() {
     },
   });
 
-  async function searchAll(query) {
-    let results = [];
-    let page = 1;
+  let allAuthoredItems = [];
+  let page = 1;
+
+  try {
     while (true) {
-      try {
-        const response = await axiosInstance.get(
-          `/search/issues?q=${query}&per_page=100&page=${page}`
-        );
-        results.push(...response.data.items);
-        const link = response.headers.link;
-        if (link && link.includes('rel="next"')) {
-          page++;
-          await new Promise((resolve) => setTimeout(resolve, 1000));
-        } else {
-          break;
+      const response = await axiosInstance.get(`/issues`, {
+        params: {
+          filter: 'created',
+          state: 'open',
+          per_page: 100,
+          page: page,
+          pulls: true // Encourages the API to include PR-specific metadata
         }
-      } catch (err) {
-        if (err.response && err.response.status === 403) {
-          console.log('Rate limit hit in fetchOngoingAuthorPrs. Waiting for 60 seconds...');
-          await new Promise((resolve) => setTimeout(resolve, 60000));
-          continue;
-        }
-        throw err;
+      });
+
+      if (response.data.length === 0) break;
+      allAuthoredItems.push(...response.data);
+      
+      const link = response.headers.link;
+      if (link && link.includes('rel="next"')) {
+        page++;
+      } else {
+        break;
       }
     }
-    return results;
+  } catch (err) {
+    console.error('❌ Error fetching from Issues API:', err.message);
+    return [];
   }
 
-  // 1. Fetch all open PRs
-  const query = `is:pr is:open author:${GITHUB_USERNAME} -user:${GITHUB_USERNAME}`;
-  const rawPrs = await searchAll(query);
-
-  // 2. Fetch only APPROVED open PRs
-  const approvedQuery = `${query} review:approved`;
-  const approvedPrs = await searchAll(approvedQuery);
-  const approvedUrls = new Set(approvedPrs.map((pr) => pr.html_url));
-
-  return rawPrs.map((pr) => {
-    const repoParts = new URL(pr.repository_url).pathname.split('/');
-    return {
-      title: pr.title,
-      url: pr.html_url,
-      repo: `${repoParts[repoParts.length - 2]}/${repoParts[repoParts.length - 1]}`,
-      createdAt: pr.created_at,
-      updatedAt: pr.updated_at,
-      number: pr.number,
-      isDraft: pr.draft,
-      labels: pr.labels.map((l) => l.name),
-      isApproved: approvedUrls.has(pr.html_url),
-    };
-  });
+  // Filter the results
+  return allAuthoredItems
+    .filter(item => {
+      // 1. Must be a Pull Request (GitHub returns PRs in the /issues endpoint)
+      const isPr = !!item.pull_request;
+      // 2. Must be in an external repository
+      const isExternal = !item.repository_url.includes(`repos/${GITHUB_USERNAME}/`);
+      return isPr && isExternal;
+    })
+    .map((pr) => {
+      const repoParts = new URL(pr.repository_url).pathname.split('/');
+      
+      return {
+        title: pr.title,
+        url: pr.html_url,
+        repo: `${repoParts[repoParts.length - 2]}/${repoParts[repoParts.length - 1]}`,
+        createdAt: pr.created_at,
+        updatedAt: pr.updated_at,
+        number: pr.number,
+        isDraft: pr.draft === true || !!(pr.pull_request && pr.pull_request.draft),
+        labels: pr.labels ? pr.labels.map((l) => l.name) : [],
+      };
+    });
 }
 
 /**

--- a/scripts/generators/html/community-html-generator.js
+++ b/scripts/generators/html/community-html-generator.js
@@ -171,7 +171,7 @@ async function createCommunityHtml(
           const labels = (task.labels || []).map((l) => l.toLowerCase());
 
           const isDraft = task.isDraft === true;
-          const isPendingMerge = task.isApproved && labels.includes('pending-pr-merge');
+          const isPendingMerge = labels.some((l) => l.includes('pending') && l.includes('merge'));
           const isBlocked =
             !isPendingMerge &&
             labels.some(

--- a/scripts/generators/html/community-html-generator.js
+++ b/scripts/generators/html/community-html-generator.js
@@ -283,13 +283,15 @@ async function createCommunityHtml(
   const hasTasks = taskCount > 0;
 
   const badgeBg = hasTasks
-    ? getColorValue(COLORS.status.green.bg)
+    ? getColorValue(COLORS.primary[10]) || '#eef2ff'
     : getColorValue(COLORS.status.red.bg);
+
   const badgeTextColor = hasTasks
-    ? getColorValue(COLORS.status.green.text)
+    ? getColorValue(COLORS.primary)
     : getColorValue(COLORS.status.red.text);
+
   const badgeBorderColor = hasTasks
-    ? getColorValue(COLORS.status.green.text)
+    ? getColorValue(COLORS.primary)
     : getColorValue(COLORS.status.red.text);
 
   const fullHtml = dedent`

--- a/scripts/generators/html/community-html-generator.js
+++ b/scripts/generators/html/community-html-generator.js
@@ -264,12 +264,12 @@ async function createCommunityHtml(
   const botRequestTasks = ongoingTasks.filter((t) => t.status === 'Request review' && isBot(t));
 
   const sections = [
+    { tasks: ongoingIssues, label: 'To do issues', type: 'todo' },
+    { tasks: manualRequestTasks, label: 'Request review', type: 'todo' },
     { tasks: ongoingPRs, label: 'Ongoing PRs', type: 'ongoing' },
     { tasks: ongoingCoAuthoredPRs, label: 'Moving co-authored PRs forward', type: 'ongoing' },
     { tasks: inProgressTasks, label: 'Review in progress', type: 'ongoing' },
-    { tasks: ongoingIssues, label: 'To do issues', type: 'todo' },
-    { tasks: manualRequestTasks, label: 'Request review', type: 'todo' },
-    { tasks: botRequestTasks, label: 'Bot request review', type: 'bot' },
+   { tasks: botRequestTasks, label: 'Bot request review', type: 'bot' },
   ];
 
   const workbenchHtml = sections

--- a/scripts/generators/markdown/community-markdown-generator.js
+++ b/scripts/generators/markdown/community-markdown-generator.js
@@ -11,7 +11,7 @@ function getStatusBadge(task) {
 
   const labels = (task.labels || []).map((l) => (typeof l === 'string' ? l : l.name).toLowerCase());
   const isDraft = task.isDraft === true;
-  const isPendingMerge = task.isApproved && labels.includes('pending-pr-merge');
+  const isPendingMerge = labels.some((l) => l.includes('pending') && l.includes('merge'));
   const isBlocked =
     !isPendingMerge &&
     labels.some((l) => l.includes('blocked') || l.includes('stalled') || l.includes('wait'));

--- a/scripts/src/main.js
+++ b/scripts/src/main.js
@@ -22,7 +22,7 @@ const {
   fetchOngoingReviews,
   fetchOngoingIssues,
   fetchOngoingAuthoredPrs,
-  fetchOngoingCoAuthoredPrs
+  fetchOngoingCoAuthoredPrs,
 } = require('../api/github-api-fetchers');
 const { fetchStrictOssArticles } = require('../api/articles-api-fetcher');
 
@@ -123,7 +123,11 @@ async function main() {
 
     // --- Fetch Ongoing Co-authored PRs (Workbench) ---
     console.log('Fetching ongoing co-authored PRs for the Active Workbench...');
-    const rawOngoingCoAuthoredPRs = await fetchOngoingCoAuthoredPrs(commitCacheFromDisk);
+
+    // Pass a fresh Map() instead of commitCacheFromDisk.
+    // This forces a fresh look at the commits for OPEN PRs only,
+    // ensuring the 'web-flow' fix is applied to the Workbench without affecting historical data.
+    const rawOngoingCoAuthoredPRs = await fetchOngoingCoAuthoredPrs(new Map());
 
     const ongoingCoAuthoredPRs = rawOngoingCoAuthoredPRs.filter((pr) => {
       const repoName = pr.repo.toLowerCase();
@@ -146,18 +150,25 @@ async function main() {
     console.log('Fetching ongoing review tasks for the Active Workbench...');
     const rawOngoingTasks = await fetchOngoingReviews();
 
+    // Only remove from the Workbench "Reviews" if it's already in the "Co-authored" list
+    const coAuthoredUrls = new Set(ongoingCoAuthoredPRs.map((pr) => pr.url));
+
     const ongoingTasks = rawOngoingTasks.filter((task) => {
       const repoName = task.repo.toLowerCase();
       // Dynamically exclude repos based on the exclusions list
       const isExcluded = excludedRepos.some((excluded) =>
         repoName.includes(excluded.toLowerCase())
       );
-      return !isExcluded;
+
+      // Check for duplication in the Workbench
+      const isAlreadyCoAuthored = coAuthoredUrls.has(task.url);
+
+      return !isExcluded && !isAlreadyCoAuthored;
     });
 
     await fs.writeFile(ongoingTasksFile, JSON.stringify(ongoingTasks, null, 2), 'utf8');
     console.log(
-      `Saved ${ongoingTasks.length} ongoing tasks to ${ongoingTasksFile} (after exclusions).`
+      `Saved ${ongoingTasks.length} ongoing tasks to ${ongoingTasksFile} (after exclusions and workbench deduplication).`
     );
 
     // --- Fetch Articles ---

--- a/scripts/src/main.js
+++ b/scripts/src/main.js
@@ -89,21 +89,6 @@ async function main() {
   }
 
   try {
-    // --- Fetch Ongoing Issues (Assigned to you) ---
-    console.log('Fetching ongoing issues for the Active Workbench...');
-    const rawOngoingIssues = await fetchOngoingIssues();
-
-    const ongoingIssues = rawOngoingIssues.filter((issue) => {
-      const repoName = issue.repo.toLowerCase();
-      const isExcluded = excludedRepos.some((excluded) =>
-        repoName.includes(excluded.toLowerCase())
-      );
-      return !isExcluded;
-    });
-
-    await fs.writeFile(ongoingIssuesFile, JSON.stringify(ongoingIssues, null, 2), 'utf8');
-    console.log(`Saved ${ongoingIssues.length} ongoing issues to ${ongoingIssuesFile}.`);
-
     // --- Fetch Ongoing Pull Requests (Submitted by you) ---
     console.log('Fetching ongoing submitted PRs...');
 
@@ -120,6 +105,21 @@ async function main() {
     const ongoingPRsFile = path.join(dataDir, 'ongoing-prs.json');
     await fs.writeFile(ongoingPRsFile, JSON.stringify(ongoingPRs, null, 2), 'utf8');
     console.log(`Saved ${ongoingPRs.length} ongoing PRs to ${ongoingPRsFile}.`);
+
+    // --- Fetch Ongoing Issues (Assigned to you) ---
+    console.log('Fetching ongoing issues for the Active Workbench...');
+    const rawOngoingIssues = await fetchOngoingIssues(ongoingPRs);
+
+    const ongoingIssues = rawOngoingIssues.filter((issue) => {
+      const repoName = issue.repo.toLowerCase();
+      const isExcluded = excludedRepos.some((excluded) =>
+        repoName.includes(excluded.toLowerCase())
+      );
+      return !isExcluded;
+    });
+
+    await fs.writeFile(ongoingIssuesFile, JSON.stringify(ongoingIssues, null, 2), 'utf8');
+    console.log(`Saved ${ongoingIssues.length} ongoing issues to ${ongoingIssuesFile}.`);
 
     // --- Fetch Ongoing Co-authored PRs (Workbench) ---
     console.log('Fetching ongoing co-authored PRs for the Active Workbench...');


### PR DESCRIPTION
## Description

This PR addresses inconsistencies in the **Active Workbench** data fetching logic, refines commit attribution, and aligns the UI with the primary brand identity. Key changes include:

### **Core Logic & Bug Fixes**

* **Linked Issue Deduplication:** Implemented logic to parse authored Pull Request descriptions for linked issues (e.g., "closes #123"). These issues are now automatically excluded from the "To-do Issues" section of the Workbench, ensuring each task is only represented once in the UI.
* **Human-Centric Review Status:** Refined `fetchOngoingReviews` to differentiate between human maintainer activity and automated bot/author interactions. PRs move to "Review in progress" only if a human (other than the author) has commented or reviewed; otherwise, they stay in "Request review."
* **Transitioned to Issues API:** Switched the `fetchOngoingAuthoredPrs` function from the `/search/issues` endpoint to the direct `/issues` endpoint. This resolves issues where draft PRs and unreviewed external contributions were being omitted by the GitHub search index.
* **Refined Commit Attribution:** Updated the `isCommitByUser` helper to prioritize the detection of the `web-flow` committer. This ensures that PRs where the user only committed suggestions or made edits via the GitHub Web UI are correctly categorized as **Reviewed PRs** rather than **Co-authored PRs**.
* **Review Deduplication:** Implemented a priority-based filtering system in `fetchOngoingReviews`. PRs are now deduplicated using a `seenUrls` Set, ensuring that "Review in progress" takes precedence over "Request review" if both statuses are returned by the API.
* **Decoupled Pending Merge Badge:** Updated the logic for the `pending merge` status indicator. The badge now renders based on the presence of the corresponding label, ensuring it displays even if the PR has not yet received a formal review.

### **UI & Branding**

* **Priority-Based Workbench Sorting:** Reorganized the **Active Workbench** sections to follow a logical priority flow: **To-do** (Issues/Manual Reviews) at the top, followed by **Ongoing** (Authored/Co-authored PRs), and **Bot** requests at the bottom.
* **Dynamic Brand Coloring:** Refactored the "Ongoing Tasks" label to use the primary brand color from `constants.js` instead of the static success green.
* **Consistency Improvements:** Utilized `COLORS.primary` and `COLORS.primary[10]` for the workbench headers and badges to ensure a unified visual experience across the Community & Activity page.

## Technical Details

* **Endpoints:** * Migrated to `/issues?filter=created&state=open` for higher reliability.
    * Integrated `/pulls/{number}/reviews` and `/issues/{number}/comments` to validate human interaction.
* **Filtering Logic:** * Added `getLinkedIssueNumbers` helper to extract issue references from PR bodies using regex.
    * Added a "Web-UI Gatekeeper" to ignore `web-flow` commits during co-authorship evaluation.
    * Added a "Human Activity Check" to filter out bot/poster comments from triggering maintainer status.
    * Added a URL-based Set in `fetchOngoingReviews` to prevent PRs from appearing in multiple task categories simultaneously.
* **Layout:** Re-ordered the `sections` array in `createCommunityHtml` to prioritize actionable "To-do" tasks.
* **Styles:** Updated `createCommunityHtml` to pull dynamic values from the centralized `COLORS` configuration.
