### PR TITLE
Feat: Migrate hosting from Netlify to GitHub Pages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -1,0 +1,47 @@
+name: Deploy to GitHub Pages
+
+# Optional: only relevant if you're hosting this portfolio on GitHub Pages.
+# The content-generation workflow (update-contributions.yml) only ever
+# commits plain HTML/Markdown to `main` — it has no opinion on hosting.
+# If you're using Netlify, Vercel, or another static host instead, delete
+# this file; your host will pick up changes from `main` on its own.
+
+on:
+  workflow_run:
+    workflows: ['Update Contributions']
+    types: [completed]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: contributions/html-generated/
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/update-contributions.yml
+++ b/.github/workflows/update-contributions.yml
@@ -69,20 +69,8 @@ jobs:
                 MSG="docs: Daily contributions update"
             fi
 
-            if [ "${{ github.repository }}" = "adiati98/oss-portfolio" ]; then
-                echo "Applying optimized deployment and updating live branch."
-                # 1. Update main branch
-                git commit -m "$MSG [skip ci]"
-                git push origin main
-                
-                # 2. Update live branch
-                git commit --amend -m "$MSG"
-                git push origin main:live --force
-            else
-                echo "Executing deployment update."
-                git commit -m "$MSG"
-                git push origin main
-            fi
+            git commit -m "$MSG"
+            git push origin main
 
             echo "pushed=true" >> $GITHUB_OUTPUT 
           else

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Manual data and preferences are managed within the `scripts/config/` and `conten
 
 ### 4. Deployment
 
-This project is host-agnostic. The content-generation workflow only ever commits plain HTML to `main` — it has no opinion on hosting. Connect your repository to a service like Netlify, Vercel, or GitHub Pages to deploy your portfolio.
+This project is host-agnostic. Connect your repository to a service like Netlify, Vercel, or GitHub Pages to deploy your portfolio.
 
 **Using GitHub Pages:** This repo ships a ready-to-use workflow, `.github/workflows/deploy-gh-pages.yml`, that publishes `contributions/html-generated/` after each content update. To use it:
 

--- a/README.md
+++ b/README.md
@@ -126,4 +126,11 @@ Manual data and preferences are managed within the `scripts/config/` and `conten
 
 ### 4. Deployment
 
-This project is host-agnostic. Connect your repository to a service like Netlify, Vercel, or GitHub Pages to deploy your portfolio.
+This project is host-agnostic. The content-generation workflow only ever commits plain HTML to `main` — it has no opinion on hosting. Connect your repository to a service like Netlify, Vercel, or GitHub Pages to deploy your portfolio.
+
+**Using GitHub Pages:** This repo ships a ready-to-use workflow, `.github/workflows/deploy-gh-pages.yml`, that publishes `contributions/html-generated/` after each content update. To use it:
+
+1. Go to **Settings → Pages** in your repository and set **Source** to **GitHub Actions**.
+2. That's it — the workflow deploys automatically whenever `Update Contributions` finishes (or run it manually via **Actions → Deploy to GitHub Pages → Run workflow**).
+
+Prefer a different host? Just delete `deploy-gh-pages.yml` and connect your repo to Netlify, Vercel, etc. as usual.

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,0 @@
-[build]
-  command = "exit 0"
-  publish = "contributions/html-generated/"
-  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF data/"
-
-[context.production]
-  ignore = "exit 0"


### PR DESCRIPTION
## Summary
- Add `deploy-gh-pages.yml`, an optional GitHub Actions workflow that publishes `contributions/html-generated/` to GitHub Pages, triggered after `Update Contributions` completes (or manually via `workflow_dispatch`)
- Simplify `update-contributions.yml`: remove the `adiati98/oss-portfolio`-only branch that amended and force-pushed to a separate `live` branch just to give Netlify a clean deploy target — every repo (including this one) now just pushes to `main`, same as forks always did
- Add `.github/dependabot.yml` to track `npm` and `github-actions` dependency updates
- Remove `netlify.toml` now that Netlify is no longer the deploy target
- Update README's Deployment section to document the GitHub Pages workflow while keeping the project explicitly host-agnostic (delete the workflow file if you prefer another host)

## Why
Managing two branches with different push/commit conventions (`main` vs. force-pushed `live`) was the source of friction being solved here. Deploying via GitHub Actions lets content generation and deployment both live on `main`.

## Test plan
- [x] Validated both workflow YAML files parse correctly
- [x] Confirmed `update-contributions.yml`'s simplified push logic matches the code path forks have always used
- [ ] GitHub only registers `workflow_dispatch`/`workflow_run` for workflow files that exist on the default branch, so `deploy-gh-pages.yml` can't be live-tested until this merges — plan to manually trigger it right after merge to confirm the Pages deploy succeeds
- [ ] Confirm the next `Update Contributions` run (or a manual trigger on `main`) still pushes correctly with the simplified logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)