### PR TITLE
feat: add site-wide dark mode with light/dark/system toggle

### DIFF
--- a/scripts/components/footer.js
+++ b/scripts/components/footer.js
@@ -23,7 +23,7 @@ function createFooterHtml() {
         &copy; ${currentYear} 
         <a href="https://github.com/${GITHUB_USERNAME}" 
            target="_blank" 
-           style="color: ${COLORS.primary.rgb};"
+           style="color: ${COLORS.primaryText};"
            class="hover:opacity-80 font-semibold transition duration-150">
             ${GITHUB_USERNAME}
         </a>'s open source contributions, 
@@ -32,7 +32,7 @@ function createFooterHtml() {
 
       <div class="text-xs mt-1">
           Made with 💙 by 
-          <a href="https://github.com/adiati98" target="_blank" style="color: ${COLORS.primary.rgb};" class="hover:opacity-80 font-semibold transition duration-150">
+          <a href="https://github.com/adiati98" target="_blank" style="color: ${COLORS.primaryText};" class="hover:opacity-80 font-semibold transition duration-150">
               Ayu Adiati
           </a>
       </div>

--- a/scripts/components/navbar.js
+++ b/scripts/components/navbar.js
@@ -1,7 +1,41 @@
 const { dedent } = require('../utils/dedent');
 const { GITHUB_USERNAME } = require('../config/config');
 const { COLORS } = require('../config/constants');
-const { GITHUB_ICON, NAV_ICONS } = require('../config/icons');
+const { GITHUB_ICON, NAV_ICONS, THEME_ICONS } = require('../config/icons');
+
+const THEME_OPTIONS = [
+  { choice: 'light', label: 'Light', icon: THEME_ICONS.sun },
+  { choice: 'dark', label: 'Dark', icon: THEME_ICONS.moon },
+  { choice: 'system', label: 'System', icon: THEME_ICONS.system },
+];
+
+function createThemeDropdownHtml(extraClass = '') {
+  const triggerIcons = THEME_OPTIONS.map(
+    ({ choice, icon }) =>
+      `<span data-theme-icon-for="${choice}" class="theme-dropdown-trigger-icon hidden">${icon}</span>`
+  ).join('');
+
+  const menuItems = THEME_OPTIONS.map(
+    ({ choice, label, icon }) => dedent`
+      <button type="button" role="menuitemradio" data-theme-choice="${choice}" class="theme-dropdown-item" aria-checked="false">
+        <span class="theme-dropdown-item-icon">${icon}</span>
+        <span>${label}</span>
+        <span class="theme-dropdown-check" aria-hidden="true">✓</span>
+      </button>
+    `
+  ).join('');
+
+  return dedent`
+    <div class="theme-dropdown relative ${extraClass}" data-theme-dropdown>
+      <button type="button" class="theme-dropdown-trigger" aria-haspopup="true" aria-expanded="false" aria-label="Change theme">
+        ${triggerIcons}
+      </button>
+      <div class="theme-dropdown-menu hidden" role="menu">
+        ${menuItems}
+      </div>
+    </div>
+  `;
+}
 
 const GITHUB_REPO_URL = `https://github.com/${GITHUB_USERNAME}/oss-portfolio`;
 
@@ -30,11 +64,13 @@ function createNavHtml(relativePath = './') {
             <a href="${base}glossary.html" style="background-color: ${COLORS.primary[10]};" 
               class="nav-link nav-desktop-link text-sm font-semibold p-2 rounded-md">Glossary</a>
 
-            <a href="${GITHUB_REPO_URL}" target="_blank" rel="noopener noreferrer" 
+            <a href="${GITHUB_REPO_URL}" target="_blank" rel="noopener noreferrer"
               class="nav-link nav-desktop-link nav-github-link flex items-center"
               title="View Repository">
               <span class="w-7 h-7 inline-block">${GITHUB_ICON}</span>
             </a>
+
+            ${createThemeDropdownHtml()}
           </div>
 
           <button id="menu-button" style="background-color: ${COLORS.nav.bgHover}; cursor: pointer;" 
@@ -54,12 +90,14 @@ function createNavHtml(relativePath = './') {
           <a href="${base}glossary.html" class="nav-link nav-mobile-link block px-3 py-2 text-base font-medium rounded-md">Glossary</a>
         </div>
         
-        <div class="mt-3 pt-3" style="border-top-color: ${COLORS.nav.bg}; border-top-width: 1px;">
-          <a href="${GITHUB_REPO_URL}" target="_blank" rel="noopener noreferrer" 
-            class="nav-link nav-mobile-github-link block w-fit hover:text-gray-200 transition duration-150 ml-3" 
+        <div class="mt-3 pt-3 flex items-center justify-between" style="border-top-color: ${COLORS.nav.bg}; border-top-width: 1px;">
+          <a href="${GITHUB_REPO_URL}" target="_blank" rel="noopener noreferrer"
+            class="nav-link nav-mobile-github-link block w-fit hover:text-gray-200 transition duration-150 ml-3"
             title="View Repository">
             <span class="w-6 h-6 inline-block">${GITHUB_ICON}</span>
           </a>
+
+          ${createThemeDropdownHtml('mr-3')}
         </div>
       </div>
 
@@ -79,6 +117,69 @@ function createNavHtml(relativePath = './') {
               closeIcon.classList.toggle('hidden', isExpanded);
             });
           }
+
+          const dropdowns = document.querySelectorAll('[data-theme-dropdown]');
+
+          function closeAllDropdowns() {
+            dropdowns.forEach((dropdown) => {
+              dropdown.querySelector('.theme-dropdown-menu').classList.add('hidden');
+              dropdown.querySelector('.theme-dropdown-trigger').setAttribute('aria-expanded', 'false');
+            });
+          }
+
+          function setTheme(choice) {
+            if (choice === 'system') {
+              localStorage.removeItem('theme');
+            } else {
+              localStorage.setItem('theme', choice);
+            }
+            const isDark =
+              choice === 'dark' ||
+              (choice === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+            document.documentElement.classList.toggle('dark', isDark);
+            reflectActiveChoice();
+          }
+
+          function reflectActiveChoice() {
+            const current = localStorage.getItem('theme') || 'system';
+            dropdowns.forEach((dropdown) => {
+              dropdown.querySelectorAll('[data-theme-icon-for]').forEach((icon) => {
+                icon.classList.toggle('hidden', icon.dataset.themeIconFor !== current);
+              });
+              dropdown.querySelectorAll('[data-theme-choice]').forEach((item) => {
+                item.setAttribute('aria-checked', String(item.dataset.themeChoice === current));
+              });
+            });
+          }
+
+          dropdowns.forEach((dropdown) => {
+            const trigger = dropdown.querySelector('.theme-dropdown-trigger');
+            const menu = dropdown.querySelector('.theme-dropdown-menu');
+
+            trigger.addEventListener('click', (e) => {
+              e.stopPropagation();
+              const isOpen = !menu.classList.contains('hidden');
+              closeAllDropdowns();
+              if (!isOpen) {
+                menu.classList.remove('hidden');
+                trigger.setAttribute('aria-expanded', 'true');
+              }
+            });
+
+            dropdown.querySelectorAll('[data-theme-choice]').forEach((item) => {
+              item.addEventListener('click', () => {
+                setTheme(item.dataset.themeChoice);
+                closeAllDropdowns();
+              });
+            });
+          });
+
+          document.addEventListener('click', closeAllDropdowns);
+          document.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape') closeAllDropdowns();
+          });
+
+          reflectActiveChoice();
         });
       </script>
     </nav>
@@ -92,6 +193,58 @@ function createNavHtml(relativePath = './') {
       
       #menu-button span svg { width: 1.5rem; height: 1.5rem; display: block; }
       .nav-github-link svg, .nav-mobile-github-link svg { width: 100%; height: 100%; }
+
+      .theme-dropdown-trigger {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 2.25rem;
+        height: 2.25rem;
+        border-radius: 0.375rem;
+        color: rgba(255, 255, 255, 0.85);
+        cursor: pointer;
+        border: none;
+        background-color: ${COLORS.nav.bgHover};
+        transition: background-color 0.15s ease-in-out, color 0.15s ease-in-out;
+      }
+      .theme-dropdown-trigger:hover,
+      .theme-dropdown-trigger[aria-expanded='true'] { color: white; }
+      .theme-dropdown-trigger-icon svg { width: 1.15rem; height: 1.15rem; display: block; }
+
+      .theme-dropdown-menu {
+        position: absolute;
+        right: 0;
+        top: calc(100% + 0.5rem);
+        min-width: 9.5rem;
+        background-color: var(--c-bg-surface);
+        border: 1px solid ${COLORS.border.light};
+        border-radius: 0.5rem;
+        box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.25);
+        padding: 0.25rem;
+        z-index: 60;
+      }
+      .theme-dropdown-item {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        width: 100%;
+        padding: 0.5rem 0.625rem;
+        border-radius: 0.375rem;
+        border: none;
+        background: transparent;
+        color: ${COLORS.text.secondary};
+        font-size: 0.875rem;
+        font-weight: 500;
+        cursor: pointer;
+        text-align: left;
+        transition: background-color 0.15s ease-in-out;
+      }
+      .theme-dropdown-item:hover,
+      .theme-dropdown-item:focus-visible { background-color: ${COLORS.primary[10]}; outline: none; }
+      .theme-dropdown-item-icon { display: inline-flex; }
+      .theme-dropdown-item-icon svg { width: 1rem; height: 1rem; display: block; }
+      .theme-dropdown-check { margin-left: auto; opacity: 0; color: ${COLORS.primaryText}; font-weight: 700; }
+      .theme-dropdown-item[aria-checked='true'] .theme-dropdown-check { opacity: 1; }
     </style>
   `;
 }

--- a/scripts/components/theme-init.js
+++ b/scripts/components/theme-init.js
@@ -1,0 +1,46 @@
+const { dedent } = require('../utils/dedent');
+
+/**
+ * Inline, synchronous script that applies the saved theme (or the OS
+ * preference, when no explicit choice was made) before the page paints, to
+ * avoid a flash of the wrong theme. Must be placed in <head> ahead of the
+ * Tailwind CDN <script> tag.
+ */
+function getThemeInitScript() {
+  return dedent`
+    <script>
+      (function () {
+        try {
+          var mq = window.matchMedia('(prefers-color-scheme: dark)');
+
+          function isDark() {
+            var stored = localStorage.getItem('theme'); // 'light' | 'dark' | null ('system')
+            if (stored === 'dark') return true;
+            if (stored === 'light') return false;
+            return mq.matches;
+          }
+
+          document.documentElement.classList.toggle('dark', isDark());
+
+          // Re-reads localStorage on every change instead of caching it, so a
+          // theme choice made via the navbar toggle (after this script ran)
+          // is respected rather than overridden by a stale snapshot.
+          mq.addEventListener('change', function () {
+            document.documentElement.classList.toggle('dark', isDark());
+          });
+        } catch (e) {}
+      })();
+    </script>
+  `;
+}
+
+/**
+ * Registers Tailwind v4's class-based dark variant so `.dark` on <html>
+ * drives `dark:` utilities instead of the OS `prefers-color-scheme` media
+ * query. Must come after the Tailwind CDN <script> tag.
+ */
+function getThemeStyleVariant() {
+  return `<style type="text/tailwindcss">@custom-variant dark (&:where(.dark, .dark *));</style>`;
+}
+
+module.exports = { getThemeInitScript, getThemeStyleVariant };

--- a/scripts/config/constants.js
+++ b/scripts/config/constants.js
@@ -1,4 +1,8 @@
-const { generateColorsObject } = require('../utils/color-helpers');
+const {
+  generateColorsObject,
+  buildFlatVarsBlock,
+  ensureReadableOn,
+} = require('../utils/color-helpers');
 const { generateFaviconSvg, encodeSvg } = require('../utils/icon-processor');
 const {
   LANDING_PAGE_ICONS,
@@ -27,8 +31,65 @@ const COLOR_PALETTE = {
   highlightBg: '#eef2ff',
 };
 
-// Generate theme-ready colors
-const COLORS = generateColorsObject(COLOR_PALETTE);
+/**
+ * DARK-MODE COUNTERPART PALETTE
+ * `primary` and `primary900` are intentionally left unchanged: both are used
+ * throughout the site as solid backgrounds paired with white text (nav bar,
+ * hero stat cards, progress bars) and brightening them would break that
+ * contrast. Every other token is brightened for legibility on dark surfaces.
+ */
+const COLOR_PALETTE_DARK = {
+  primary: '#4338CA',
+  primary900: '#312E81',
+  neutral: '#94a3b8',
+  success: '#34d399',
+  merged: '#a78bfa',
+  error: '#f87171',
+  textPrimary: '#f1f5f9',
+  textSecondary: '#cbd5e1',
+  textMuted: '#94a3b8',
+  highlightBg: '#1e1b4b',
+};
+
+/**
+ * The dark-mode surface that primary-colored text/icon colors get checked
+ * against. Most of that text sits on `dark:bg-slate-800` cards rather than
+ * directly on the `dark:bg-slate-900` page background — cards are the
+ * lighter (harder-to-contrast-against) of the two surfaces, so deriving
+ * against this one also guarantees AA against the darker page background.
+ */
+const DARK_CARD_BG = '#1e293b';
+
+/**
+ * Lightened, dark-mode-readable variants of brand colors, derived
+ * programmatically (not hardcoded) so this stays correct for forks that
+ * configure a different `COLOR_PALETTE.primary`. `ensureReadableOn` keeps
+ * the same hue/saturation and only raises lightness until it clears WCAG AA
+ * (4.5:1) against the dark page background.
+ */
+const PRIMARY_TEXT_DARK = ensureReadableOn(COLOR_PALETTE.primary, DARK_CARD_BG, 4.5);
+const ACCENT_STRONG_DARK = ensureReadableOn(COLOR_PALETTE.primary900, DARK_CARD_BG, 4.5);
+
+/**
+ * Single-value (non-laddered) color tokens that aren't part of the main
+ * opacity-variant system above.
+ */
+const FLAT_COLOR_TOKENS = {
+  'c-bg-surface': { light: '#ffffff', dark: '#1e293b' }, // card/table surfaces
+  'c-accent-yellow': { light: '#eab308', dark: '#facc15' },
+  'c-accent-strong': { light: '#3730a3', dark: ACCENT_STRONG_DARK }, // glossary bold text
+  'c-primary-text': { light: COLOR_PALETTE.primary, dark: PRIMARY_TEXT_DARK }, // primary-colored TEXT (not fills)
+  'c-draft-bg': { light: '#f1f5f9', dark: '#334155' }, // lighter than the slate-800 card behind it
+  'c-draft-text': { light: '#475569', dark: '#e2e8f0' },
+  'c-draft-border': { light: '#cbd5e1', dark: '#64748b' },
+};
+
+// Generate theme-ready colors (every leaf is a CSS var() reference)
+const { colors: COLORS, cssVarsBlock: PALETTE_CSS_VARS } = generateColorsObject(
+  COLOR_PALETTE,
+  COLOR_PALETTE_DARK,
+  FLAT_COLOR_TOKENS
+);
 
 // Generate browser-ready favicon
 const FAVICON_SVG_ENCODED = encodeSvg(
@@ -63,22 +124,27 @@ function getHoverStyles() {
  */
 const WORKBENCH_STATUS_COLORS = {
   ongoing: {
-    bg: '#ecfeff',
-    text: '#086788',
-    border: '#a5f3fc',
+    bg: 'var(--wb-ongoing-bg)',
+    text: 'var(--wb-ongoing-text)',
+    border: 'var(--wb-ongoing-border)',
   },
   todo: {
-    bg: '#fff7ed',
-    text: '#c2410c',
-    border: '#fdba74',
+    bg: 'var(--wb-todo-bg)',
+    text: 'var(--wb-todo-text)',
+    border: 'var(--wb-todo-border)',
   },
   bot: {
-    bg: '#f8fafc',
-    text: '#475569',
-    border: '#e2e8f0',
+    bg: 'var(--wb-bot-bg)',
+    text: 'var(--wb-bot-text)',
+    border: 'var(--wb-bot-border)',
   },
   emptyMessage: {
-    text: '#991b1b',
+    text: 'var(--wb-empty-text)',
+  },
+  draft: {
+    bg: 'var(--c-draft-bg)',
+    text: 'var(--c-draft-text)',
+    border: 'var(--c-draft-border)',
   },
 };
 
@@ -87,18 +153,18 @@ const WORKBENCH_STATUS_COLORS = {
  */
 const WORKBENCH_BALL_STATUS = {
   waiting: {
-    dot: '#84cc16',
-    text: '#4d7c0f',
+    dot: 'var(--wb-waiting-dot)',
+    text: 'var(--wb-waiting-text)',
     label: 'Waiting',
   },
   takeAction: {
-    dot: '#d946ef',
-    text: '#a21caf',
+    dot: 'var(--wb-takeaction-dot)',
+    text: 'var(--wb-takeaction-text)',
     label: 'Take Action',
   },
   watching: {
-    dot: '#0ea5e9',
-    text: '#0369a1',
+    dot: 'var(--wb-watching-dot)',
+    text: 'var(--wb-watching-text)',
     label: 'Watching',
   },
   approved: {
@@ -107,11 +173,40 @@ const WORKBENCH_BALL_STATUS = {
     label: 'Approved',
   },
   stale: {
-    dot: '#94a3b8',
-    text: '#64748b',
+    dot: 'var(--wb-stale-dot)',
+    text: 'var(--wb-stale-text)',
     label: 'Stale',
   },
 };
+
+const WORKBENCH_CSS_VARS = buildFlatVarsBlock({
+  'wb-ongoing-bg': { light: '#ecfeff', dark: '#083344' },
+  'wb-ongoing-text': { light: '#086788', dark: '#67e8f9' },
+  'wb-ongoing-border': { light: '#a5f3fc', dark: '#0e7490' },
+  'wb-todo-bg': { light: '#fff7ed', dark: '#431407' },
+  'wb-todo-text': { light: '#c2410c', dark: '#fdba74' },
+  'wb-todo-border': { light: '#fdba74', dark: '#c2410c' },
+  'wb-bot-bg': { light: '#f8fafc', dark: '#1e293b' },
+  'wb-bot-text': { light: '#475569', dark: '#cbd5e1' },
+  'wb-bot-border': { light: '#e2e8f0', dark: '#475569' },
+  'wb-empty-text': { light: '#991b1b', dark: '#fca5a5' },
+  'wb-waiting-dot': { light: '#84cc16', dark: '#a3e635' },
+  'wb-waiting-text': { light: '#4d7c0f', dark: '#bef264' },
+  'wb-takeaction-dot': { light: '#d946ef', dark: '#e879f9' },
+  'wb-takeaction-text': { light: '#a21caf', dark: '#f0abfc' },
+  'wb-watching-dot': { light: '#0ea5e9', dark: '#38bdf8' },
+  'wb-watching-text': { light: '#0369a1', dark: '#7dd3fc' },
+  'wb-stale-dot': { light: '#94a3b8', dark: '#cbd5e1' },
+  'wb-stale-text': { light: '#64748b', dark: '#94a3b8' },
+});
+
+/**
+ * Combined `:root{...} html.dark{...}` CSS variable declarations for every
+ * color token used across the site. Interpolated once into the shared base
+ * CSS (see getCommonBaseCss in style-generator.js) so every generated page
+ * picks it up.
+ */
+const THEME_CSS_VARS = `${PALETTE_CSS_VARS}\n${WORKBENCH_CSS_VARS}`;
 
 module.exports = {
   LANDING_PAGE_ICONS,
@@ -127,4 +222,5 @@ module.exports = {
   COLOR_PALETTE,
   WORKBENCH_STATUS_COLORS,
   WORKBENCH_BALL_STATUS,
+  THEME_CSS_VARS,
 };

--- a/scripts/config/icons.js
+++ b/scripts/config/icons.js
@@ -135,6 +135,29 @@ const NAV_ICONS = {
   `
 };
 
+/**
+ * Theme Toggle Icons (light / dark / system)
+ */
+const THEME_ICONS = {
+  sun: `
+    <svg fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+      <circle cx="12" cy="12" r="4"/>
+      <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/>
+    </svg>
+  `,
+  moon: `
+    <svg fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+    </svg>
+  `,
+  system: `
+    <svg fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+      <rect x="3" y="4" width="18" height="12" rx="1.5"/>
+      <path d="M8 20h8M12 16v4"/>
+    </svg>
+  `,
+};
+
 module.exports = {
   LANDING_PAGE_ICONS,
   SPARKLES_SVG,
@@ -146,4 +169,5 @@ module.exports = {
   FAVICON_SVG_RAW_TEMPLATE,
   GITHUB_ICON,
   NAV_ICONS,
+  THEME_ICONS,
 };

--- a/scripts/generators/css/style-generator.js
+++ b/scripts/generators/css/style-generator.js
@@ -3,7 +3,7 @@
  */
 
 const { dedent } = require('../../utils/dedent');
-const { COLORS } = require('../../config/constants');
+const { COLORS, THEME_CSS_VARS } = require('../../config/constants');
 
 // --- 1. BASE STYLES (Shared by all pages) ---
 
@@ -14,6 +14,7 @@ const { COLORS } = require('../../config/constants');
 function getCommonBaseCss() {
   return dedent`
     @import url('https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap');
+    ${THEME_CSS_VARS}
     html, body {
       margin: 0;
       padding: 0;
@@ -35,11 +36,11 @@ function getCommonBaseCss() {
       transition: border-color 0.15s ease-in-out !important;
     }
     .nav-report-button:hover {
-      border-color: ${COLORS.primary.rgb} !important;
+      border-color: ${COLORS.primaryText} !important;
     }
     .nav-report-button:focus-visible {
-      border-color: ${COLORS.primary.rgb};
-      outline: 2px solid ${COLORS.primary.rgb};
+      border-color: ${COLORS.primaryText};
+      outline: 2px solid ${COLORS.primaryText};
       outline-offset: 2px;
     }
         
@@ -48,11 +49,11 @@ function getCommonBaseCss() {
       transition: border-color 0.15s ease-in-out !important;
     }
     .nav-contribution-button:hover {
-      border-color: ${COLORS.primary.rgb} !important;
+      border-color: ${COLORS.primaryText} !important;
     }
     .nav-contribution-button:focus-visible { 
-      border-color: ${COLORS.primary.rgb};
-      outline: 2px solid ${COLORS.primary.rgb};
+      border-color: ${COLORS.primaryText};
+      outline: 2px solid ${COLORS.primaryText};
       outline-offset: 2px;
     }
 
@@ -108,7 +109,7 @@ function getCommunityStyleCss() {
 
     /* The 'Tab' focus state */
     summary:focus-visible {
-      outline: 2px solid ${COLORS.primary.rgb};
+      outline: 2px solid ${COLORS.primaryText};
       outline-offset: -2px;
       background-color: ${COLORS.primary[5]};
       border-radius: 0.75rem;
@@ -120,7 +121,7 @@ function getCommunityStyleCss() {
     }
     .metric-card-hover:hover {
       transform: translateY(-4px);
-      border-color: ${COLORS.primary.rgb} !important;
+      border-color: ${COLORS.primaryText} !important;
       box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.05);
     }
 
@@ -155,7 +156,7 @@ function getBlogStyleCss() {
       border-bottom: none;
     }
     .article-card h3 a {
-      color: ${COLORS.primary.rgb};
+      color: ${COLORS.primaryText};
       text-decoration: none;
       font-weight: 700;
     }
@@ -192,7 +193,7 @@ function getIndexStyleCss() {
     .hover-underline-primary:hover {
       text-decoration: underline;
       text-underline-offset: 4px;
-      text-decoration-color: ${COLORS.primary.rgb};
+      text-decoration-color: ${COLORS.primaryText};
     }
 
     /* Animation for the Contribution Bars */
@@ -225,7 +226,7 @@ function getReportsListStyleCss() {
       transition: background-color 0.15s ease-in-out;
     }
     summary:focus-visible {
-      outline: 2px solid ${COLORS.primary.rgb};
+      outline: 2px solid ${COLORS.primaryText};
       outline-offset: 2px;
     }
 
@@ -235,7 +236,7 @@ function getReportsListStyleCss() {
     details[open] summary {
       background-color: ${COLORS.primary[5]};
       border-radius: 0.5rem 0.5rem 0 0;
-      color: ${COLORS.primary.rgb};
+      color: ${COLORS.primaryText};
     }
     details[open] summary:hover,
     details[open] summary:focus-visible {
@@ -258,11 +259,11 @@ function getReportsListStyleCss() {
       transition: border-color 0.15s ease-in-out !important;
     }
     .report-card-link:hover {
-      border-color: ${COLORS.primary.rgb} !important;
+      border-color: ${COLORS.primaryText} !important;
     }
     .report-card-link:focus-visible {
-      border-color: ${COLORS.primary.rgb};
-      outline: 2px solid ${COLORS.primary.rgb};
+      border-color: ${COLORS.primaryText};
+      outline: 2px solid ${COLORS.primaryText};
       outline-offset: 2px;
     }
   `;
@@ -280,12 +281,12 @@ function getReportStyleCss() {
       outline: none;
       margin: 0.5em 0;
       padding: 0.5em 0;
-      color: #1f2937;
+      color: ${COLORS.text.primary};
       display: list-item;
       white-space: nowrap;
     }
     summary:focus-visible {
-      outline: 2px solid ${COLORS.primary.rgb};
+      outline: 2px solid ${COLORS.primaryText};
       outline-offset: 2px;
     }
 
@@ -300,7 +301,7 @@ function getReportStyleCss() {
       background-color: ${COLORS.primary[5]};
     }
     .details-section details:open summary {
-      color: ${COLORS.primary.rgb};
+      color: ${COLORS.primaryText};
     }
 
     .report-table {
@@ -313,24 +314,24 @@ function getReportStyleCss() {
       position: sticky;
       top: 0;
       z-index: 10;
-      background-color: #ffffff;
+      background-color: var(--c-bg-surface);
       background-image: linear-gradient(${COLORS.primary[5]}, ${COLORS.primary[5]});
       font-weight: 700;
       padding: 12px;
       text-align: left;
       border-bottom: none;
-      box-shadow: inset 0 -1px 0 0 ${COLORS.primary.rgb};
+      box-shadow: inset 0 -1px 0 0 ${COLORS.primaryText};
     }
 
     .report-table td {
-      background-color: #ffffff;
+      background-color: var(--c-bg-surface);
     }
 
     .report-table th,
     .report-table td {
       padding: 12px;
       text-align: left;
-      border-bottom: 1px solid #e5e7eb;
+      border-bottom: 1px solid ${COLORS.border.default};
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
@@ -350,12 +351,12 @@ function getReportStyleCss() {
     }
 
     .table-row-hover:focus-visible {
-      outline: 2px solid ${COLORS.primary.rgb};
+      outline: 2px solid ${COLORS.primaryText};
       outline-offset: -2px;
     }
 
-    .report-table tbody tr.bg-white { background-color: #ffffff; }
-    .report-table tbody tr.bg-gray-50 { background-color: #f9fafb; }
+    .report-table tbody tr.bg-white { background-color: var(--c-bg-surface); }
+    .report-table tbody tr.bg-gray-50 { background-color: ${COLORS.background.altRows}; }
 
     .th-content {
       display: inline-flex;
@@ -377,7 +378,7 @@ function getReportStyleCss() {
     th.sort-custom1 .sort-icon,
     th.sort-custom2 .sort-icon {
       opacity: 1 !important;
-      color: ${COLORS.primary.rgb} !important;
+      color: ${COLORS.primaryText} !important;
       font-weight: bold;
     }
 
@@ -396,7 +397,7 @@ function getReportStyleCss() {
     }
 
     .search-input {
-      border-color: ${COLORS.primary.rgb};
+      border-color: ${COLORS.primaryText};
       transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
     }
     .search-input:focus,
@@ -437,8 +438,8 @@ function getGlossaryStyleCss() {
     .glossary-code-block {
       display: block;
       font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-      background-color: #f8fafc;
-      border: 1px solid #e2e8f0;
+      background-color: ${COLORS.background.altRows};
+      border: 1px solid ${COLORS.border.default};
     }
 
     /* Target the text inside to ensure monospace inheritance */
@@ -448,7 +449,7 @@ function getGlossaryStyleCss() {
 
     /* Bold text: Clean, high-contrast, no background color */
     .glossary-content strong {
-      color: #3730a3; /* text-indigo-800 */
+      color: var(--c-accent-strong);
       font-weight: 900;
       background-color: transparent !important;
       padding: 0;
@@ -465,7 +466,7 @@ function getGlossaryStyleCss() {
     }
 
     :target h3 {
-      color: ${COLORS.primary.rgb} !important;
+      color: ${COLORS.primaryText} !important;
     }
   `;
 }

--- a/scripts/generators/html/blog-html-generator.js
+++ b/scripts/generators/html/blog-html-generator.js
@@ -9,6 +9,7 @@ const { createNavHtml } = require('../../components/navbar');
 const { createFooterHtml } = require('../../components/footer');
 const { getBlogStyleCss } = require('../css/style-generator');
 const { getColorValue } = require('../../utils/color-helpers');
+const { getThemeInitScript, getThemeStyleVariant } = require('../../components/theme-init');
 
 async function createBlogHtml(articles) {
   const htmlBaseDir = path.join(BASE_DIR, 'html-generated');
@@ -29,16 +30,16 @@ async function createBlogHtml(articles) {
       });
 
       return dedent`
-      <div class="article-card group py-10 border-b border-slate-100 last:border-0 transition-colors hover:bg-indigo-50/50">
+      <div class="article-card group py-10 border-b border-slate-100 dark:border-slate-800 last:border-0 transition-colors hover:bg-indigo-50/50 dark:hover:bg-indigo-500/10">
         <h2 class="text-xl sm:text-2xl font-bold mb-3 pl-4">
-          <a href="${article.link}" target="_blank" rel="noopener noreferrer" 
-             style="color: ${getColorValue(COLORS.primary)};" 
-             class="group-hover:text-indigo-800 transition-colors block">
+          <a href="${article.link}" target="_blank" rel="noopener noreferrer"
+             style="color: ${getColorValue(COLORS.primaryText)};"
+             class="group-hover:text-indigo-800 dark:group-hover:text-indigo-300 transition-colors block">
             ${article.title}
           </a>
         </h2>
-        <p class="article-meta text-slate-500 text-sm font-medium pl-4">
-          Published on <span class="platform-tag font-bold text-slate-700">${article.platform}</span> — ${date}
+        <p class="article-meta text-slate-500 dark:text-slate-400 text-sm font-medium pl-4">
+          Published on <span class="platform-tag font-bold text-slate-700 dark:text-slate-200">${article.platform}</span> — ${date}
         </p>
       </div>`;
     })
@@ -52,16 +53,18 @@ async function createBlogHtml(articles) {
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
       <title>Articles | ${GITHUB_USERNAME} Portfolio</title>
       <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,${FAVICON_SVG_ENCODED}">
+      ${getThemeInitScript()}
       <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+      ${getThemeStyleVariant()}
       <style>${blogCss}</style>
     </head>
-    <body class="bg-white antialiased flex flex-col h-full min-h-full">
+    <body class="bg-white dark:bg-slate-900 antialiased flex flex-col h-full min-h-full">
       ${navHtml}
       <main class="grow w-full">
         <div class="px-6 sm:px-12 lg:px-16 xl:px-32 py-10">
           <div class="max-w-7xl mx-auto">
             <header style="border-bottom-color: ${getColorValue(COLORS.primary[15]) || '#e2e8f0'};" class="text-center mt-16 mb-16 pb-12 border-b-2">
-              <h1 style="color: ${getColorValue(COLORS.primary)};" class="text-4xl sm:text-6xl font-black mb-6 pt-8">
+              <h1 style="color: ${getColorValue(COLORS.primaryText)};" class="text-4xl sm:text-6xl font-black mb-6 pt-8">
                 Open Source and GitHub Articles
               </h1>
               <p style="color: ${getColorValue(COLORS.text.secondary)};" class="text-xl max-w-3xl mx-auto leading-relaxed">
@@ -71,7 +74,7 @@ async function createBlogHtml(articles) {
 
             <div class="max-w-[90ch] mx-auto">
               <div class="articles-list">
-                ${listItems || '<p class="text-slate-400 italic text-center py-12">No articles found with Open Source or GitHub tags.</p>'}
+                ${listItems || '<p class="text-slate-400 dark:text-slate-500 italic text-center py-12">No articles found with Open Source or GitHub tags.</p>'}
               </div>
             </div>
           </div>

--- a/scripts/generators/html/community-html-generator.js
+++ b/scripts/generators/html/community-html-generator.js
@@ -16,6 +16,7 @@ const { WORKBENCH_SUCCESS_MESSAGES } = require('../../metadata/workbench-message
 const { getCommunityStyleCss } = require('../css/style-generator');
 const { getColorValue } = require('../../utils/color-helpers');
 const { sanitizeAttribute } = require('../../utils/html-helpers');
+const { getThemeInitScript, getThemeStyleVariant } = require('../../components/theme-init');
 
 /**
  * Generates the Community & Activity HTML page.
@@ -41,15 +42,15 @@ async function createCommunityHtml(
   const achievementCards = rolesData.achievements
     .map(
       (ach) => dedent`
-        <div class="bg-white p-6 rounded-xl border border-slate-200 shadow-sm hover:border-indigo-400 transition-colors duration-200 flex flex-col items-center text-center">
-          <div class="p-3 rounded-full mb-4 shrink-0" style="background-color: ${getColorValue(COLORS.primary[10]) || '#f0f7ff'}; color: ${getColorValue(COLORS.primary)};">
+        <div class="bg-white dark:bg-slate-800 p-6 rounded-xl border border-slate-200 dark:border-slate-700 shadow-sm hover:border-indigo-400 transition-colors duration-200 flex flex-col items-center text-center">
+          <div class="p-3 rounded-full mb-4 shrink-0" style="background-color: ${getColorValue(COLORS.primary[10]) || '#f0f7ff'}; color: ${getColorValue(COLORS.primaryText)};">
             ${SPARKLES_SVG}
           </div>
           <div class="flex flex-col items-center gap-3">
-            <h3 class="text-lg font-black leading-tight text-center" style="color: ${getColorValue(COLORS.primary)};">
+            <h3 class="text-lg font-black leading-tight text-center" style="color: ${getColorValue(COLORS.primaryText)};">
               ${ach.title}
             </h3>
-            <div class="inline-flex items-center justify-center h-auto min-h-7 px-3 py-1 rounded-full text-xs font-bold uppercase tracking-widest bg-slate-100 text-slate-600 border border-slate-200 text-center">
+            <div class="inline-flex items-center justify-center h-auto min-h-7 px-3 py-1 rounded-full text-xs font-bold uppercase tracking-widest bg-slate-100 dark:bg-slate-700 text-slate-600 dark:text-slate-300 border border-slate-200 dark:border-slate-600 text-center">
               ${sanitizeAttribute(ach.org)} <span class="mx-2 opacity-40" aria-hidden="true">|</span> ${ach.year}
             </div>
           </div>
@@ -72,7 +73,7 @@ async function createCommunityHtml(
         ? getColorValue(COLORS.status.green.text)
         : getColorValue(COLORS.text.muted);
 
-      const brandColor = getColorValue(COLORS.primary);
+      const brandColor = getColorValue(COLORS.primaryText);
 
       const orgDisplay = role.orgUrl
         ? dedent`
@@ -81,14 +82,14 @@ async function createCommunityHtml(
              style="color: ${brandColor}; text-decoration-color: ${brandColor};">
             ${sanitizeAttribute(role.org)}
           </a>`
-        : `<span class="text-slate-700">${sanitizeAttribute(role.org)}</span>`;
+        : `<span class="text-slate-700 dark:text-slate-200">${sanitizeAttribute(role.org)}</span>`;
 
       return dedent`
-        <div class="table-row-hover flex flex-col xl:flex-row xl:items-center justify-between p-4 border-b border-slate-100 last:border-0 transition-colors gap-3">
+        <div class="table-row-hover flex flex-col xl:flex-row xl:items-center justify-between p-4 border-b border-slate-100 dark:border-slate-700 last:border-0 transition-colors gap-3">
           <div class="flex items-start xl:items-center space-x-3 pr-2">
             <div class="w-2.5 h-2.5 rounded-full shrink-0 mt-1.5 xl:mt-0" style="background-color: ${bulletColor};" aria-hidden="true"></div>
             <div>
-              <h3 class="font-bold text-slate-900 leading-tight text-base sm:text-lg">${role.title}</h3>
+              <h3 class="font-bold text-slate-900 dark:text-slate-100 leading-tight text-base sm:text-lg">${role.title}</h3>
               <p class="text-sm sm:text-base font-medium">${orgDisplay}</p>
             </div>
           </div>
@@ -97,7 +98,7 @@ async function createCommunityHtml(
                   style="background-color: ${statusBg}; color: ${statusColor};">
               ${isActive ? 'Active' : 'Past'}
             </span>
-            <span class="text-sm font-mono text-slate-500 leading-tight">${role.period}</span>
+            <span class="text-sm font-mono text-slate-500 dark:text-slate-400 leading-tight">${role.period}</span>
           </div>
         </div>
       `;
@@ -184,9 +185,9 @@ async function createCommunityHtml(
   function renderStatusIndicator(type) {
     const configs = {
       draft: {
-        bg: getColorValue(COLORS.gray[10]),
-        text: getColorValue(COLORS.gray[600]),
-        border: getColorValue(COLORS.gray[200]),
+        bg: getColorValue(WORKBENCH_STATUS_COLORS.draft.bg),
+        text: getColorValue(WORKBENCH_STATUS_COLORS.draft.text),
+        border: getColorValue(WORKBENCH_STATUS_COLORS.draft.border),
         label: 'Draft',
       },
       pending: {
@@ -207,8 +208,8 @@ async function createCommunityHtml(
     if (!config) return '';
 
     return dedent`
-      <div class="inline-flex items-center px-2 py-0.5 mt-1.5 rounded-full text-[11px] font-bold uppercase tracking-wider border" 
-           style="background-color: ${config.bg}; color: ${config.text}; border-color: ${config.border}33;">
+      <div class="inline-flex items-center px-2 py-0.5 mt-1.5 rounded-full text-[11px] font-bold uppercase tracking-wider border"
+           style="background-color: ${config.bg}; color: ${config.text}; border-color: ${config.border};">
         ${config.label}
       </div>`;
   }
@@ -298,7 +299,7 @@ async function createCommunityHtml(
               : `<div class="w-2 h-2 rounded-full shrink-0" style="background-color: ${ballStatus.dot || ballStatus.bg || getColorValue(COLORS.status.green.bg)};"></div>`;
 
             const textColorStyle = isApproved
-              ? `color: ${getColorValue(COLORS.text.main || '#0f172a')};`
+              ? `color: ${getColorValue(COLORS.text.primary)};`
               : `color: ${ballStatus.text || ballStatus.color || getColorValue(COLORS.status.green.text)};`;
 
             const wrapperPaddingClass = isApproved ? 'pl-4' : '';
@@ -312,7 +313,7 @@ async function createCommunityHtml(
                       ${ballStatus.label}
                     </span>
                   </div>
-                  <span class="text-[11px] text-slate-400 font-bold ml-4 mt-0.5 uppercase tracking-tight text-left">
+                  <span class="text-[11px] text-slate-400 dark:text-slate-500 font-bold ml-4 mt-0.5 uppercase tracking-tight text-left">
                     ${ballStatus.child}
                   </span>
                 </div>
@@ -321,23 +322,23 @@ async function createCommunityHtml(
           }
 
           return dedent`
-            <tr class="table-row-hover border-b border-slate-100 last:border-0 transition-colors" 
+            <tr class="table-row-hover border-b border-slate-100 dark:border-slate-700 last:border-0 transition-colors" 
                 data-status="${ballStatus?.label.toLowerCase() || ''}" 
                 data-date="${subDate}"
                 data-repo="${repoName.toLowerCase()}">
               ${statusColumnHtml}
               <td class="px-6 py-4 vertical-align-top ${ballStatus ? 'w-1/4' : 'w-1/3'}">
                 <div class="flex flex-col items-start">
-                  <span class="text-sm font-semibold text-slate-500">${repoName}</span>
+                  <span class="text-sm font-semibold text-slate-500 dark:text-slate-400">${repoName}</span>
                   ${statusIndicator}
                 </div>
               </td>
               <td class="px-6 py-4 vertical-align-top">
                 <div class="flex flex-col">
-                  <a href="${task.url}" target="_blank" class="hover:underline font-medium text-sm sm:text-base leading-snug" style="color: ${getColorValue(COLORS.primary)};">
+                  <a href="${task.url}" target="_blank" class="hover:underline font-medium text-sm sm:text-base leading-snug" style="color: ${getColorValue(COLORS.primaryText)};">
                     ${task.title}
                   </a>
-                  ${task.commitCount ? `<span class="text-[11px] text-slate-400 mt-1 font-mono uppercase tracking-tighter">${task.commitCount} contributions</span>` : ''}
+                  ${task.commitCount ? `<span class="text-[11px] text-slate-400 dark:text-slate-500 mt-1 font-mono uppercase tracking-tighter">${task.commitCount} contributions</span>` : ''}
                 </div>
               </td>
             </tr>
@@ -350,7 +351,7 @@ async function createCommunityHtml(
           ? dedent`
             <th scope="col" class="px-6 py-3 text-left">
               <button type="button" 
-                      class="flex items-center text-xs font-black text-slate-700 uppercase tracking-widest cursor-pointer group/sort focus:outline-none focus:ring-2 focus:ring-indigo-500 rounded px-1"
+                      class="flex items-center text-xs font-black text-slate-700 dark:text-slate-300 uppercase tracking-widest cursor-pointer group/sort focus:outline-none focus:ring-2 focus:ring-indigo-500 rounded px-1"
                       onclick="sortWorkbenchTable(this.parentElement, ${index})"
                       onkeydown="if(event.key==='Enter'||event.key===' '){ event.preventDefault(); sortWorkbenchTable(this.parentElement, ${index}); }">
                 Status
@@ -363,22 +364,22 @@ async function createCommunityHtml(
         <div class="overflow-x-auto">
           <div class="min-w-[600px]">
             <table class="min-w-full" id="workbench-table-${index}">
-              <thead class="bg-slate-50/80 border-b border-slate-100">
+              <thead class="bg-slate-50/80 dark:bg-slate-800/60 border-b border-slate-100 dark:border-slate-700">
                 <tr>
                   ${tableHeaderStatusHtml}
                   <th scope="col" class="px-6 py-3 text-left">
                     <button type="button" 
-                            class="flex items-center text-xs font-black text-slate-700 uppercase tracking-widest cursor-pointer group/sort focus:outline-none focus:ring-2 focus:ring-indigo-500 rounded px-1"
+                            class="flex items-center text-xs font-black text-slate-700 dark:text-slate-300 uppercase tracking-widest cursor-pointer group/sort focus:outline-none focus:ring-2 focus:ring-indigo-500 rounded px-1"
                             onclick="sortWorkbenchTable(this.parentElement, ${tableIndexStr}, 'repo')"
                             onkeydown="if(event.key==='Enter'||event.key===' '){ event.preventDefault(); sortWorkbenchTable(this.parentElement, ${tableIndexStr}, 'repo'); }">
                       Repository
                       <span class="sort-icon ml-1" aria-hidden="true">↕</span>
                     </button>
                   </th>
-                  <th scope="col" class="px-6 py-3 text-left text-xs font-black text-slate-700 uppercase tracking-widest">Task</th>
+                  <th scope="col" class="px-6 py-3 text-left text-xs font-black text-slate-700 dark:text-slate-300 uppercase tracking-widest">Task</th>
                 </tr>
               </thead>
-              <tbody class="divide-y divide-slate-100">
+              <tbody class="divide-y divide-slate-100 dark:divide-slate-700">
                 ${rows}
               </tbody>
             </table>
@@ -398,9 +399,9 @@ async function createCommunityHtml(
     const sectionId = `section-${index}`;
 
     return dedent`
-      <details id="${sectionId}" class="mb-6 group border border-slate-200 rounded-xl overflow-hidden shadow-xs bg-white" ${openAttribute}>
+      <details id="${sectionId}" class="mb-6 group border border-slate-200 dark:border-slate-700 rounded-xl overflow-hidden shadow-xs bg-white dark:bg-slate-800" ${openAttribute}>
         <summary 
-          class="list-none cursor-pointer p-4 bg-slate-50/50 hover:bg-slate-50 transition-all focus:outline-none focus-visible:ring-4 focus-visible:ring-indigo-500/30 focus-visible:bg-white"
+          class="list-none cursor-pointer p-4 bg-slate-50/50 dark:bg-slate-800/40 hover:bg-slate-50 dark:hover:bg-slate-800/70 transition-all focus:outline-none focus-visible:ring-4 focus-visible:ring-indigo-500/30 focus-visible:bg-white dark:focus-visible:bg-slate-800"
           role="button"
           tabindex="0">
           <div class="flex items-center gap-3">
@@ -411,12 +412,12 @@ async function createCommunityHtml(
               </span>
               <span>${label}</span>
             </span>
-            <span class="ml-auto text-slate-400 group-open:rotate-180 transition-transform duration-200">
+            <span class="ml-auto text-slate-400 dark:text-slate-500 group-open:rotate-180 transition-transform duration-200">
               <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>
             </span>
           </div>
         </summary>
-        <div class="bg-white border-t border-slate-100">
+        <div class="bg-white dark:bg-slate-800 border-t border-slate-100 dark:border-slate-700">
           ${sectionContent}
         </div>
       </details>
@@ -456,11 +457,11 @@ async function createCommunityHtml(
     : getColorValue(COLORS.status.red.bg);
 
   const badgeTextColor = hasTasks
-    ? getColorValue(COLORS.primary)
+    ? getColorValue(COLORS.primaryText)
     : getColorValue(COLORS.status.red.text);
 
   const badgeBorderColor = hasTasks
-    ? getColorValue(COLORS.primary)
+    ? getColorValue(COLORS.primaryText)
     : getColorValue(COLORS.status.red.text);
 
   const fullHtml = dedent`
@@ -471,29 +472,31 @@ async function createCommunityHtml(
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
       <title>Community & Activity | ${GITHUB_USERNAME} Portfolio</title>
       <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,${FAVICON_SVG_ENCODED}">
+      ${getThemeInitScript()}
       <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+      ${getThemeStyleVariant()}
       <style>
         ${communityCss}
         details summary::-webkit-details-marker { display:none; }
       </style>
     </head>
-    <body class="bg-white antialiased flex flex-col h-full min-h-full">
+    <body class="bg-white dark:bg-slate-900 antialiased flex flex-col h-full min-h-full">
       ${navHtml}
       <main class="grow w-full">
         <div class="px-6 sm:px-12 lg:px-16 xl:px-32 py-10">
           <div class="max-w-7xl mx-auto">
             <header style="border-bottom-color: ${getColorValue(COLORS.primary[15]) || '#e2e8f0'};" class="text-center mt-16 mb-16 pb-12 border-b-2">
-              <h1 style="color: ${getColorValue(COLORS.primary)};" class="text-4xl sm:text-6xl font-black mb-6 pt-8">
+              <h1 style="color: ${getColorValue(COLORS.primaryText)};" class="text-4xl sm:text-6xl font-black mb-6 pt-8">
                 Community & Activity
               </h1>
-              <p class="text-xl max-w-3xl mx-auto leading-relaxed text-slate-600">
+              <p class="text-xl max-w-3xl mx-auto leading-relaxed text-slate-600 dark:text-slate-300">
                 A showcase of ecosystem honors, dedicated stewardship roles, and real-time maintenance efforts.
               </p>
             </header>
 
             <section class="mb-20" aria-labelledby="milestones-heading">
               <div class="flex flex-col items-center mb-10">
-                <h2 id="milestones-heading" class="text-sm font-black uppercase tracking-[0.4em] text-slate-600 mb-3 text-center">Milestones and Awards</h2>
+                <h2 id="milestones-heading" class="text-sm font-black uppercase tracking-[0.4em] text-slate-600 dark:text-slate-300 mb-3 text-center">Milestones and Awards</h2>
                 <div class="w-16 h-1.5 rounded-full" style="background-color: ${getColorValue(COLORS.primary)};" aria-hidden="true"></div>
               </div>
               <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 max-w-6xl mx-auto">
@@ -502,18 +505,18 @@ async function createCommunityHtml(
             </section>
 
             <div class="grid grid-cols-1 lg:grid-cols-12 gap-10 items-start">
-              <section class="lg:col-span-4 bg-white rounded-2xl shadow-sm border border-slate-200 overflow-hidden">
-                <div class="p-6 border-b border-slate-100" style="background-color: ${getColorValue(COLORS.primary[10]) || '#eef2ff'};">
-                  <h2 class="text-xl font-bold" style="color: ${getColorValue(COLORS.primary)};">Ecosystem Advocacy & Roles</h2>
+              <section class="lg:col-span-4 bg-white dark:bg-slate-800 rounded-2xl shadow-sm border border-slate-200 dark:border-slate-700 overflow-hidden">
+                <div class="p-6 border-b border-slate-100 dark:border-slate-700" style="background-color: ${getColorValue(COLORS.primary[10]) || '#eef2ff'};">
+                  <h2 class="text-xl font-bold" style="color: ${getColorValue(COLORS.primaryText)};">Ecosystem Advocacy & Roles</h2>
                 </div>
-                <div class="divide-y divide-slate-100">
+                <div class="divide-y divide-slate-100 dark:divide-slate-700">
                   ${rolesItems}
                 </div>
               </section>
 
-              <section class="lg:col-span-8 bg-white rounded-2xl shadow-sm border border-slate-200 overflow-hidden">
-                <div class="p-6 border-b border-slate-100 flex flex-col sm:flex-row justify-between items-center gap-4 mb-6" style="background-color: ${getColorValue(COLORS.primary[10]) || '#eef2ff'};">
-                  <h2 class="text-xl font-bold text-center sm:text-left" style="color: ${getColorValue(COLORS.primary)};">
+              <section class="lg:col-span-8 bg-white dark:bg-slate-800 rounded-2xl shadow-sm border border-slate-200 dark:border-slate-700 overflow-hidden">
+                <div class="p-6 border-b border-slate-100 dark:border-slate-700 flex flex-col sm:flex-row justify-between items-center gap-4 mb-6" style="background-color: ${getColorValue(COLORS.primary[10]) || '#eef2ff'};">
+                  <h2 class="text-xl font-bold text-center sm:text-left" style="color: ${getColorValue(COLORS.primaryText)};">
                     Active Workbench
                   </h2>
                   <span class="px-3 py-1 rounded-full text-xs font-black uppercase tracking-widest border text-center transition-all shadow-sm"

--- a/scripts/generators/html/contributions-report-html-generator.js
+++ b/scripts/generators/html/contributions-report-html-generator.js
@@ -8,6 +8,7 @@ const { createFooterHtml } = require('../../components/footer');
 const { FAVICON_SVG_ENCODED, COLORS } = require('../../config/constants');
 const { getReportsListStyleCss } = require('../css/style-generator');
 const { getColorValue } = require('../../utils/color-helpers');
+const { getThemeInitScript, getThemeStyleVariant } = require('../../components/theme-init');
 
 const HTML_OUTPUT_DIR_NAME = 'html-generated';
 const HTML_REPORTS_FILENAME = 'reports.html';
@@ -80,7 +81,7 @@ async function createHtmlReports(quarterlyFileLinks = []) {
       // Start a new year section with a dedicated heading
       linkHtml += dedent`
             <details ${openAttribute} class="col-span-full mb-8 border rounded-2xl overflow-hidden transition duration-300" style="border-color: ${getColorValue(COLORS.border.light)};">
-                <summary style="color: ${getColorValue(COLORS.text.primary)};" class="text-2xl font-bold p-6 cursor-pointer transition duration-150 flex items-center bg-slate-50/50">
+                <summary style="color: ${getColorValue(COLORS.text.primary)};" class="text-2xl font-bold p-6 cursor-pointer transition duration-150 flex items-center bg-slate-50/50 dark:bg-slate-800/60">
                     <span class="mr-3">📅</span> ${year} Reports
                 </summary>
                 <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6 p-8">
@@ -89,10 +90,10 @@ async function createHtmlReports(quarterlyFileLinks = []) {
       // Add the quarterly cards for this year
       for (const link of linksByYear[year]) {
         linkHtml += dedent`
-                <a href="./${link.relativePath}" 
-                   style="border-color: ${getColorValue(COLORS.border.light)};" 
-                   class="report-card-link bg-white border rounded-xl shadow-sm hover:shadow-md transition-all duration-200 p-6">
-                    <p style="color: ${getColorValue(COLORS.primary)};" class="text-sm font-semibold">${link.quarterText}</p>
+                <a href="./${link.relativePath}"
+                   style="border-color: ${getColorValue(COLORS.border.light)};"
+                   class="report-card-link bg-white dark:bg-slate-800 border rounded-xl shadow-sm hover:shadow-md transition-all duration-200 p-6">
+                    <p style="color: ${getColorValue(COLORS.primaryText)};" class="text-sm font-semibold">${link.quarterText}</p>
                     <p style="color: ${getColorValue(COLORS.text.primary)};" class="text-3xl font-extrabold mt-1">${link.totalContributions}</p>
                     <p style="color: ${getColorValue(COLORS.text.muted)};" class="text-xs">Total Contributions</p>
                 </a>
@@ -121,18 +122,20 @@ async function createHtmlReports(quarterlyFileLinks = []) {
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Quarterly Reports | ${GITHUB_USERNAME} Portfolio</title>
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,${FAVICON_SVG_ENCODED}">
+  ${getThemeInitScript()}
   <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+  ${getThemeStyleVariant()}
   <style>
     ${reportsListCss}
   </style>
 </head>
-<body class="bg-white antialiased flex flex-col h-full min-h-full">
+<body class="bg-white dark:bg-slate-900 antialiased flex flex-col h-full min-h-full">
 ${navHtml}
   <main class="grow w-full">
     <div class="px-4 sm:px-8 lg:px-12 xl:px-16 2xl:px-24 py-6 sm:py-10">
       <div class="max-w-[120ch] mx-auto">
         <header style="border-bottom-color: ${getColorValue(COLORS.primary[15])};" class="text-center mt-16 mb-16 pb-12 border-b-2">
-          <h1 style="color: ${getColorValue(COLORS.primary)};" class="text-4xl sm:text-6xl font-black mb-6 pt-8">
+          <h1 style="color: ${getColorValue(COLORS.primaryText)};" class="text-4xl sm:text-6xl font-black mb-6 pt-8">
             Quarterly Reports
           </h1>
           <p style="color: ${getColorValue(COLORS.text.secondary)};" class="text-xl max-w-3xl mx-auto leading-relaxed">

--- a/scripts/generators/html/glossary-html-generator.js
+++ b/scripts/generators/html/glossary-html-generator.js
@@ -9,6 +9,7 @@ const { COLORS, FAVICON_SVG_ENCODED } = require('../../config/constants');
 const { GLOSSARY_CONTENT } = require('../../metadata/glossary');
 const { getColorValue } = require('../../utils/color-helpers');
 const { getGlossaryStyleCss } = require('../css/style-generator');
+const { getThemeInitScript, getThemeStyleVariant } = require('../../components/theme-init');
 
 async function createGlossaryHtml() {
   const htmlBaseDir = path.join(BASE_DIR, 'html-generated');
@@ -33,11 +34,14 @@ async function createGlossaryHtml() {
         // 3. List items: Wrap lines starting with '*' or '-' in <li>
         .replace(
           /^\s*[*|-]\s+(.*)$/gm,
-          '<li class="ml-4 list-disc list-inside text-indigo-600">$1</li>'
+          '<li class="ml-4 list-disc list-inside text-indigo-600 dark:text-indigo-300">$1</li>'
         )
 
         // 4. Wrap <li> groups in <ul>
-        .replace(/(<li.*?>.*?<\/li>)+/g, '<ul class="my-3 space-y-1 text-indigo-600">$1</ul>')
+        .replace(
+          /(<li.*?>.*?<\/li>)+/g,
+          '<ul class="my-3 space-y-1 text-indigo-600 dark:text-indigo-300">$1</ul>'
+        )
 
         // 5. Cleanup
         .replace(/<\/ul>\s+/g, '</ul>')
@@ -66,21 +70,21 @@ async function createGlossaryHtml() {
 
           return dedent`
             <div id="${item.id}" class="mb-16 last:mb-0">
-              <h3 style="color: ${getColorValue(COLORS.primary)}; border-bottom: 2px solid ${getColorValue(COLORS.primary[15])};" 
+              <h3 style="color: ${getColorValue(COLORS.primaryText)}; border-bottom: 2px solid ${getColorValue(COLORS.primary[15])};"
                   class="text-xl font-extrabold mb-6 pb-2 inline-block">
                 ${item.title}
               </h3>
               
               <div class="space-y-6">
-                <p class="text-lg text-slate-600 leading-relaxed">
+                <p class="text-lg text-slate-600 dark:text-slate-300 leading-relaxed">
                   ${description}
                 </p>
-                
+
                 <div class="glossary-code-block p-6 overflow-x-auto rounded-2xl">
-                  <span class="block text-xs uppercase tracking-widest text-slate-400 mb-3 font-black font-mono">
+                  <span class="block text-xs uppercase tracking-widest text-slate-400 dark:text-slate-500 mb-3 font-black font-mono">
                     ${label}
                   </span>
-                  <div class="text-sm text-indigo-600 leading-relaxed">
+                  <div class="text-sm text-indigo-600 dark:text-indigo-300 leading-relaxed">
                     ${processedNote}
                   </div>
                 </div>
@@ -93,10 +97,10 @@ async function createGlossaryHtml() {
       return dedent`
         <section id="${group.id}" class="mb-24 last:mb-0">
           <div class="mb-10">
-            <h2 style="color: ${getColorValue(COLORS.primary)};" class="text-3xl sm:text-4xl font-black mb-2">
+            <h2 style="color: ${getColorValue(COLORS.primaryText)};" class="text-3xl sm:text-4xl font-black mb-2">
               ${group.title}
             </h2>
-            <p class="text-slate-500 text-lg font-medium italic">${processText(group.description)}</p>
+            <p class="text-slate-500 dark:text-slate-400 text-lg font-medium italic">${processText(group.description)}</p>
           </div>
           <div class="space-y-2">
             ${itemsHtml}
@@ -114,19 +118,21 @@ async function createGlossaryHtml() {
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
       <title>Glossary | ${GITHUB_USERNAME} OSS Portfolio</title>
       <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,${FAVICON_SVG_ENCODED}">
+      ${getThemeInitScript()}
       <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+      ${getThemeStyleVariant()}
       <style>${glossaryCss}</style>
     </head>
-    <body class="bg-white antialiased flex flex-col h-full min-h-full">
+    <body class="bg-white dark:bg-slate-900 antialiased flex flex-col h-full min-h-full">
       ${navHtml}
       <main class="grow w-full">
         <div class="px-6 sm:px-12 lg:px-16 xl:px-32 py-10">
           <div class="max-w-7xl mx-auto">
             <header style="border-bottom-color: ${getColorValue(COLORS.primary[15]) || '#e2e8f0'};" class="text-center mt-16 mb-16 pb-12 border-b-2">
-              <h1 style="color: ${getColorValue(COLORS.primary)};" class="text-4xl sm:text-6xl font-black mb-6 pt-8">
+              <h1 style="color: ${getColorValue(COLORS.primaryText)};" class="text-4xl sm:text-6xl font-black mb-6 pt-8">
                 ${GLOSSARY_CONTENT.title}
               </h1>
-              <p class="text-xl max-w-3xl mx-auto leading-relaxed text-slate-600">
+              <p class="text-xl max-w-3xl mx-auto leading-relaxed text-slate-600 dark:text-slate-300">
                 ${processText(GLOSSARY_CONTENT.subtitle)}
               </p>
             </header>

--- a/scripts/generators/html/landing-page-html-generator.js
+++ b/scripts/generators/html/landing-page-html-generator.js
@@ -15,6 +15,7 @@ const {
 } = require('../../config/constants');
 const { getIndexStyleCss } = require('../css/style-generator');
 const { getColorValue } = require('../../utils/color-helpers');
+const { getThemeInitScript, getThemeStyleVariant } = require('../../components/theme-init');
 
 const htmlBaseDir = path.join(BASE_DIR, 'html-generated');
 const HTML_OUTPUT_PATH = path.join(htmlBaseDir, 'index.html');
@@ -130,22 +131,22 @@ async function createIndexHtml(finalContributions = {}, articles = []) {
             const repoUrl = `https://github.com/${repo}`;
 
             return `
-        <div class="flex flex-col sm:flex-row sm:items-start justify-between py-4 border-b border-slate-100 last:border-0 gap-3 sm:gap-4">
+        <div class="flex flex-col sm:flex-row sm:items-start justify-between py-4 border-b border-slate-100 dark:border-slate-700 last:border-0 gap-3 sm:gap-4">
           <div class="flex flex-col min-w-0">
-            ${owner ? `<span class="text-xs uppercase tracking-[0.15em] text-slate-500 font-black leading-none mb-1.5 block">${owner}</span>` : ''}
-            <a href="${repoUrl}" target="_blank" rel="noopener noreferrer" class="${nameClass} break-all hover:underline underline-offset-4" style="color: ${getColorValue(COLORS.primary)};">
+            ${owner ? `<span class="text-xs uppercase tracking-[0.15em] text-slate-500 dark:text-slate-400 font-black leading-none mb-1.5 block">${owner}</span>` : ''}
+            <a href="${repoUrl}" target="_blank" rel="noopener noreferrer" class="${nameClass} break-all hover:underline underline-offset-4" style="color: ${getColorValue(COLORS.primaryText)};">
               ${name}
             </a>
           </div>
           <div class="shrink-0 mt-1 sm:mt-0 sm:self-center">
-            <span class="text-xs font-black text-slate-600 whitespace-nowrap px-2 py-1 bg-slate-50 rounded-md border border-slate-200">
+            <span class="text-xs font-black text-slate-600 dark:text-slate-300 whitespace-nowrap px-2 py-1 bg-slate-50 dark:bg-slate-800/60 rounded-md border border-slate-200 dark:border-slate-700">
               ${count} contributions
             </span>
           </div>
         </div>`;
           })
           .join('')
-      : '<p class="text-sm text-slate-500 font-medium italic">No activity recorded yet.</p>';
+      : '<p class="text-sm text-slate-500 dark:text-slate-400 font-medium italic">No activity recorded yet.</p>';
 
   const chosenPersona = determinePersona(countsDict);
   const { title: personaTitle, desc: personaDesc, key: activePersonaKey } = chosenPersona;
@@ -162,18 +163,20 @@ async function createIndexHtml(finalContributions = {}, articles = []) {
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
       <title>Open Source Portfolio | ${GITHUB_USERNAME}</title>
       <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,${FAVICON_SVG_ENCODED}">
+      ${getThemeInitScript()}
       <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+      ${getThemeStyleVariant()}
       <style>${indexCss}</style>
     </head>
-    <body class="bg-white antialiased flex flex-col h-full min-h-full">
+    <body class="bg-white dark:bg-slate-900 antialiased flex flex-col h-full min-h-full">
       ${navHtml}
       <main class="grow w-full">
         <header class="pt-24 pb-20 px-6 border-b" style="border-color: ${getColorValue(COLORS.border.light)};">
           <div class="max-w-4xl mx-auto text-center">
-            <h1 class="text-5xl md:text-7xl font-extrabold mb-8 mt-12" style="color: ${getColorValue(COLORS.primary)};">
+            <h1 class="text-5xl md:text-7xl font-extrabold mb-8 mt-12" style="color: ${getColorValue(COLORS.primaryText)};">
               Open Source Portfolio
             </h1>
-            <h2 class="block text-4xl md:text-5xl font-bold opacity-80 mb-8" style="color: ${getColorValue(COLORS.primary[75])}";>@${GITHUB_USERNAME}</h2>
+            <h2 class="block text-4xl md:text-5xl font-bold opacity-80 mb-8" style="color: ${getColorValue(COLORS.primaryText)};">@${GITHUB_USERNAME}</h2>
             <p class="text-xl md:text-2xl leading-relaxed max-w-2xl mx-auto" style="color: ${getColorValue(COLORS.text.secondary)};">
               A comprehensive visualization of open source contributions, from high-level impact to granular quarterly details.
             </p>
@@ -209,7 +212,7 @@ async function createIndexHtml(finalContributions = {}, articles = []) {
                   </div>
                 </div>
 
-                <div class="lg:col-span-2 flex flex-col bg-white rounded-2xl shadow-sm border border-slate-200 overflow-hidden"> 
+                <div class="lg:col-span-2 flex flex-col bg-white dark:bg-slate-800 rounded-2xl shadow-sm border border-slate-200 dark:border-slate-700 overflow-hidden"> 
                   ${['Merged PRs', 'Issues', 'Reviewed PRs', 'Co-Authored PRs', 'Collaborations']
                     .map((label, idx) => {
                       const key = [
@@ -236,25 +239,25 @@ async function createIndexHtml(finalContributions = {}, articles = []) {
 
                       const labelClass = isHighest
                         ? 'text-lg sm:text-xl font-black self-start tracking-tighter'
-                        : 'text-slate-800 font-bold text-md-lg sm:text-lg self-start tracking-tighter';
+                        : 'text-slate-800 dark:text-slate-100 font-bold text-md-lg sm:text-lg self-start tracking-tighter';
 
                       const labelInlineStyle = isHighest
-                        ? `style="color: ${getColorValue(COLORS.primary)};"`
+                        ? `style="color: ${getColorValue(COLORS.primaryText)};"`
                         : '';
 
-                      const trackClass = isHighest ? 'bg-white' : 'bg-slate-100';
+                      const trackClass = isHighest ? 'bg-white dark:bg-slate-900' : 'bg-slate-100 dark:bg-slate-700';
 
                       return `
-                    <div ${rowStyle} class="flex-1 flex flex-col justify-center px-8 py-4 border-b border-slate-100 hover:opacity-95 transition-all last:border-0 relative">
+                    <div ${rowStyle} class="flex-1 flex flex-col justify-center px-8 py-4 border-b border-slate-100 dark:border-slate-700 hover:opacity-95 transition-all last:border-0 relative">
                       <div class="flex justify-between items-center mb-2">
                         <span class="${labelClass}" ${labelInlineStyle}>${label}</span>
                         <div class="flex flex-col sm:flex-row items-end sm:items-baseline">
-                          <span style="color: ${getColorValue(COLORS.primary)};" class="tracking-tighter ${
+                          <span style="color: ${getColorValue(COLORS.primaryText)};" class="tracking-tighter ${
                             isHighest
                               ? 'font-black text-3xl sm:text-4xl'
                               : 'font-bold text-2xl sm:text-3xl'
                           } leading-none">${count}</span>
-                          <span class="text-xs sm:text-sm text-slate-600 mt-1 sm:mt-0 ml-0 sm:ml-2 font-mono font-semibold">${s.pctStr}</span>
+                          <span class="text-xs sm:text-sm text-slate-600 dark:text-slate-300 mt-1 sm:mt-0 ml-0 sm:ml-2 font-mono font-semibold">${s.pctStr}</span>
                         </div>
                       </div>
                       <div class="w-full ${trackClass} rounded-full h-3 overflow-hidden flex">
@@ -269,29 +272,29 @@ async function createIndexHtml(finalContributions = {}, articles = []) {
               </div> 
 
               <div class="mt-8 grid grid-cols-1 md:grid-cols-2 gap-8 text-left">
-                <div class="bg-white p-6 sm:p-8 rounded-2xl border border-slate-200 shadow-sm min-w-0">
-                  <h2 class="text-sm uppercase tracking-widest font-black text-slate-800 mb-4">Primary Focus Projects</h2>
-                  <div class="divide-y divide-slate-100 min-w-0">${topReposHtml}</div>
+                <div class="bg-white dark:bg-slate-800 p-6 sm:p-8 rounded-2xl border border-slate-200 dark:border-slate-700 shadow-sm min-w-0">
+                  <h2 class="text-sm uppercase tracking-widest font-black text-slate-800 dark:text-slate-100 mb-4">Primary Focus Projects</h2>
+                  <div class="divide-y divide-slate-100 dark:divide-slate-700 min-w-0">${topReposHtml}</div>
                 </div>
                 
-                <div class="bg-white p-6 sm:p-8 rounded-2xl border border-slate-200 shadow-sm flex flex-col justify-between">
+                <div class="bg-white dark:bg-slate-800 p-6 sm:p-8 rounded-2xl border border-slate-200 dark:border-slate-700 shadow-sm flex flex-col justify-between">
                   <div>
-                    <h2 class="text-sm uppercase tracking-widest font-black text-slate-800 mb-4">
+                    <h2 class="text-sm uppercase tracking-widest font-black text-slate-800 dark:text-slate-100 mb-4">
                       Collaboration Profile
                     </h2>
                     <div>
-                      <p style="color: ${getColorValue(COLORS.primary)};" class="text-3xl font-black mb-2 tracking-tight">${personaTitle}</p>
-                      <p class="text-md text-slate-500 leading-relaxed">${personaDesc}</p>
+                      <p style="color: ${getColorValue(COLORS.primaryText)};" class="text-3xl font-black mb-2 tracking-tight">${personaTitle}</p>
+                      <p class="text-md text-slate-500 dark:text-slate-400 leading-relaxed">${personaDesc}</p>
                     </div>
                   </div>
                   
-                  <div class="mt-6 pt-4 border-t border-slate-100 flex items-start">
-                    <span style="color: ${getColorValue(COLORS.primary)};" class="mr-3 mt-0.5 shrink-0">
+                  <div class="mt-6 pt-4 border-t border-slate-100 dark:border-slate-700 flex items-start">
+                    <span style="color: ${getColorValue(COLORS.primaryText)};" class="mr-3 mt-0.5 shrink-0">
                       ${INFO_ICON_SVG}
                     </span>
-                    <p class="text-xs text-slate-500 leading-snug">
+                    <p class="text-xs text-slate-500 dark:text-slate-400 leading-snug">
                       This profile is an assigned category based on contribution activity. 
-                      <a href="glossary.html" class="font-bold underline decoration-slate-300 hover:decoration-current transition-colors" style="color: ${getColorValue(COLORS.primary)};">
+                      <a href="glossary.html" class="font-bold underline decoration-slate-300 dark:decoration-slate-600 hover:decoration-current transition-colors" style="color: ${getColorValue(COLORS.primaryText)};">
                         Learn more in the Glossary.
                       </a>
                     </p>
@@ -299,53 +302,53 @@ async function createIndexHtml(finalContributions = {}, articles = []) {
                 </div>
               </div>
 
-              <section class="mt-16 pt-12 border-t border-slate-100">
-                <h2 class="text-sm uppercase tracking-[0.2em] font-black text-slate-800 mb-8 text-center">Explore Detailed Metrics & Activities</h2>
+              <section class="mt-16 pt-12 border-t border-slate-100 dark:border-slate-800">
+                <h2 class="text-sm uppercase tracking-[0.2em] font-black text-slate-800 dark:text-slate-100 mb-8 text-center">Explore Detailed Metrics & Activities</h2>
                 <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
                   
-                  <a href="reports.html" class="group p-6 bg-slate-50 rounded-2xl border border-slate-200 hover:border-indigo-400 transition-all flex flex-col justify-between shadow-sm">
+                  <a href="reports.html" class="group p-6 bg-slate-50 dark:bg-slate-800/60 rounded-2xl border border-slate-200 dark:border-slate-700 hover:border-indigo-400 transition-all flex flex-col justify-between shadow-sm">
                     <div class="flex items-center space-x-4 mb-4">
-                      <div class="p-3 bg-white rounded-xl shadow-sm group-hover:scale-110 transition-transform text-xl">
+                      <div class="p-3 bg-white dark:bg-slate-700 rounded-xl shadow-sm group-hover:scale-110 transition-transform text-xl">
                         📊
                       </div>
                       <div>
-                        <h3 class="font-black text-slate-900">Reports</h3>
-                        <p class="text-xs text-slate-600 font-bold">Seasonal breakdown</p>
+                        <h3 class="font-black text-slate-900 dark:text-slate-100">Reports</h3>
+                        <p class="text-xs text-slate-600 dark:text-slate-300 font-bold">Seasonal breakdown</p>
                       </div>
                     </div>
-                    <div style="color: ${getColorValue(COLORS.primary)};" class="flex items-center text-xs font-black uppercase tracking-wider opacity-80 group-hover:opacity-100 transition-opacity">
+                    <div style="color: ${getColorValue(COLORS.primaryText)};" class="flex items-center text-xs font-black uppercase tracking-wider opacity-80 group-hover:opacity-100 transition-opacity">
                       <span>View Reports</span>
                       <span class="ml-2 group-hover:translate-x-1 transition-transform">${rightArrowSvg}</span>
                     </div>
                   </a>
 
-                  <a href="community-activity.html" class="group p-6 bg-slate-50 rounded-2xl border border-slate-200 hover:border-indigo-400 transition-all flex flex-col justify-between shadow-sm">
+                  <a href="community-activity.html" class="group p-6 bg-slate-50 dark:bg-slate-800/60 rounded-2xl border border-slate-200 dark:border-slate-700 hover:border-indigo-400 transition-all flex flex-col justify-between shadow-sm">
                     <div class="flex items-center space-x-4 mb-4">
-                      <div class="p-3 bg-white rounded-xl shadow-sm group-hover:scale-110 transition-transform text-xl">
+                      <div class="p-3 bg-white dark:bg-slate-700 rounded-xl shadow-sm group-hover:scale-110 transition-transform text-xl">
                         🤝
                       </div>
                       <div>
-                        <h3 class="font-black text-slate-900">Community</h3>
-                        <p class="text-xs text-slate-600 font-bold">Roles & Active Tasks</p>
+                        <h3 class="font-black text-slate-900 dark:text-slate-100">Community</h3>
+                        <p class="text-xs text-slate-600 dark:text-slate-300 font-bold">Roles & Active Tasks</p>
                       </div>
                     </div>
-                    <div style="color: ${getColorValue(COLORS.primary)};" class="flex items-center text-xs font-black uppercase tracking-wider opacity-80 group-hover:opacity-100 transition-opacity">
+                    <div style="color: ${getColorValue(COLORS.primaryText)};" class="flex items-center text-xs font-black uppercase tracking-wider opacity-80 group-hover:opacity-100 transition-opacity">
                       <span>View Activity</span>
                       <span class="ml-2 group-hover:translate-x-1 transition-transform">${rightArrowSvg}</span>
                     </div>
                   </a>
 
-                  <a href="blog.html" class="group p-6 bg-slate-50 rounded-2xl border border-slate-200 hover:border-indigo-400 transition-all flex flex-col justify-between shadow-sm">
+                  <a href="blog.html" class="group p-6 bg-slate-50 dark:bg-slate-800/60 rounded-2xl border border-slate-200 dark:border-slate-700 hover:border-indigo-400 transition-all flex flex-col justify-between shadow-sm">
                     <div class="flex items-center space-x-4 mb-4">
-                      <div class="p-3 bg-white rounded-xl shadow-sm group-hover:scale-110 transition-transform text-xl">
+                      <div class="p-3 bg-white dark:bg-slate-700 rounded-xl shadow-sm group-hover:scale-110 transition-transform text-xl">
                         ✍️
                       </div>
                       <div>
-                        <h3 class="font-black text-slate-900">Articles</h3>
-                        <p class="text-xs text-slate-600 font-bold">${articleCount} Tutorials & Posts</p>
+                        <h3 class="font-black text-slate-900 dark:text-slate-100">Articles</h3>
+                        <p class="text-xs text-slate-600 dark:text-slate-300 font-bold">${articleCount} Tutorials & Posts</p>
                       </div>
                     </div>
-                    <div style="color: ${getColorValue(COLORS.primary)};" class="flex items-center text-xs font-black uppercase tracking-wider opacity-80 group-hover:opacity-100 transition-opacity">
+                    <div style="color: ${getColorValue(COLORS.primaryText)};" class="flex items-center text-xs font-black uppercase tracking-wider opacity-80 group-hover:opacity-100 transition-opacity">
                       <span>Read Articles</span>
                       <span class="ml-2 group-hover:translate-x-1 transition-transform">${rightArrowSvg}</span>
                     </div>

--- a/scripts/generators/html/quarterly-reports-html-generator.js
+++ b/scripts/generators/html/quarterly-reports-html-generator.js
@@ -22,6 +22,7 @@ const {
 } = require('../../config/constants');
 const { getColorValue } = require('../../utils/color-helpers');
 const { sanitizeAttribute } = require('../../utils/html-helpers');
+const { getThemeInitScript, getThemeStyleVariant } = require('../../components/theme-init');
 
 /**
  * Generates and writes individual HTML report files for each quarter's contributions.
@@ -142,14 +143,14 @@ async function writeHtmlFiles(groupedContributions) {
     };
 
     const baseClasses =
-      'w-40 xs:w-44 sm:w-52 h-20 p-2 sm:p-4 flex flex-col justify-center rounded-lg shadow-md transition duration-200 border border-gray-200';
+      'w-40 xs:w-44 sm:w-52 h-20 p-2 sm:p-4 flex flex-col justify-center rounded-lg shadow-md transition duration-200 border border-gray-200 dark:border-slate-700';
 
     if (previousReport) {
       const prevPath = getReportPath(previousReport);
       previousButton = dedent`
-        <a href="${prevPath}" class="${baseClasses} bg-white nav-report-button text-left" style="color: ${getColorValue(COLORS.primary)};">
-          <span class="text-[10px] sm:text-xs font-medium text-gray-500">Previous</span>
-          <span class="flex items-center space-x-1 font-bold text-sm sm:text-lg break-words whitespace-normal" style="color: ${getColorValue(COLORS.primary)};">
+        <a href="${prevPath}" class="${baseClasses} bg-white dark:bg-slate-800 nav-report-button text-left" style="color: ${getColorValue(COLORS.primaryText)};">
+          <span class="text-[10px] sm:text-xs font-medium text-gray-500 dark:text-slate-400">Previous</span>
+          <span class="flex items-center space-x-1 font-bold text-sm sm:text-lg break-words whitespace-normal" style="color: ${getColorValue(COLORS.primaryText)};">
             ${LEFT_ARROW_SVG}
             <span class="whitespace-normal min-w-0">${previousReport.fullQuarterName}</span>
           </span>
@@ -164,9 +165,9 @@ async function writeHtmlFiles(groupedContributions) {
     if (nextReport) {
       const nextPath = getReportPath(nextReport);
       nextButton = dedent`
-        <a href="${nextPath}" class="${baseClasses} bg-white nav-report-button text-right" style="color: ${getColorValue(COLORS.primary)};">
-          <span class="text-[10px] sm:text-xs font-medium text-gray-500">Next</span>
-          <span class="flex items-center space-x-1 justify-end font-bold text-sm sm:text-lg break-words whitespace-normal" style="color: ${getColorValue(COLORS.primary)};">
+        <a href="${nextPath}" class="${baseClasses} bg-white dark:bg-slate-800 nav-report-button text-right" style="color: ${getColorValue(COLORS.primaryText)};">
+          <span class="text-[10px] sm:text-xs font-medium text-gray-500 dark:text-slate-400">Next</span>
+          <span class="flex items-center space-x-1 justify-end font-bold text-sm sm:text-lg break-words whitespace-normal" style="color: ${getColorValue(COLORS.primaryText)};">
             <span class="whitespace-normal min-w-0">${nextReport.fullQuarterName}</span>
             ${RIGHT_ARROW_SVG}
           </span>
@@ -236,7 +237,7 @@ async function writeHtmlFiles(groupedContributions) {
       .slice(0, 3)
       .map(
         (item) => dedent`
-          <li class="pl-2"><a href='https://github.com/${item[0]}' target='_blank' class="text-blue-600 hover:text-blue-800 hover:underline font-mono text-sm">${item[0]}</a> (${item[1]} contributions)</li>
+          <li class="pl-2"><a href='https://github.com/${item[0]}' target='_blank' class="text-blue-600 dark:text-blue-300 hover:text-blue-800 dark:hover:text-blue-200 hover:underline font-mono text-sm">${item[0]}</a> (${item[1]} contributions)</li>
         `
       )
       .join('');
@@ -321,23 +322,25 @@ async function writeHtmlFiles(groupedContributions) {
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>${quarter} ${year} Report | ${GITHUB_USERNAME} Portfolio</title>
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,${FAVICON_SVG_ENCODED}">
+  ${getThemeInitScript()}
   <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+  ${getThemeStyleVariant()}
   <style>
     ${dynamicCss}
   </style>
 </head>
-<body class="bg-white antialiased flex flex-col h-full min-h-full">
+<body class="bg-white dark:bg-slate-900 antialiased flex flex-col h-full min-h-full">
 ${navHtmlForReports}
   <main class="grow w-full">
     <div class="px-4 sm:px-8 lg:px-12 xl:px-16 2xl:px-24 py-6 sm:py-10">
       <div class="max-w-[120ch] mx-auto">
         <header style="border-bottom-color: ${COLORS.primary[15] || '#e2e8f0'};" class="text-center mt-16 mb-12 pb-4 border-b-2">
-          <h1 style="color: ${getColorValue(COLORS.primary)};" class="text-4xl sm:text-5xl font-extrabold mb-2 pt-8">${quarter} ${year}</h1>
-          <p class="text-lg text-gray-500 mt-2">Open Source Contributions Report</p>
+          <h1 style="color: ${getColorValue(COLORS.primaryText)};" class="text-4xl sm:text-5xl font-extrabold mb-2 pt-8">${quarter} ${year}</h1>
+          <p class="text-lg text-gray-500 dark:text-slate-400 mt-2">Open Source Contributions Report</p>
         </header>
 
         <section class="mb-8">
-          <h2 style="border-left-color: ${getColorValue(COLORS.primary)};" class="text-3xl font-semibold text-gray-800 mb-12 border-l-4 pl-3">📊 Quarterly Statistics</h2>
+          <h2 style="border-left-color: ${getColorValue(COLORS.primaryText)};" class="text-3xl font-semibold text-gray-800 dark:text-slate-100 mb-12 border-l-4 pl-3">📊 Quarterly Statistics</h2>
           <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
           <div style="background-color: ${getColorValue(COLORS.primary)};" class="text-white p-6 rounded-xl shadow-lg flex flex-col items-center justify-center">
             <p class="text-4xl font-extrabold">${totalContributions}</p>
@@ -351,7 +354,7 @@ ${navHtmlForReports}
         </section>
 
         <section class="mb-8">
-          <h3 class="text-2xl font-semibold text-gray-800 mt-16 mb-4 border-l-4 border-green-500 pl-3">Contribution Breakdown</h3>
+          <h3 class="text-2xl font-semibold text-gray-800 dark:text-slate-100 mt-16 mb-4 border-l-4 border-green-500 dark:border-green-400 pl-3">Contribution Breakdown</h3>
           <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-4 text-sm">
             ${[
               {
@@ -387,9 +390,9 @@ ${navHtmlForReports}
             ]
               .map(
                 (item) => `
-              <a href="#${item.id}" class="nav-contribution-button flex flex-col items-center p-3 bg-white border rounded-xl shadow-sm hover:shadow-lg transition text-center" style="color: ${getColorValue(COLORS.primary)};">
-                <span class="text-2xl font-bold" style="color: ${getColorValue(COLORS.primary)};">${item.count}</span>
-                <div class="flex items-center justify-center gap-1.5 text-gray-500 mt-1">
+              <a href="#${item.id}" class="nav-contribution-button flex flex-col items-center p-3 bg-white dark:bg-slate-800 border rounded-xl shadow-sm hover:shadow-lg transition text-center" style="color: ${getColorValue(COLORS.primaryText)};">
+                <span class="text-2xl font-bold" style="color: ${getColorValue(COLORS.primaryText)};">${item.count}</span>
+                <div class="flex items-center justify-center gap-1.5 text-gray-500 dark:text-slate-400 mt-1">
                   <span class="breakdown-icon-wrapper opacity-70">
                     ${item.icon}
                   </span>
@@ -403,15 +406,15 @@ ${navHtmlForReports}
         </section>
 
         <section class="mb-8">
-          <h3 class="text-2xl font-semibold text-gray-800 mb-4 border-l-4 border-yellow-500 pl-3">Top 3 Repositories</h3>
-          <div class="p-4 bg-gray-50 rounded-lg shadow-sm">
-            <ol class="list-decimal list-inside pl-4 text-gray-600 space-y-1">
+          <h3 class="text-2xl font-semibold text-gray-800 dark:text-slate-100 mb-4 border-l-4 border-yellow-500 dark:border-yellow-400 pl-3">Top 3 Repositories</h3>
+          <div class="p-4 bg-gray-50 dark:bg-slate-800/60 rounded-lg shadow-sm">
+            <ol class="list-decimal list-inside pl-4 text-gray-600 dark:text-slate-300 space-y-1">
               ${top3Repos}
             </ol>
           </div>
         </section>
 
-        <hr class="my-8 border-gray-200">
+        <hr class="my-8 border-gray-200 dark:border-slate-700">
       
         <section class="space-y-6">
     `;
@@ -432,8 +435,8 @@ ${navHtmlForReports}
       }
 
       // Details tag is used for collapsible sections.
-      htmlContent += `<details id="${sectionInfo.id}" class="border border-gray-200 rounded-xl p-4 shadow-sm">\n`;
-      htmlContent += ` <summary style="color: ${getColorValue(COLORS.primary)};" class="text-xl font-bold cursor-pointer outline-none">\n`;
+      htmlContent += `<details id="${sectionInfo.id}" class="border border-gray-200 dark:border-slate-700 rounded-xl p-4 shadow-sm">\n`;
+      htmlContent += ` <summary style="color: ${getColorValue(COLORS.primaryText)};" class="text-xl font-bold cursor-pointer outline-none">\n`;
       htmlContent += `  <div class="inline-flex items-center flex-nowrap gap-2 ml-3" style="vertical-align: middle;">\n`;
       htmlContent += `    <span class="w-6 h-6 flex items-center shrink-0">${sectionInfo.icon}</span>\n`;
       htmlContent += `    <span class="text-xl font-bold whitespace-nowrap">${sectionInfo.title} (${items.length})</span>\n`;
@@ -441,7 +444,7 @@ ${navHtmlForReports}
       htmlContent += ` </summary>\n`;
 
       if (!items || items.length === 0) {
-        htmlContent += `<div class="p-4 text-gray-500 bg-gray-50 rounded-lg">No contributions of this type in this quarter.</div>\n`;
+        htmlContent += `<div class="p-4 text-gray-500 dark:text-slate-400 bg-gray-50 dark:bg-slate-800/60 rounded-lg">No contributions of this type in this quarter.</div>\n`;
       } else {
         // Search bar with icon styling for the table in the current section.
         const searchInputId = `${sectionInfo.id}-search`;
@@ -452,24 +455,24 @@ ${navHtmlForReports}
           <div class="flex flex-wrap gap-2 items-center mb-4 mt-2 px-1">
             
             <div class="icon-input-container grow">
-              <div class="input-icon" style="color: ${getColorValue(COLORS.primary)};">
+              <div class="input-icon" style="color: ${getColorValue(COLORS.primaryText)};">
                 ${SEARCH_SVG}
               </div>
               
-              <input 
-                type="text" 
-                id="${searchInputId}" 
-                placeholder="${visualPlaceholder}" 
+              <input
+                type="text"
+                id="${searchInputId}"
+                placeholder="${visualPlaceholder}"
                 aria-label="${accessibleLabel}"
-                class="search-input w-full border rounded-md 
+                class="search-input w-full border rounded-md bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 placeholder-slate-400 dark:placeholder-slate-500
                 px-3 py-2 text-sm focus:outline-none focus:ring-1 transition"
-                style="border-color: ${getColorValue(COLORS.primary)};"
+                style="border-color: ${getColorValue(COLORS.primaryText)};"
               />
             </div>
 
             <button 
-            class="reset-btn bg-gray-100 
-            hover:bg-gray-200 text-gray-700 px-3 py-2 rounded-md text-sm font-medium transition"
+            class="reset-btn bg-gray-100 dark:bg-slate-700
+            hover:bg-gray-200 dark:hover:bg-slate-600 text-gray-700 dark:text-slate-200 px-3 py-2 rounded-md text-sm font-medium transition"
             >
               Reset
             </button>
@@ -477,9 +480,9 @@ ${navHtmlForReports}
         `;
 
         // Generate the contribution table.
-        let tableContent = `<div class="overflow-x-auto rounded-lg border border-gray-100 max-h-[70vh] overflow-y-auto">\n`;
-        tableContent += ` <table class="report-table min-w-full divide-y divide-gray-200 bg-white">\n`;
-        tableContent += `  <thead class="bg-white">\n`;
+        let tableContent = `<div class="overflow-x-auto rounded-lg border border-gray-100 dark:border-slate-800 max-h-[70vh] overflow-y-auto">\n`;
+        tableContent += ` <table class="report-table min-w-full divide-y divide-gray-200 dark:divide-slate-700 bg-white dark:bg-slate-800">\n`;
+        tableContent += `  <thead class="bg-white dark:bg-slate-800">\n`;
         tableContent += `   <tr>\n`;
 
         // Generate table headers with sorting attributes (data-type).
@@ -493,13 +496,13 @@ ${navHtmlForReports}
             : `<span class="th-content">${sectionInfo.headers[i]} <span class="sort-icon ml-1">↕</span></span>`;
           const cursorStyle = isStaticColumn ? 'cursor: default;' : 'cursor: pointer;';
 
-          tableContent += `    <th ${thAttributes} class="py-3 px-4" style="color: ${getColorValue(COLORS.primary)}; ${cursorStyle}">
+          tableContent += `    <th ${thAttributes} class="py-3 px-4" style="color: ${getColorValue(COLORS.primaryText)}; ${cursorStyle}">
               ${headerContent}
           </th>\n`;
         }
         tableContent += `   </tr>\n`;
         tableContent += `  </thead>\n`;
-        tableContent += `  <tbody class="divide-y divide-gray-100">\n`;
+        tableContent += `  <tbody class="divide-y divide-gray-100 dark:divide-slate-700">\n`;
 
         let counter = 1;
         // Generate table rows, mapping data properties to columns.
@@ -517,11 +520,11 @@ ${navHtmlForReports}
           tableContent += `    <td>${counter++}.</td>\n`;
 
           // Repo column (String type).
-          const repoSpanHtml = `<span class="font-mono text-xs bg-gray-100 p-1 rounded">${item.repo}</span>`;
+          const repoSpanHtml = `<span class="font-mono text-xs bg-gray-100 dark:bg-slate-700 p-1 rounded">${item.repo}</span>`;
           tableContent += `    <td data-value="${item.repo}" data-col-type="string">${repoSpanHtml}</td>\n`;
 
           // Title column (String type, contains hyperlink).
-          const linkHtml = `<a href='${item.url}' target='_blank' class="text-blue-600 hover:text-blue-800 hover:underline">${item.title}</a>`;
+          const linkHtml = `<a href='${item.url}' target='_blank' class="text-blue-600 dark:text-blue-300 hover:text-blue-800 dark:hover:text-blue-200 hover:underline">${item.title}</a>`;
           tableContent += `    <td data-value="${safeTitle}" data-col-type="string">${linkHtml}</td>\n`;
 
           // Handle the remaining columns based on the contribution type.

--- a/scripts/utils/color-helpers.js
+++ b/scripts/utils/color-helpers.js
@@ -64,84 +64,318 @@ function generateColorVariants(hex) {
 }
 
 /**
- * Generates the final COLORS object with all opacity variants.
- * @param {object} palette The base hex colors
+ * Converts a hex color to HSL.
+ * @param {string} hex The hex color
+ * @returns {{h: number, s: number, l: number}} Hue (0-360), saturation/lightness (0-100)
  */
-function generateColorsObject(palette) {
-  const primaryVariants = generateColorVariants(palette.primary);
-  const primary900Variants = generateColorVariants(palette.primary900);
-  const neutralVariants = generateColorVariants(palette.neutral);
-  const successVariants = generateColorVariants(palette.success);
-  const mergedVariants = generateColorVariants(palette.merged);
-  const errorVariants = generateColorVariants(palette.error);
-  const textPrimaryVariants = generateColorVariants(palette.textPrimary);
-  const textSecondaryVariants = generateColorVariants(palette.textSecondary);
-  const textMutedVariants = generateColorVariants(palette.textMuted);
+function hexToHsl(hex) {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return { h: 0, s: 0, l: 0 };
 
-  return {
-    primary: primaryVariants,
-    primary900: primary900Variants,
-    gray: neutralVariants,
+  const r = rgb.r / 255;
+  const g = rgb.g / 255;
+  const b = rgb.b / 255;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const l = (max + min) / 2;
+  const d = max - min;
+
+  let h = 0;
+  let s = 0;
+
+  if (d !== 0) {
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    switch (max) {
+      case r:
+        h = ((g - b) / d) % 6;
+        break;
+      case g:
+        h = (b - r) / d + 2;
+        break;
+      default:
+        h = (r - g) / d + 4;
+    }
+    h *= 60;
+    if (h < 0) h += 360;
+  }
+
+  return { h, s: s * 100, l: l * 100 };
+}
+
+/**
+ * Converts HSL back to a hex color.
+ */
+function hslToHex(h, s, l) {
+  const hN = ((h % 360) + 360) % 360;
+  const sN = Math.min(100, Math.max(0, s)) / 100;
+  const lN = Math.min(100, Math.max(0, l)) / 100;
+
+  if (sN === 0) {
+    const v = Math.round(lN * 255);
+    const hex = v.toString(16).padStart(2, '0');
+    return `#${hex}${hex}${hex}`.toUpperCase();
+  }
+
+  const c = (1 - Math.abs(2 * lN - 1)) * sN;
+  const x = c * (1 - Math.abs(((hN / 60) % 2) - 1));
+  const m = lN - c / 2;
+
+  let [r, g, b] = [0, 0, 0];
+  if (hN < 60) [r, g, b] = [c, x, 0];
+  else if (hN < 120) [r, g, b] = [x, c, 0];
+  else if (hN < 180) [r, g, b] = [0, c, x];
+  else if (hN < 240) [r, g, b] = [0, x, c];
+  else if (hN < 300) [r, g, b] = [x, 0, c];
+  else [r, g, b] = [c, 0, x];
+
+  const toHex = (v) =>
+    Math.round((v + m) * 255)
+      .toString(16)
+      .padStart(2, '0');
+
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`.toUpperCase();
+}
+
+/**
+ * WCAG relative luminance of a hex color.
+ * @see https://www.w3.org/TR/WCAG21/#dfn-relative-luminance
+ */
+function relativeLuminance(hex) {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return 0;
+
+  const channel = (v) => {
+    const c = v / 255;
+    return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+  };
+
+  return 0.2126 * channel(rgb.r) + 0.7152 * channel(rgb.g) + 0.0722 * channel(rgb.b);
+}
+
+/**
+ * WCAG contrast ratio between two hex colors (1 to 21).
+ * @see https://www.w3.org/TR/WCAG21/#dfn-contrast-ratio
+ */
+function getContrastRatio(hex1, hex2) {
+  const l1 = relativeLuminance(hex1);
+  const l2 = relativeLuminance(hex2);
+  const lighter = Math.max(l1, l2);
+  const darker = Math.min(l1, l2);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+/**
+ * Lightens `hex` in HSL space (preserving its hue/saturation) until it
+ * reaches at least `minRatio` WCAG contrast against `bgHex`. This is what
+ * makes the dark-mode palette brand-agnostic: whatever `primary` color a
+ * fork configures, its dark-mode text variant is derived to stay readable
+ * on a dark background instead of relying on a hardcoded hex.
+ * @param {string} hex - The color to adjust (e.g. the light-mode brand color)
+ * @param {string} bgHex - The background it will be read against
+ * @param {number} minRatio - Minimum WCAG contrast ratio to reach (4.5 = AA for normal text)
+ * @returns {string} A hex color, lightened just enough to pass `minRatio`
+ */
+function ensureReadableOn(hex, bgHex, minRatio = 4.5) {
+  const { h, s, l } = hexToHsl(hex);
+  let lightness = l;
+  let candidate = hex;
+  let iterations = 0;
+
+  // Step lightness up in small increments rather than jumping straight to
+  // white, so the result still reads as "the brand color, brightened" and
+  // not as a generic off-white.
+  while (getContrastRatio(candidate, bgHex) < minRatio && lightness < 96 && iterations < 25) {
+    lightness += 4;
+    candidate = hslToHex(h, s, lightness);
+    iterations++;
+  }
+
+  return candidate;
+}
+
+const OPACITY_LEVELS = [5, 10, 15, 25, 50, 75, 100];
+
+/**
+ * Theme-color tokens that get a full opacity ladder (hex, rgb, and each
+ * OPACITY_LEVELS entry), keyed by their COLOR_PALETTE property name and
+ * the CSS variable prefix they should be declared under.
+ */
+const LADDERED_TOKENS = {
+  primary: 'c-primary',
+  primary900: 'c-primary900',
+  neutral: 'c-neutral',
+  success: 'c-success',
+  merged: 'c-merged',
+  error: 'c-error',
+  textPrimary: 'c-text-primary',
+  textSecondary: 'c-text-secondary',
+  textMuted: 'c-text-muted',
+};
+
+function varRef(name) {
+  return `var(--${name})`;
+}
+
+/**
+ * Builds the {hex, rgb, 5, 10, ...} shape for a token, but every leaf is a
+ * CSS var() reference instead of a literal color.
+ */
+function buildVarRefs(varName) {
+  const refs = { hex: varRef(`${varName}-hex`), rgb: varRef(`${varName}-rgb`) };
+  OPACITY_LEVELS.forEach((level) => {
+    refs[level] = varRef(`${varName}-${level}`);
+  });
+  return refs;
+}
+
+/**
+ * Appends the literal `--name: value;` declarations for one token's full
+ * opacity ladder into the given light/dark line buffers.
+ */
+function pushTokenDeclarations(varName, lightHex, darkHex, lightLines, darkLines) {
+  const light = generateColorVariants(lightHex);
+  const dark = generateColorVariants(darkHex);
+
+  lightLines.push(`--${varName}-hex: ${light.hex};`, `--${varName}-rgb: ${light.rgb};`);
+  darkLines.push(`--${varName}-hex: ${dark.hex};`, `--${varName}-rgb: ${dark.rgb};`);
+
+  OPACITY_LEVELS.forEach((level) => {
+    lightLines.push(`--${varName}-${level}: ${light[level]};`);
+    darkLines.push(`--${varName}-${level}: ${dark[level]};`);
+  });
+}
+
+/**
+ * Generates the COLORS object (every leaf is a CSS var() reference) plus the
+ * matching `:root { ... } html.dark { ... }` variable declarations needed to
+ * make those references resolve correctly in each theme.
+ *
+ * @param {object} lightPalette - hex colors for the light theme (COLOR_PALETTE shape)
+ * @param {object} darkPalette - hex colors for the dark theme (same shape)
+ * @param {object} flatTokens - single-value (non-laddered) tokens, e.g.
+ *   { 'c-bg-surface': { light: '#ffffff', dark: '#1e293b' } }
+ * @returns {{colors: object, cssVarsBlock: string}}
+ */
+function generateColorsObject(lightPalette, darkPalette, flatTokens = {}) {
+  const lightLines = [];
+  const darkLines = [];
+  const refs = {};
+
+  Object.entries(LADDERED_TOKENS).forEach(([key, varName]) => {
+    refs[key] = buildVarRefs(varName);
+    pushTokenDeclarations(varName, lightPalette[key], darkPalette[key], lightLines, darkLines);
+  });
+
+  const flatRefs = {};
+  Object.entries(flatTokens).forEach(([varName, { light, dark }]) => {
+    flatRefs[varName] = varRef(varName);
+    lightLines.push(`--${varName}: ${light};`);
+    darkLines.push(`--${varName}: ${dark};`);
+  });
+
+  const colors = {
+    primary: refs.primary,
+    primary900: refs.primary900,
+    // Same brand hue as `primary`, but lightened for dark mode so primary-
+    // colored TEXT/icons/accents stay readable on a dark page. Use this
+    // (not `primary`) for anything that ISN'T a solid fill with white text
+    // on top — those must keep `primary` fixed or they lose contrast.
+    primaryText: flatRefs['c-primary-text'] || refs.primary.rgb,
+    gray: refs.neutral,
     status: {
       green: {
-        bg: successVariants[10],
-        text: successVariants.rgb,
-        bgHex: successVariants.hex,
-        textRgb: successVariants.rgb,
+        bg: refs.success[10],
+        text: refs.success.rgb,
+        bgHex: refs.success.hex,
+        textRgb: refs.success.rgb,
       },
       purple: {
-        bg: mergedVariants[10],
-        text: mergedVariants.rgb,
-        bgHex: mergedVariants.hex,
-        textRgb: mergedVariants.rgb,
+        bg: refs.merged[10],
+        text: refs.merged.rgb,
+        bgHex: refs.merged.hex,
+        textRgb: refs.merged.rgb,
       },
       red: {
-        bg: errorVariants[10],
-        text: errorVariants.rgb,
-        bgHex: errorVariants.hex,
-        textRgb: errorVariants.rgb,
+        bg: refs.error[10],
+        text: refs.error.rgb,
+        bgHex: refs.error.hex,
+        textRgb: refs.error.rgb,
       },
       gray: {
-        bg: neutralVariants[10],
-        text: neutralVariants.rgb,
-        bgHex: neutralVariants.hex,
-        textRgb: neutralVariants.rgb,
+        bg: refs.neutral[10],
+        text: refs.neutral.rgb,
+        bgHex: refs.neutral.hex,
+        textRgb: refs.neutral.rgb,
       },
     },
     link: {
-      text: primaryVariants.rgb,
-      textHover: primaryVariants[75],
+      text: refs.primary.rgb,
+      textHover: refs.primary[75],
     },
     background: {
-      white: 'rgb(255, 255, 255)',
-      altRows: neutralVariants[5],
-      light: primaryVariants[5],
-      lightGray: neutralVariants[5],
+      white: flatRefs['c-bg-surface'] || 'rgb(255, 255, 255)',
+      altRows: refs.neutral[5],
+      light: refs.primary[5],
+      lightGray: refs.neutral[5],
     },
     border: {
-      default: neutralVariants[15],
-      section: neutralVariants[15],
-      bottomAccent: primaryVariants[15],
-      light: neutralVariants[10],
+      default: refs.neutral[15],
+      section: refs.neutral[15],
+      bottomAccent: refs.primary[15],
+      light: refs.neutral[10],
     },
     text: {
-      primary: textPrimaryVariants.rgb,
-      secondary: textSecondaryVariants.rgb,
-      muted: textMutedVariants.rgb,
+      primary: refs.textPrimary.rgb,
+      secondary: refs.textSecondary.rgb,
+      muted: refs.textMuted.rgb,
       white: 'rgb(255, 255, 255)',
     },
     sectionAccent: {
-      green: successVariants.rgb,
-      yellow: '#eab308',
-      indigo: primaryVariants.rgb,
+      green: refs.success.rgb,
+      yellow: flatRefs['c-accent-yellow'] || '#eab308',
+      indigo: refs.primary.rgb,
     },
     nav: {
-      bg: primaryVariants.rgb,
-      bgDark: primary900Variants.rgb,
-      bgHover: primaryVariants[75],
+      bg: refs.primary.rgb,
+      bgDark: refs.primary900.rgb,
+      bgHover: refs.primary[75],
       text: 'rgb(255, 255, 255)',
     },
   };
+
+  const cssVarsBlock = [
+    ':root {',
+    ...lightLines.map((line) => `  ${line}`),
+    '}',
+    'html.dark {',
+    ...darkLines.map((line) => `  ${line}`),
+    '}',
+  ].join('\n');
+
+  return { colors, cssVarsBlock };
+}
+
+/**
+ * Builds a `:root { ... } html.dark { ... }` declarations block for a flat
+ * set of single-value tokens that aren't part of the main palette/COLORS
+ * object (e.g. workbench status colors).
+ * @param {object} tokens - { varName: { light: value, dark: value } }
+ */
+function buildFlatVarsBlock(tokens) {
+  const lightLines = [];
+  const darkLines = [];
+  Object.entries(tokens).forEach(([varName, { light, dark }]) => {
+    lightLines.push(`--${varName}: ${light};`);
+    darkLines.push(`--${varName}: ${dark};`);
+  });
+  return [
+    ':root {',
+    ...lightLines.map((line) => `  ${line}`),
+    '}',
+    'html.dark {',
+    ...darkLines.map((line) => `  ${line}`),
+    '}',
+  ].join('\n');
 }
 
 /**
@@ -161,7 +395,13 @@ function getColorValue(color, fallback = '#000000') {
 module.exports = {
   hexToRgb,
   rgbToRgba,
+  hexToHsl,
+  hslToHex,
+  relativeLuminance,
+  getContrastRatio,
+  ensureReadableOn,
   generateColorVariants,
   generateColorsObject,
+  buildFlatVarsBlock,
   getColorValue,
 };


### PR DESCRIPTION
## Description

This PR holds below changes:

- Adds a class-based dark theme (Tailwind `@custom-variant`) across every generated page — landing, blog, glossary, reports, every quarterly report, and Community & Activity — with a unified navbar dropdown (sun/moon/monitor) to switch between **Light**, **Dark,** and **System**. System mode follows the OS preference live, with a FOUC-safe inline bootstrap script so there's no flash of the wrong theme on load.

- Replaces ad hoc hex literals and Tailwind color classes with a single generated `:root{...} html.dark{...}` CSS-variable layer, so every existing `COLORS.*` call site (navbar, footer, all 6 page generators, workbench status colors) automatically resolves to the right theme without per-call-site changes.

- Makes the color choices brand-agnostic: dark-mode "primary text" and accent colors are derived programmatically via HSL lightening checked against live WCAG AA contrast ratios (`ensureReadableOn`), not hand-picked hex guesses — so forks that configure a different brand `primary` color stay readable automatically.

- Fixes several pre-existing and dark-mode-specific readability issues found along the way: an invisible Active Workbench row divider, a "Draft" status badge that was silently rendering black text/border (undefined `COLORS.gray[*]` lookups), an over-saturated primary text color that was technically WAVE-passing but hard to read, and a handful of card borders that were either invisible (same shade as their parent card) or unintentionally too bright.