### PR TITLE
fix: Resolve workbench status logic and synchronize generator engines

### DIFF
--- a/scripts/generators/html/community-html-generator.js
+++ b/scripts/generators/html/community-html-generator.js
@@ -119,46 +119,67 @@ async function createCommunityHtml(
   };
 
   /**
-   * Logic to determine ball-tracking status for ongoing tasks
+   * Logic to determine ball-tracking status based on the user's role
+   * @param {Object} task - The task data
+   * @param {string} role - 'owner' (for Ongoing/Co-authored) or 'reviewer' (for Review in progress)
    */
-  function getWorkbenchStatus(task) {
+  function getWorkbenchStatus(task, role = 'owner') {
     const now = new Date();
 
-    // 1. APPROVED SHIELD - Priority Override
+    // 1. Common Logic: Approved & Stale
     if (task.reviewState === 'APPROVED' || task.status === 'APPROVED') {
-      return {
-        ...WORKBENCH_BALL_STATUS.approved,
-        child: '',
-      };
+      return { ...WORKBENCH_BALL_STATUS.approved, child: '' };
     }
 
-    // 2. Substantive Date Calculation
     const effectiveDate = task.lastSubstantiveDate || task.updatedAt;
-    const lastUpdate = new Date(effectiveDate);
-    const diffDays = (now - lastUpdate) / (1000 * 60 * 60 * 24);
+    const diffDays = (now - new Date(effectiveDate)) / (1000 * 60 * 60 * 24);
 
-    // 3. Stale Check - Updated to show dynamic day count
     if (diffDays >= 21) {
-      return {
-        ...WORKBENCH_BALL_STATUS.stale,
-        child: `${Math.floor(diffDays)} days`,
-      };
+      return { ...WORKBENCH_BALL_STATUS.stale, child: `${Math.floor(diffDays)} days` };
     }
 
-    // 4. Responsibility Logic
-    const lastActor = task.lastActor;
-    const isMe = lastActor === GITHUB_USERNAME;
-    const isAuthor = lastActor === task.author;
+    // 2. Normalization
+    // Fallback: If lastActor is missing, use the login from the task.user object
+    const rawLastActor =
+      task.lastActor || (task.user && typeof task.user === 'object' ? task.user.login : task.user);
 
+    const lastActor = String(rawLastActor || '')
+      .toLowerCase()
+      .trim();
+    const prAuthor = String(task.author || '')
+      .toLowerCase()
+      .trim();
+    const me = String(GITHUB_USERNAME || '')
+      .toLowerCase()
+      .trim();
+
+    const isMe = lastActor === me;
+    const isAuthor = lastActor === prAuthor;
+
+    // 3. Sub-label
     const isFormalReview = task.hasFormalReview === true;
     const childBase = isFormalReview ? 'Review' : 'Discussion';
     const isBotActor = task.isLastActorBot || isBot({ user: lastActor, title: '' });
     const childStatus = isBotActor ? `${childBase} + BOT` : childBase;
 
-    if (isMe) return { ...WORKBENCH_BALL_STATUS.waiting, child: childStatus };
-    if (isAuthor) return { ...WORKBENCH_BALL_STATUS.takeAction, child: childStatus };
+    // 4. Branching Logic by Role
 
-    return { ...WORKBENCH_BALL_STATUS.watching, child: childStatus };
+    if (role === 'reviewer') {
+      // SCENARIO: You are reviewing someone else's PR
+      if (isMe) return { ...WORKBENCH_BALL_STATUS.waiting, child: childStatus };
+      if (isAuthor) return { ...WORKBENCH_BALL_STATUS.takeAction, child: childStatus };
+      return { ...WORKBENCH_BALL_STATUS.watching, child: childStatus };
+    } else {
+      // SCENARIO: You are the Author or Co-Author (Ongoing / Co-authored)
+      if (isMe) return { ...WORKBENCH_BALL_STATUS.waiting, child: childStatus };
+
+      // In ongoing and co-authored PR, "Not Me" is treated as "Take Action"
+      if (!isMe && !isBotActor) {
+        return { ...WORKBENCH_BALL_STATUS.takeAction, child: childStatus };
+      }
+
+      return { ...WORKBENCH_BALL_STATUS.watching, child: childStatus };
+    }
   }
 
   function renderStatusIndicator(type) {
@@ -234,7 +255,13 @@ async function createCommunityHtml(
           }
 
           // New ball-tracking logic only for "ongoing" task types
-          const ballStatus = type === 'ongoing' ? getWorkbenchStatus(task) : null;
+          let ballStatus = null;
+
+          if (label === 'Review in progress') {
+            ballStatus = getWorkbenchStatus(task, 'reviewer');
+          } else if (label === 'Ongoing PRs' || label === 'Moving co-authored PRs forward') {
+            ballStatus = getWorkbenchStatus(task, 'owner');
+          }
 
           return dedent`
             <tr class="table-row-hover border-b border-slate-100 last:border-0 transition-colors">

--- a/scripts/generators/markdown/community-markdown-generator.js
+++ b/scripts/generators/markdown/community-markdown-generator.js
@@ -6,10 +6,10 @@ const { WORKBENCH_BALL_STATUS } = require('../../config/constants');
 
 /**
  * Maps ball status to GitHub-friendly indicators (using Shields.io for consistency).
+ * @param {Object} task - The task data
+ * @param {string} role - 'owner' or 'reviewer'
  */
-function getBallTrackingBadge(task, type) {
-  if (type !== 'ongoing') return null;
-
+function getBallTrackingBadge(task, role = 'owner') {
   // 1. Approved logic - HIGHEST PRIORITY
   if (task.reviewState === 'APPROVED' || task.status === 'APPROVED') {
     return {
@@ -22,7 +22,7 @@ function getBallTrackingBadge(task, type) {
   const lastUpdate = new Date(task.lastSubstantiveDate || task.updatedAt);
   const diffDays = (now - lastUpdate) / (1000 * 60 * 60 * 24);
 
-  // 2. Stale logic - Displays day count
+  // 2. Stale logic
   if (diffDays >= 21) {
     const dayCount = Math.floor(diffDays);
     return {
@@ -31,19 +31,32 @@ function getBallTrackingBadge(task, type) {
     };
   }
 
-  // 3. Actor logic - For active, non-approved PRs
-  const lastActor = task.lastActor;
-  const isMe = lastActor === GITHUB_USERNAME;
-  const isAuthor = lastActor === task.author;
+  // 3. Normalization with Fallback (Matches HTML logic)
+  const rawLastActor = task.lastActor || (task.user && typeof task.user === 'object' ? task.user.login : task.user);
+  
+  const lastActor = String(rawLastActor || '').toLowerCase().trim();
+  const prAuthor = String(task.author || '').toLowerCase().trim();
+  const me = String(GITHUB_USERNAME || '').toLowerCase().trim();
 
+  const isMe = lastActor === me;
+  const isAuthor = lastActor === prAuthor;
+
+  // 4. Sub-label logic
   let child = task.hasFormalReview ? 'Review' : 'Discussion';
-  const isBotActor = task.isLastActorBot || /\[bot\]$|dependabot|snyk/i.test(lastActor || '');
-
+  const isBotActor = task.isLastActorBot || /\[bot\]$|dependabot|snyk/i.test(lastActor);
   if (isBotActor) child += ' + BOT';
 
+  // 5. Branching Logic by Role
   let statusKey = 'watching';
-  if (isMe) statusKey = 'waiting';
-  else if (isAuthor) statusKey = 'takeAction';
+
+  if (role === 'reviewer') {
+    if (isMe) statusKey = 'waiting';
+    else if (isAuthor) statusKey = 'takeAction';
+  } else {
+    // Scenario: Owner/Co-Author
+    if (isMe) statusKey = 'waiting';
+    else if (!isMe && !isBotActor) statusKey = 'takeAction';
+  }
 
   const colorMap = {
     waiting: '4338ca', // Indigo 700
@@ -53,7 +66,7 @@ function getBallTrackingBadge(task, type) {
 
   const config = WORKBENCH_BALL_STATUS[statusKey];
   const color = colorMap[statusKey] || '334155';
-  const label = config.label.toUpperCase().replace(' ', '%20');
+  const label = config.label.toUpperCase().replace(/ /g, '%20');
 
   return {
     badge: `<img src="https://img.shields.io/badge/${label}-${color}?style=flat-square" alt="${config.label}">`,
@@ -176,9 +189,9 @@ async function createCommunityMarkdown(
 
   md += buildSection('To do issues', '📝', ongoingIssues, 'todo');
   md += buildSection('Request review', '📥', manualRequestTasks, 'todo');
-  md += buildSection('Ongoing PRs', '📤', ongoingPRs, 'ongoing');
-  md += buildSection('Moving Co-authored PRs Forward', '🤝', ongoingCoAuthoredPRs, 'ongoing');
-  md += buildSection('Review in progress', '🔄', inProgressTasks, 'ongoing');
+  md += buildSection('Ongoing PRs', '📤', ongoingPRs, 'owner');
+  md += buildSection('Moving Co-authored PRs Forward', '🤝', ongoingCoAuthoredPRs, 'owner');
+  md += buildSection('Review in progress', '🔄', inProgressTasks, 'reviewer');
   md += buildSection('Bot request review', '🤖', botTasks, 'bot');
 
   md += `---\n`;


### PR DESCRIPTION
# Description

This PR fixes the "Active Workbench" status logic which was incorrectly defaulting to "Watching" even when action was required. This was primarily caused by a missing data property and a lack of role-specific context in the state calculation.

## Changes

### 1. Logic Fix: Identity Fallback
Fixed the status calculation by implementing a fallback to `task.user.login` when the `lastActor` property is missing. Added strict string normalization (lowercase and trimming) to ensure identity matches between the current user, the author, and the last actor are accurate.

### 2. Role-Based Status Branching
Introduced context-aware logic to differentiate between **Reviewer** and **Owner** roles:
- **Reviewer:** The status correctly switches to "Take Action" only when the PR Author moves.
- **Owner/Co-Author:** The status correctly switches to "Take Action" when any external non-bot entity interacts with the PR.

### 3. Engine Parity (HTML & Markdown)
Synchronized the status calculation logic across both the HTML and Markdown generators. This ensures that the Shields.io badges in the GitHub profile README accurately reflect the same status as the web portfolio dashboard.

### 4. Refined Bot Detection
Updated the regex-based bot detection to ensure automated system pushes or bot reviews do not incorrectly trigger "Take Action" alerts, keeping the focus on human interactions.