### PR TITLE
Fix contributions total double-count + allow manual full sync

### DIFF
--- a/.github/workflows/update-contributions.yml
+++ b/.github/workflows/update-contributions.yml
@@ -7,6 +7,11 @@ on:
     # Daily update at 01:00 UTC
     - cron: '0 1 * * *'
   workflow_dispatch:
+    inputs:
+      full_sync:
+        description: 'Run a full sync (re-verify the entire history) instead of the daily incremental update'
+        type: boolean
+        default: false
 
 jobs:
   run_scheduled_update:
@@ -48,8 +53,12 @@ jobs:
             done
           }
 
-          if [ "$SCHEDULE" = "1 0 1 * *" ]; then
-            echo "Running monthly full sync..."
+          # A full sync runs on the monthly schedule OR when manually
+          # triggered from the Actions UI with the full_sync input checked.
+          # github.event.schedule is empty for workflow_dispatch runs, so the
+          # input is the only way to force a full sync manually.
+          if [ "$SCHEDULE" = "1 0 1 * *" ] || [ "$FULL_SYNC" = "true" ]; then
+            echo "Running full sync..."
             # FULL_RESYNC re-crawls the entire history from live GitHub data
             # instead of trusting caches — but deliberately does NOT delete
             # all-contributions.json first. That file is the fallback the
@@ -75,6 +84,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}
           SCHEDULE: ${{ github.event.schedule }}
+          FULL_SYNC: ${{ inputs.full_sync }}
 
       - name: Format generated files
         run: npm run format
@@ -88,9 +98,11 @@ jobs:
           git add contributions/markdown-generated/ contributions/html-generated/ data/
 
           if ! git diff --staged --quiet; then
-            # Determine the commit message based on schedule
+            # Determine the commit message based on the sync type
             if [ "$SCHEDULE" = "1 0 1 * *" ]; then
                 MSG="docs: Monthly full sync"
+            elif [ "$FULL_SYNC" = "true" ]; then
+                MSG="docs: Full sync"
             else
                 MSG="docs: Daily contributions update"
             fi
@@ -105,3 +117,4 @@ jobs:
           fi
         env:
           SCHEDULE: ${{ github.event.schedule }}
+          FULL_SYNC: ${{ inputs.full_sync }}

--- a/scripts/src/main.js
+++ b/scripts/src/main.js
@@ -412,14 +412,31 @@ async function main() {
     const quarterlyHtmlLinks = await writeHtmlFiles(grouped);
 
     // 3. Generate README and glossary files (Markdown)
-    // failedFetchCache.size: confirmed-403 PRs (e.g. an org needing SSO
-    // authorization we don't have) are real contributions we just couldn't
-    // fetch enough detail on to categorize — see failed-fetch-cache.js.
-    await createStatsReadme(finalContributions, articles, failedFetchCache.size);
+    // Confirmed-403 PRs (e.g. a public repo in an org that enforces SSO we
+    // aren't authorized for) are real contributions we couldn't fetch enough
+    // detail on to categorize — see failed-fetch-cache.js — so they belong in
+    // the headline total. But some of them are ALSO already present in a
+    // category: the historical pipeline pushes them into `collaborations` with
+    // a null date as a graceful fallback. Adding failedFetchCache.size wholesale
+    // would double-count those, so we add only the entries not already
+    // categorized. This also keeps the headline stable if a run's in-memory
+    // failed-fetch set is transiently larger than what ends up persisted.
+    const categorizedUrls = new Set();
+    for (const type of Object.keys(finalContributions)) {
+      if (!Array.isArray(finalContributions[type])) continue;
+      for (const item of finalContributions[type]) {
+        if (item?.url) categorizedUrls.add(item.url.replace(/\/$/, '').toLowerCase());
+      }
+    }
+    const uncountedFailedFetch = [...failedFetchCache.keys()].filter(
+      (url) => !categorizedUrls.has(url.replace(/\/$/, '').toLowerCase())
+    ).length;
+
+    await createStatsReadme(finalContributions, articles, uncountedFailedFetch);
 
     // 4. Generate landing page (index.html)
     console.log('Generating landing page...');
-    await createIndexHtml(finalContributions, articles, failedFetchCache.size);
+    await createIndexHtml(finalContributions, articles, uncountedFailedFetch);
 
     // 5. Generate the Glossary page
     console.log('Generating Glossary...');


### PR DESCRIPTION
Follow-up to #149. Two small, independent changes.

## 1. Stop double-counting failed-fetch PRs (`scripts/src/main.js`)

The headline **Total Contributions** was computed as `grandTotal + failedFetchCache.size`. But some confirmed-403 PRs (e.g. `shesharpnl/*`, which sits behind org SSO we aren't authorized for) are *also* already present in a category — the historical pipeline pushes them into `collaborations` with a null date as a graceful fallback. Adding the full failed-fetch count on top counted those twice.

Now `main.js` builds a set of every already-categorized URL and adds **only** the failed-fetch entries not already in it. Every real contribution — including the 403 PRs — is still counted exactly once.

On the current committed data this corrects the total from an inflated **2746** to **2740** (verified by running the real generators against `all-contributions.json`). It also incidentally makes the headline robust: if a run's in-memory failed-fetch set is transiently larger than what ends up persisted, the extra entries are almost always already-categorized and get filtered out, so they can't leak into the headline (which is what produced the one-off 2765 in a prior run).

## 2. Allow manual full sync from the Actions UI (`.github/workflows/update-contributions.yml`)

`github.event.schedule` is empty for `workflow_dispatch` runs, so a manually triggered run always took the daily/incremental path — there was no way to force a full sync from the UI. Added a boolean `full_sync` input; when checked, the run takes the full-sync path (same as the monthly cron), independent of the schedule.

## Testing
- Dedup verified end-to-end through the real report generators on the committed data → **2740**.
- Workflow YAML validated.
- Full sync will be exercised directly on GitHub via the new `full_sync` input after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)