### PR TITLE
fix: Resolve persona calculation by mapping category keys

### DIFF
--- a/scripts/metadata/personas.js
+++ b/scripts/metadata/personas.js
@@ -4,26 +4,31 @@
  */
 const personaCategories = [
   {
+    key: 'reviewedPrCount',
     title: 'Community Mentor',
     desc: 'Expert advocate for code quality and peer development. Code review and technical guidance ensure high standards across the community.',
     priority: 1,
   },
   {
+    key: 'prCount',
     title: 'Core Contributor',
     desc: 'Main driver of project development. Responsible for moving features from concept to production through robust code and resolving complex bugs to ensure software stability.',
     priority: 2,
   },
   {
+    key: 'issueCount',
     title: 'Project Architect',
     desc: 'Strategic problem-solver focused on technical discovery. Skilled at identifying critical system issues and defining feature planning that shapes the long-term technical roadmap.',
     priority: 3,
   },
   {
+    key: 'coAuthoredPrCount',
     title: 'Collaborative Partner',
     desc: 'Focused on shared project success. Pair programming and co-authoring code delivers high-impact value through collective development effort.',
     priority: 4,
   },
   {
+    key: 'collaborationCount',
     title: 'Ecosystem Partner',
     desc: 'Community builder focused on technical discussion and engagement. Facilitates collaboration through project discussions to ensure the open source ecosystem remains vibrant and interconnected.',
     priority: 5,


### PR DESCRIPTION
## Description

This PR fixes a bug in the `determinePersona` function where the portfolio would default to "Community Mentor" regardless of actual contribution data. 

### Changes

*   **metadata/personas.js**: Added a `key` property to each object in `personaCategories`. These keys (`prCount`, `issueCount`, `reviewedPrCount`, `coAuthoredPrCount`, and `collaborationCount`) now correctly map to the contribution data processed in the generator script.
*   **Logic Fix**: Previously, the calculation attempted to access `curr.key`, which was `undefined`. This caused all contribution counts to be treated as `0` during comparison, leading the script to fall back to the category with the highest priority rank (Priority 1) every time.