### PR TITLE
Add Last Interaction column and bot allowlist to Active Workbench

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ When the GitHub Action triggers the runner, the script executes a multi-stage pi
 #### 1. Data Fetching & Processing
 
 - **GitHub API (v3):** The script communicates with the GitHub REST API to collect activity: **Merged Pull Requests (PRs), Issues, Reviewed PRs, Co-authored PRs, and Collaborations**.
-- **Active Workbench:** Tracks ongoing maintenance tasks and open reviews. It intelligently categorizes tasks into dedicated tables, separating human-centric contributions from automated bot activity (e.g., Dependabot, Snyk) to streamline workflow visibility. Additionally, it supports dynamic repository exclusions to filter out specified organizations or projects.
+- **Active Workbench:** Tracks ongoing maintenance tasks and open reviews. It intelligently categorizes tasks into dedicated tables, separating human-centric contributions from automated bot activity (e.g., Dependabot, Snyk) to streamline workflow visibility, and shows the GitHub username of the relevant person in the "Last Interaction" column — the last actor whenever a task needs attention ("Take Action") or is awaiting someone else ("Watching"), or the reviewer who approved it ("Approved"). Additionally, it supports dynamic repository exclusions (`contents/repo-exclusions.js`) and a per-bot allowlist (`contents/allowed-bot.js`) to filter out specified organizations/projects or let trusted bots be treated as the last actor.
 - **Personal Technical Writing:**
     - **Automated Sync:** Fetches latest articles from **Dev.to** via their API.
     - **Curated Content:** Integrates long-form technical guides authored for freeCodeCamp, managed through manual metadata in `contents/fcc-articles.js`.
@@ -118,10 +118,11 @@ Manual data and preferences are managed within the `scripts/config/` and `conten
 - **Leadership Metadata:** Update `contents/leadership.js` to reflect roles and achievements.
 - **Article Metadata:** Update `contents/fcc-articles.js` to add new freeCodeCamp publications.
 - **Repo Exclusions:** Update `contents/repo-exclusions.js` to filter out specific organizations or repositories from the Active Workbench.
+- **Bot Allowlist:** The Active Workbench excludes bots (e.g., Dependabot, Snyk) from being treated as a "last actor" by default. If you rely on a bot that leaves actionable comments or reviews (e.g., an AI review bot), list its username in the `allowedBot` array in `contents/allowed-bot.js` to have it show up as the last actor (driving "Take Action" / "Watching" status and the "Last Interaction" column) instead of being grouped under bot activity.
 - **Theming:** Update `COLOR_PALETTE` in `scripts/config/constants.js` to change the look of the generated HTML reports.
 
 > [!TIP]
-> If you do not have articles on freeCodeCamp or do not wish to exclude any repositories from the Active Workbench, ensure the respective files (`contents/fcc-articles.js` or `contents/repo-exclusions.js`) export an empty array: `module.exports = [];`. This ensures the generator runs smoothly.
+> If you do not have articles on freeCodeCamp, do not wish to exclude any repositories from the Active Workbench, or do not want to allowlist any bots, ensure the respective files (`contents/fcc-articles.js`, `contents/repo-exclusions.js`, or `contents/allowed-bot.js`) export an empty array: `module.exports = [];`. This ensures the generator runs smoothly.
 
 ### 4. Deployment
 

--- a/contents/allowed-bot.js
+++ b/contents/allowed-bot.js
@@ -1,0 +1,19 @@
+module.exports = {
+  /**
+   * Allowed Bots List
+   * -----------------
+   * By default, the Active Workbench excludes bots (Dependabot, Snyk, etc.) from being
+   * treated as a "last actor" — their activity is grouped separately and never produces
+   * a "Take Action" status or shows up in the "Last Interaction" column.
+   *
+   * List a bot's username here (matched case-insensitively with .includes(), same as
+   * excludedRepos in repo-exclusions.js) to make an exception: that bot will be treated
+   * like a human actor in the Active Workbench only — it can show up as the last actor,
+   * drive "Take Action" / "Watching" status, and have its tasks excluded from the
+   * "Bot request review" bucket.
+   * Example: 'promptless' matches 'promptless[bot]' and 'promptless-for-oss[bot]'.
+   *
+   * Leave this empty if you want every bot excluded — this has no effect elsewhere.
+   */
+  allowedBot: ['promptless', 'promptless-for-oss'],
+};

--- a/scripts/api/fetch-ongoing-workbench.js
+++ b/scripts/api/fetch-ongoing-workbench.js
@@ -167,6 +167,7 @@ const formatTask = async (pr, status) => {
     isLastActorBot: activity.isLastActorBot,
     hasFormalReview: activity.hasFormalReview,
     reviewState: activity.reviewState,
+    approvedBy: activity.approvedBy,
     lastSubstantiveDate: activity.lastSubstantiveDate,
     author: pr.user.login,
   };

--- a/scripts/generators/html/community-html-generator.js
+++ b/scripts/generators/html/community-html-generator.js
@@ -17,6 +17,7 @@ const { getCommunityStyleCss } = require('../css/style-generator');
 const { getColorValue } = require('../../utils/color-helpers');
 const { sanitizeAttribute } = require('../../utils/html-helpers');
 const { getThemeInitScript, getThemeStyleVariant } = require('../../components/theme-init');
+const { isAllowedBotLogin, isBotLogin } = require('../../utils/bot-helpers');
 
 /**
  * Generates the Community & Activity HTML page.
@@ -109,6 +110,7 @@ async function createCommunityHtml(
 
   const isBot = (t) => {
     const username = typeof t.user === 'object' ? t.user?.login : t.user;
+    if (isAllowedBotLogin(username)) return false;
     const userStr = String(username || '').toLowerCase();
     const titleStr = String(t.title || '').toLowerCase();
     return (
@@ -129,14 +131,22 @@ async function createCommunityHtml(
 
     // 1. Common Logic: Approved & Stale
     if (task.reviewState === 'APPROVED' || task.status === 'APPROVED') {
-      return { ...WORKBENCH_BALL_STATUS.approved, child: '' };
+      return {
+        ...WORKBENCH_BALL_STATUS.approved,
+        child: '',
+        lastActorDisplay: task.approvedBy ? String(task.approvedBy).trim() : '',
+      };
     }
 
     const effectiveDate = task.lastSubstantiveDate || task.updatedAt;
     const diffDays = (now - new Date(effectiveDate)) / (1000 * 60 * 60 * 24);
 
     if (diffDays >= 21) {
-      return { ...WORKBENCH_BALL_STATUS.stale, child: `${Math.floor(diffDays)} days` };
+      return {
+        ...WORKBENCH_BALL_STATUS.stale,
+        child: `${Math.floor(diffDays)} days`,
+        lastActorDisplay: '',
+      };
     }
 
     // 2. Normalization
@@ -159,26 +169,33 @@ async function createCommunityHtml(
     // 3. Sub-label
     const isFormalReview = task.hasFormalReview === true;
     const childBase = isFormalReview ? 'Review' : 'Discussion';
-    const isBotActor = task.isLastActorBot || isBot({ user: lastActor, title: '' });
+    const isBotActor =
+      !isAllowedBotLogin(lastActor) && (task.isLastActorBot || isBotLogin(lastActor));
     const childStatus = isBotActor ? `${childBase} + BOT` : childBase;
+
+    // Only surface the actor's username when there's an action to track (Take Action / Watching).
+    const lastActorDisplay = String(rawLastActor || '').trim();
 
     // 4. Branching Logic by Role
 
     if (role === 'reviewer') {
       // SCENARIO: You are reviewing someone else's PR
-      if (isMe) return { ...WORKBENCH_BALL_STATUS.waiting, child: childStatus };
-      if (isAuthor) return { ...WORKBENCH_BALL_STATUS.takeAction, child: childStatus };
-      return { ...WORKBENCH_BALL_STATUS.watching, child: childStatus };
+      if (isMe)
+        return { ...WORKBENCH_BALL_STATUS.waiting, child: childStatus, lastActorDisplay: '' };
+      if (isAuthor)
+        return { ...WORKBENCH_BALL_STATUS.takeAction, child: childStatus, lastActorDisplay };
+      return { ...WORKBENCH_BALL_STATUS.watching, child: childStatus, lastActorDisplay };
     } else {
       // SCENARIO: You are the Author or Co-Author (Ongoing / Co-authored)
-      if (isMe) return { ...WORKBENCH_BALL_STATUS.waiting, child: childStatus };
+      if (isMe)
+        return { ...WORKBENCH_BALL_STATUS.waiting, child: childStatus, lastActorDisplay: '' };
 
       // In ongoing and co-authored PR, "Not Me" is treated as "Take Action"
       if (!isMe && !isBotActor) {
-        return { ...WORKBENCH_BALL_STATUS.takeAction, child: childStatus };
+        return { ...WORKBENCH_BALL_STATUS.takeAction, child: childStatus, lastActorDisplay };
       }
 
-      return { ...WORKBENCH_BALL_STATUS.watching, child: childStatus };
+      return { ...WORKBENCH_BALL_STATUS.watching, child: childStatus, lastActorDisplay };
     }
   }
 
@@ -321,12 +338,21 @@ async function createCommunityHtml(
             `;
           }
 
+          const lastInteractionColumnHtml = ballStatus
+            ? dedent`
+              <td class="px-6 py-4 vertical-align-top w-[160px]">
+                <span class="text-sm text-slate-500 dark:text-slate-400">${ballStatus.lastActorDisplay || ''}</span>
+              </td>
+            `
+            : '';
+
           return dedent`
-            <tr class="table-row-hover border-b border-slate-100 dark:border-slate-700 last:border-0 transition-colors" 
-                data-status="${ballStatus?.label.toLowerCase() || ''}" 
+            <tr class="table-row-hover border-b border-slate-100 dark:border-slate-700 last:border-0 transition-colors"
+                data-status="${ballStatus?.label.toLowerCase() || ''}"
                 data-date="${subDate}"
                 data-repo="${repoName.toLowerCase()}">
               ${statusColumnHtml}
+              ${lastInteractionColumnHtml}
               <td class="px-6 py-4 vertical-align-top ${ballStatus ? 'w-1/4' : 'w-1/3'}">
                 <div class="flex flex-col items-start">
                   <span class="text-sm font-semibold text-slate-500 dark:text-slate-400">${repoName}</span>
@@ -360,6 +386,12 @@ async function createCommunityHtml(
             </th>`
           : '';
 
+      const tableHeaderLastInteractionHtml =
+        type === 'ongoing'
+          ? dedent`
+            <th scope="col" class="px-6 py-3 text-left text-xs font-black text-slate-700 dark:text-slate-300 uppercase tracking-widest">Last Interaction</th>`
+          : '';
+
       sectionContent = dedent`
         <div class="overflow-x-auto">
           <div class="min-w-[600px]">
@@ -367,6 +399,7 @@ async function createCommunityHtml(
               <thead class="bg-slate-50/80 dark:bg-slate-800/60 border-b border-slate-100 dark:border-slate-700">
                 <tr>
                   ${tableHeaderStatusHtml}
+                  ${tableHeaderLastInteractionHtml}
                   <th scope="col" class="px-6 py-3 text-left">
                     <button type="button" 
                             class="flex items-center text-xs font-black text-slate-700 dark:text-slate-300 uppercase tracking-widest cursor-pointer group/sort focus:outline-none focus:ring-2 focus:ring-indigo-500 rounded px-1"

--- a/scripts/generators/markdown/community-markdown-generator.js
+++ b/scripts/generators/markdown/community-markdown-generator.js
@@ -3,6 +3,7 @@ const path = require('path');
 const { BASE_DIR, GITHUB_USERNAME } = require('../../config/config');
 const { WORKBENCH_SUCCESS_MESSAGES } = require('../../metadata/workbench-messages');
 const { WORKBENCH_BALL_STATUS } = require('../../config/constants');
+const { isAllowedBotLogin, isBotLogin } = require('../../utils/bot-helpers');
 
 /**
  * Maps ball status to GitHub-friendly indicators (using Shields.io for consistency).
@@ -15,6 +16,7 @@ function getBallTrackingBadge(task, role = 'owner') {
     return {
       badge: `<img src="https://img.shields.io/badge/APPROVED-15803d?style=flat-square" alt="Approved">`,
       child: ``,
+      lastActorDisplay: task.approvedBy ? String(task.approvedBy).trim() : '',
     };
   }
 
@@ -28,22 +30,31 @@ function getBallTrackingBadge(task, role = 'owner') {
     return {
       badge: `<img src="https://img.shields.io/badge/IDLE-334155?style=flat-square" alt="Idle">`,
       child: `<br><sub>${dayCount} days</sub>`,
+      lastActorDisplay: '',
     };
   }
 
   // 3. Normalization with Fallback (Matches HTML logic)
-  const rawLastActor = task.lastActor || (task.user && typeof task.user === 'object' ? task.user.login : task.user);
-  
-  const lastActor = String(rawLastActor || '').toLowerCase().trim();
-  const prAuthor = String(task.author || '').toLowerCase().trim();
-  const me = String(GITHUB_USERNAME || '').toLowerCase().trim();
+  const rawLastActor =
+    task.lastActor || (task.user && typeof task.user === 'object' ? task.user.login : task.user);
+
+  const lastActor = String(rawLastActor || '')
+    .toLowerCase()
+    .trim();
+  const prAuthor = String(task.author || '')
+    .toLowerCase()
+    .trim();
+  const me = String(GITHUB_USERNAME || '')
+    .toLowerCase()
+    .trim();
 
   const isMe = lastActor === me;
   const isAuthor = lastActor === prAuthor;
 
   // 4. Sub-label logic
   let child = task.hasFormalReview ? 'Review' : 'Discussion';
-  const isBotActor = task.isLastActorBot || /\[bot\]$|dependabot|snyk/i.test(lastActor);
+  const isBotActor =
+    !isAllowedBotLogin(lastActor) && (task.isLastActorBot || isBotLogin(lastActor));
   if (isBotActor) child += ' + BOT';
 
   // 5. Branching Logic by Role
@@ -68,9 +79,14 @@ function getBallTrackingBadge(task, role = 'owner') {
   const color = colorMap[statusKey] || '334155';
   const label = config.label.toUpperCase().replace(/ /g, '%20');
 
+  // Only surface the actor's username when there's an action to track (Take Action / Watching).
+  const lastActorDisplay =
+    statusKey === 'takeAction' || statusKey === 'watching' ? String(rawLastActor || '').trim() : '';
+
   return {
     badge: `<img src="https://img.shields.io/badge/${label}-${color}?style=flat-square" alt="${config.label}">`,
     child: `<br><sub>${child}</sub>`,
+    lastActorDisplay,
   };
 }
 
@@ -109,6 +125,7 @@ async function createCommunityMarkdown(
 
   const isBot = (t) => {
     const username = typeof t.user === 'object' ? t.user?.login : t.user;
+    if (isAllowedBotLogin(username)) return false;
     const userStr = String(username || '').toLowerCase();
     const titleStr = String(t.title || '').toLowerCase();
     return (
@@ -160,8 +177,8 @@ async function createCommunityMarkdown(
       section += `> ***${randomMsg}***\n`;
     } else {
       if (hasStatus) {
-        section += `| Status | Repository | Task |\n`;
-        section += `| :--- | :--- | :--- |\n`;
+        section += `| Status | Last Interaction | Repository | Task |\n`;
+        section += `| :--- | :--- | :--- | :--- |\n`;
       } else {
         section += `| Repository | Task |\n`;
         section += `| :--- | :--- |\n`;
@@ -180,7 +197,8 @@ async function createCommunityMarkdown(
           if (hasStatus) {
             const ballData = getBallTrackingBadge(task, type);
             const statusCell = ballData ? `${ballData.badge}${ballData.child}` : `—`;
-            section += `| ${statusCell} | **${repoName}**${extraBadge} | [${task.title}](${task.url}) |\n`;
+            const lastInteractionCell = ballData?.lastActorDisplay || '';
+            section += `| ${statusCell} | ${lastInteractionCell} | **${repoName}**${extraBadge} | [${task.title}](${task.url}) |\n`;
           } else {
             section += `| **${repoName}**${extraBadge} | [${task.title}](${task.url}) |\n`;
           }

--- a/scripts/utils/bot-helpers.js
+++ b/scripts/utils/bot-helpers.js
@@ -1,0 +1,33 @@
+/**
+ * SHARED: Bot detection with a dynamic allowlist.
+ * The Active Workbench excludes bots by default; `allowedBot` entries in
+ * contents/allowed-bot.js are treated as human actors instead (see that file for why).
+ */
+function loadAllowedBots() {
+  try {
+    const allowedBotConfig = require('../../contents/allowed-bot');
+    return (allowedBotConfig.allowedBot || []).map((b) => String(b).toLowerCase());
+  } catch (e) {
+    return [];
+  }
+}
+
+const ALLOWED_BOTS = loadAllowedBots();
+
+function isAllowedBotLogin(login) {
+  const lower = String(login || '').toLowerCase();
+  if (!lower) return false;
+  return ALLOWED_BOTS.some((allowed) => lower.includes(allowed));
+}
+
+/**
+ * @param {string} login
+ * @param {string} [type] - GitHub actor/user `type` field, e.g. 'Bot'.
+ */
+function isBotLogin(login, type) {
+  const lower = String(login || '').toLowerCase();
+  if (isAllowedBotLogin(lower)) return false;
+  return type === 'Bot' || /\[bot\]$|dependabot|snyk/i.test(lower);
+}
+
+module.exports = { isAllowedBotLogin, isBotLogin };

--- a/scripts/utils/github-helpers.js
+++ b/scripts/utils/github-helpers.js
@@ -1,3 +1,5 @@
+const { isBotLogin } = require('./bot-helpers');
+
 /**
  * HELPER: Extracts linked issue numbers from PR descriptions.
  */
@@ -22,6 +24,7 @@ async function getPrActivityMeta(owner, repo, prNumber, axiosInstance, prMainUpd
     isLastActorBot: false,
     hasFormalReview: false,
     reviewState: null,
+    approvedBy: null,
     lastSubstantiveDate: prMainUpdatedAt,
   };
 
@@ -58,8 +61,7 @@ async function getPrActivityMeta(owner, repo, prNumber, axiosInstance, prMainUpd
 
     const lastEvent = substantiveEvents[substantiveEvents.length - 1];
     const lastActor = lastEvent?.actor?.login || lastEvent?.user?.login || lastEvent?.author?.login;
-    const isLastActorBot =
-      lastEvent?.actor?.type === 'Bot' || /\[bot\]$|dependabot|snyk/i.test(lastActor || '');
+    const isLastActorBot = isBotLogin(lastActor, lastEvent?.actor?.type);
 
     let timestamps = [];
     substantiveEvents.forEach((e) => {
@@ -82,11 +84,15 @@ async function getPrActivityMeta(owner, repo, prNumber, axiosInstance, prMainUpd
       .filter((r) => r.state !== 'COMMENTED')
       .sort((a, b) => new Date(b.submitted_at) - new Date(a.submitted_at))[0];
 
+    const approvedBy =
+      latestReview && latestReview.state === 'APPROVED' ? latestReview.user?.login || null : null;
+
     fallbackActivity = {
       lastActor,
       isLastActorBot,
       hasFormalReview: reviews.length > 0,
       reviewState: latestReview ? latestReview.state : null,
+      approvedBy,
       lastSubstantiveDate,
     };
 
@@ -104,7 +110,7 @@ async function getPrActivityMeta(owner, repo, prNumber, axiosInstance, prMainUpd
         timelineItems.push({
           date: new Date(c.created_at),
           login: c.user.login,
-          isBot: c.user.type === 'Bot' || /\[bot\]$|dependabot|snyk/i.test(c.user.login),
+          isBot: isBotLogin(c.user.login, c.user.type),
         });
       }
     });
@@ -114,7 +120,7 @@ async function getPrActivityMeta(owner, repo, prNumber, axiosInstance, prMainUpd
         timelineItems.push({
           date: new Date(c.created_at),
           login: c.user.login,
-          isBot: c.user.type === 'Bot' || /\[bot\]$|dependabot|snyk/i.test(c.user.login),
+          isBot: isBotLogin(c.user.login, c.user.type),
         });
       }
     });
@@ -124,7 +130,7 @@ async function getPrActivityMeta(owner, repo, prNumber, axiosInstance, prMainUpd
         timelineItems.push({
           date: new Date(r.submitted_at),
           login: r.user.login,
-          isBot: r.user.type === 'Bot' || /\[bot\]$|dependabot|snyk/i.test(r.user.login),
+          isBot: isBotLogin(r.user.login, r.user.type),
         });
       }
     });
@@ -138,6 +144,7 @@ async function getPrActivityMeta(owner, repo, prNumber, axiosInstance, prMainUpd
         isLastActorBot: latest.isBot,
         hasFormalReview: fallbackActivity.hasFormalReview || explicitReviewsResp.data.length > 0,
         reviewState: fallbackActivity.reviewState,
+        approvedBy: fallbackActivity.approvedBy,
         lastSubstantiveDate: latest.date.toISOString(),
       };
     }


### PR DESCRIPTION
## Summary
- Add a "Last Interaction" column to the Active Workbench tables (Ongoing PRs, Co-authored PRs, Review in progress) in both the markdown and HTML Community & Activity reports. It shows the GitHub username of the last actor for "Take Action" / "Watching" status, and the reviewer's username for "Approved" status. Other statuses (Waiting, Idle) leave it blank.
- Bots are excluded from being treated as the "last actor" by default (existing behavior). Add `contents/allowed-bot.js` so specific bots (e.g. `promptless`, `promptless-for-oss`) can be opted in to be treated as a human actor in the Active Workbench only — this is fully dynamic, so anyone using this project who doesn't configure the file is unaffected.
- Update README to document the new column and the bot allowlist file.

## Test plan
- [x] Verified via scripted smoke tests (not a live `npm start`, since that needs `GITHUB_TOKEN`) that:
  - An allowlisted bot as last actor produces "Take Action"/"Watching" with its username shown, no "+ BOT" suffix.
  - A non-allowlisted bot (e.g. dependabot) as last actor keeps the "+ BOT" suffix and existing "Watching" fallback behavior.
  - A PR authored by an allowlisted bot is excluded from the "Bot request review" bucket; one authored by dependabot still lands there.
  - An "Approved" task shows the approving reviewer's username in the new column.
- [x] `node --check` on all touched files.