### PR TITLE
fix: Standardize workbench section IDs and enhance markdown organization linking

### DIFF
--- a/scripts/generators/html/community-html-generator.js
+++ b/scripts/generators/html/community-html-generator.js
@@ -379,7 +379,7 @@ async function createCommunityHtml(
       `;
     }
 
-    const sectionId = label === 'Ongoing PRs' ? 'active-workbench' : `section-${index}`;
+    const sectionId = `section-${index}`;
 
     return dedent`
       <details id="${sectionId}" class="mb-6 group border border-slate-200 rounded-xl overflow-hidden shadow-xs bg-white" ${openAttribute}>
@@ -518,7 +518,7 @@ async function createCommunityHtml(
         function syncSectionState() {
           const hash = window.location.hash;
           const allDetails = document.querySelectorAll('details');
-          
+
           if (hash) {
             const target = document.querySelector(hash);
             if (target && target.tagName === 'DETAILS') {
@@ -530,10 +530,9 @@ async function createCommunityHtml(
             }
           }
 
-          const defaultSection = document.getElementById('active-workbench');
-          if (defaultSection) {
-            defaultSection.open = true;
-          }
+          allDetails.forEach((detail, idx) => {
+            detail.open = (idx === 0);
+          });
         }
 
         document.addEventListener('DOMContentLoaded', () => {
@@ -554,12 +553,12 @@ async function createCommunityHtml(
         });
 
         window.addEventListener('hashchange', syncSectionState);
-        
+
         function sortWorkbenchTable(header, tableIndex, sortType = 'status') {
           if (header.tagName === 'BUTTON') {
             header = header.parentElement;
           }
-            
+
           const table = document.getElementById('workbench-table-' + tableIndex);
           const tbody = table.querySelector('tbody');
           const rows = Array.from(tbody.querySelectorAll('tr'));

--- a/scripts/generators/markdown/community-markdown-generator.js
+++ b/scripts/generators/markdown/community-markdown-generator.js
@@ -130,14 +130,17 @@ async function createCommunityMarkdown(
 
   md += `## 🏆 Major Milestones\n\n`;
   rolesData.achievements.forEach((ach) => {
-    md += `* **${ach.title}** (${ach.year}) — *${ach.org}*\n`;
+    const orgDisplay = ach.orgUrl ? `[${ach.org}](${ach.orgUrl})` : ach.org;
+    md += `* **${ach.title}** (${ach.year}) — *${orgDisplay}*\n`;
   });
   md += `\n`;
 
   md += `## 🏗️ Roles & Impact\n\n`;
   rolesData.roles.forEach((role) => {
     const icon = role.active ? '🟢 **Active**' : '⚪ *Past*';
-    md += `* ${icon} | **${role.title}** at ${role.org} (${role.period})\n`;
+    const orgDisplay = role.orgUrl ? `[${role.org}](${role.orgUrl})` : role.org;
+
+    md += `* ${icon} | **${role.title}** at ${orgDisplay} (${role.period})\n`;
   });
   md += `\n`;
 


### PR DESCRIPTION
## Description

This PR refines the workbench behavior for the HTML dashboard and enhances the data presentation in the markdown generator:

*   **Uniform ID Mapping**: Replaced the conditional ID assignment (`active-workbench`) with a consistent `section-${index}` format in the HTML generator.
*   **Default State Logic**: Updated the frontend initialization to strictly open only the first workbench category (`index === 0`) by default, ensuring a cleaner initial view.
*   **Markdown Organization Linking**: Updated the markdown generator to support hyperlinked organizations. If an `orgUrl` is present in the leadership data, the organization name is now automatically rendered as a link in both the Milestones and Roles sections.

## Changes

- Removed the hardcoded `active-workbench` ID condition in favor of index-based IDs in `createCommunityHtml`.
- Refined the `allDetails` loop in the frontend script to explicitly set the open state based on index parity.
- Modified `createCommunityMarkdown` to conditionally wrap `role.org` and `ach.org` in Markdown link syntax based on the presence of `orgUrl`.