### PR TITLE
Fix GitHub Pages always deploying one commit behind

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -32,7 +32,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
+          # Check out main by name so this always deploys the commit "Update
+          # Contributions" just pushed, not the commit that was HEAD before it ran.
+          ref: main
 
       - name: Setup Pages
         uses: actions/configure-pages@v5


### PR DESCRIPTION
## Bug

Every deploy of the live site was showing data from the commit *before* the "Update Contributions" run that triggered it, not the commit it actually pushed.

Confirmed directly: after merging #150 and running a manual full sync, the repo's `main` correctly settled on **2744** total contributions, but the live GitHub Pages site kept showing **2765** (the number from the run before). Checked the deploy run's actual checkout log — it pulled `605523e0` (HEAD *before* the full-sync run started), while the full sync had already pushed `9fea4e26` (HEAD *after* it finished) by the time the deploy fired.

## Root cause

`deploy-gh-pages.yml` checked out `github.event.workflow_run.head_sha`. That value is fixed at the moment the triggering run *starts* — but "Update Contributions" commits and pushes its own result as its last step, so `head_sha` is always one commit stale by the time `workflow_run` fires with `conclusion: success`.

## Fix

Check out `main` by name instead of pinning a sha. By the time this workflow runs, the triggering workflow's push has already landed on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)