### PR TITLE
fix: Prevent misclassification of collaborations as co-authored PRs and filter historical commits

### DIFF
--- a/scripts/api/fetch-historical-contributions.js
+++ b/scripts/api/fetch-historical-contributions.js
@@ -206,7 +206,8 @@ async function fetchContributions(requestedStartYear, prCache, persistentCommitC
     prUpdatedAt = null,
     logState,
     year,
-    title
+    title,
+    prCreatedAt = null
   ) {
     const prUrlKey = `/repos/${owner}/${repo}/pulls/${prNumber}`;
 
@@ -243,6 +244,11 @@ async function fetchContributions(requestedStartYear, prCache, persistentCommitC
 
       function isCommitByUser(c) {
         try {
+          // --- Ignore stale historical commits from wrong base branches ---
+          if (prCreatedAt && new Date(c.commit?.author?.date) < new Date(prCreatedAt)) {
+            return false;
+          }
+
           const lowerUsername = username.toLowerCase();
           const commitMessage = c.commit?.message || '';
           const isBranchUpdate = /^Merge branch '.+' into .+/i.test(commitMessage);
@@ -456,7 +462,8 @@ async function fetchContributions(requestedStartYear, prCache, persistentCommitC
           pr.updated_at,
           logState,
           year,
-          pr.title
+          pr.title,
+          pr.created_at
         );
 
         if (commitDetails && commitDetails.firstCommitDate) {
@@ -574,7 +581,8 @@ async function fetchContributions(requestedStartYear, prCache, persistentCommitC
           item.updated_at,
           logState,
           year,
-          item.title
+          item.title,
+          item.created_at
         );
 
         if (commitDetails && commitDetails.firstCommitDate) {

--- a/scripts/api/fetch-historical-contributions.js
+++ b/scripts/api/fetch-historical-contributions.js
@@ -562,6 +562,44 @@ async function fetchContributions(requestedStartYear, prCache, persistentCommitC
       let hasReview = false;
       let hasCommits = false;
 
+      // 1. Independent Check: Is it a co-authored PR?
+      if (item.pull_request) {
+        let mergedAt = item.pull_request.merged_at || null;
+        const commitDetails = await getFirstCommitDetails(
+          owner,
+          repoName,
+          item.number,
+          GITHUB_USERNAME,
+          commitCache,
+          item.updated_at,
+          logState,
+          year,
+          item.title
+        );
+
+        if (commitDetails && commitDetails.firstCommitDate) {
+          hasCommits = true;
+          const daysDiff = Math.round(
+            (new Date(commitDetails.firstCommitDate) - new Date(item.created_at)) /
+              (1000 * 60 * 60 * 24)
+          );
+          contributions.coAuthoredPrs.push({
+            title: item.title,
+            url: item.html_url,
+            repo: `${owner}/${repoName}`,
+            date: commitDetails.firstCommitDate,
+            createdAt: item.created_at,
+            firstCommitDate: commitDetails.firstCommitDate,
+            firstCommitPeriod: daysDiff + (daysDiff === 1 ? ' day' : ' days'),
+            commitCount: commitDetails.commitCount,
+            mergedAt,
+            state: item.state,
+          });
+          seenUrls.coAuthoredPrs.add(item.html_url);
+        }
+      }
+
+      // 2. Independent Check: Is it a reviewed PR?
       if (item.pull_request && !uniqueReviewedPrs.has(item.html_url)) {
         const myFirstReviewDate = await getPrMyFirstReviewDate(
           owner,
@@ -601,6 +639,7 @@ async function fetchContributions(requestedStartYear, prCache, persistentCommitC
         }
       }
 
+      // 3. Fallback: Only categorize as a pure collaboration if no commits AND no reviews were found
       if (!hasCommits && !hasReview) {
         const firstCommentDate = await getFirstCommentDate(
           item.comments_url,


### PR DESCRIPTION
## Description

This PR addresses two edge cases where external pull requests are miscategorized inside the data acquisition loop:

1. **Independent Categorization Flow**: Resolves an issue where human-authored pull requests from collaboration query results were inadvertently pushed directly to the `collaborations` array. Implements independent evaluation paths for both co-authored commits and code reviews, ensuring a PR can simultaneously exist in `coAuthoredPrs` and `reviewedPrs` without falling back to `collaborations` by default.

2. **Pre-Creation Commit Filtering**: Fixes a timeline bug where pull requests created with an incorrect base branch pull in historical commits from previous years. Updates `getFirstCommitDetails` to pass down and evaluate `prCreatedAt`, ignoring any commit signatures timestamped prior to the official creation date of the PR. This ensures accurate quarterly placement and prevents anomalous negative period values.