### PR TITLE
Fix: contribution total double-count, stale workbench PRs, and API fetch resilience

### DIFF
--- a/scripts/api/fetch-historical-contributions.js
+++ b/scripts/api/fetch-historical-contributions.js
@@ -3,7 +3,11 @@ const axios = require('axios');
 
 // Import configuration
 const { GITHUB_USERNAME, BASE_URL } = require('../config/config');
-const { attachRateLimitLogger, withRateLimitRetry } = require('../utils/http-helpers');
+const {
+  attachRateLimitLogger,
+  withRateLimitRetry,
+  keepAliveAgent,
+} = require('../utils/http-helpers');
 
 /**
  * Fetches the year the user joined GitHub to set the baseline for discovery.
@@ -38,6 +42,8 @@ async function fetchContributions(
   const axiosInstance = attachRateLimitLogger(
     axios.create({
       baseURL: BASE_URL,
+      httpsAgent: keepAliveAgent,
+      timeout: 30000,
       headers: {
         Authorization: `token ${token}`,
         Accept: 'application/vnd.github.v3+json',
@@ -99,14 +105,12 @@ async function fetchContributions(
     logState.hasLogged = true;
   }
 
-  // GitHub's search API allows only 30 requests/minute — the year loop below
-  // fires 7 distinct search queries per year with nothing in between, which
-  // alone exceeds that after just a few years. This tracks the last search
-  // call process-wide (not just between pages of one query) so every call
-  // waits out a minimum gap first, instead of only pacing within a single
-  // query's own pagination.
-  let lastSearchCallAt = 0;
-  const MIN_SEARCH_INTERVAL_MS = 2000;
+  // Pace only BETWEEN pages of a single query, not before every query. Most
+  // year queries return a single page and so incur no delay at all; the
+  // withRateLimitRetry wrapper below already absorbs the occasional secondary
+  // rate-limit with backoff. A blanket pre-emptive gap before every call just
+  // added minutes of fixed waiting to a run that is otherwise sequential.
+  const INTER_PAGE_DELAY_MS = 1000;
 
   /**
    * A helper function to fetch all pages for a given search query.
@@ -115,12 +119,6 @@ async function fetchContributions(
     let results = [];
     let page = 1;
     while (true) {
-      const wait = MIN_SEARCH_INTERVAL_MS - (Date.now() - lastSearchCallAt);
-      if (wait > 0) {
-        await new Promise((resolve) => setTimeout(resolve, wait));
-      }
-      lastSearchCallAt = Date.now();
-
       const response = await withRateLimitRetry(
         () => axiosInstance.get(`/search/issues?q=${query}&per_page=100&page=${page}`),
         { label: `search p${page}`, assumeRateLimit: true }
@@ -130,6 +128,7 @@ async function fetchContributions(
       const linkHeader = response.headers.link;
       if (linkHeader && linkHeader.includes('rel="next"')) {
         page++;
+        await new Promise((resolve) => setTimeout(resolve, INTER_PAGE_DELAY_MS));
       } else {
         break;
       }

--- a/scripts/api/fetch-ongoing-workbench.js
+++ b/scripts/api/fetch-ongoing-workbench.js
@@ -6,6 +6,7 @@ const {
   attachRateLimitLogger,
   withRateLimitRetry,
   mapWithConcurrency,
+  keepAliveAgent,
 } = require('../utils/http-helpers');
 
 /**
@@ -17,6 +18,8 @@ if (!token) throw new Error('GITHUB_TOKEN is not set.');
 const axiosInstance = attachRateLimitLogger(
   axios.create({
     baseURL: BASE_URL,
+    httpsAgent: keepAliveAgent,
+    timeout: 30000,
     headers: {
       Authorization: `token ${token}`,
       Accept: 'application/vnd.github.v3+json',
@@ -27,9 +30,13 @@ const axiosInstance = attachRateLimitLogger(
 // How many PRs to process concurrently per fetcher. Bounded (rather than
 // unlimited Promise.all) so we don't fire hundreds of simultaneous requests
 // at GitHub's secondary rate limiter when a user has thousands of open PRs
-// to track — high enough to actually cut wall time, low enough to stay well
-// under the abuse-detection threshold.
-const PR_CONCURRENCY = 6;
+// to track. Each PR's activity fetch already fans out to 4 parallel calls, so
+// the real peak is PR_CONCURRENCY * 4 sockets — kept at 3 (=> ~12 in flight,
+// further capped by the agent's maxSockets) to stay under GitHub's
+// abuse-detection threshold. Going higher (6 => ~24) reliably tripped
+// secondary rate limits and ECONNRESET storms that cost far more in backoff
+// than the extra parallelism saved.
+const PR_CONCURRENCY = 3;
 
 /**
  * SHARED UTILITY: searchAll
@@ -160,9 +167,13 @@ async function getFirstCommitDetails(
     // authorship — mark it as unknown rather than a confirmed "no", so
     // callers don't drop a PR just because we couldn't check it this run.
     if (err.isPermanent403 && failedFetchCache) {
+      // Stamp with the PR's own updated_at, not the run time. This 403 will be
+      // rendered as a ghost row in the historical reports, and it belongs in
+      // the quarter it was actually active in (e.g. a 2023 PR), not in
+      // whatever quarter this daily run happens to fall in.
       failedFetchCache.set(prUrl, {
         status: '403 Forbidden',
-        timestamp: new Date().toISOString(),
+        timestamp: prUpdatedAt || new Date().toISOString(),
         title: prTitle || 'Unknown Title',
       });
     }
@@ -392,12 +403,14 @@ async function fetchOngoingCoAuthoredPrs(commitCache, activityCache, failedFetch
       pr.title
     );
 
-    // A confirmed commit by the user -> definitely co-authored. A fetch we
-    // couldn't complete (fetchFailed, e.g. a permanently-403ing repo) -> the
-    // search query already confirms the user commented on this PR, so keep
-    // it listed rather than silently dropping a real contribution just
-    // because we couldn't verify commit-level detail.
-    if (commitDetails?.firstCommitDate || commitDetails?.fetchFailed) {
+    // Only a confirmed commit by the user keeps a PR on the Active Workbench.
+    // A fetch we couldn't complete (fetchFailed, e.g. a permanently-403ing
+    // repo) is NOT kept here: those are almost always old, dormant PRs we
+    // can't verify, and the Active Workbench is for current tasks only. The
+    // 403 is still recorded (getFirstCommitDetails wrote it to the
+    // failed-fetch cache), so it still surfaces in the historical reports as
+    // a ghost row — just not as an active task.
+    if (commitDetails?.firstCommitDate) {
       const formatted = await formatTask(pr, 'Co-authoring', activityCache, failedFetchCache);
       formatted.body = pr.body;
       return formatted;

--- a/scripts/utils/contributions-groupers.js
+++ b/scripts/utils/contributions-groupers.js
@@ -9,38 +9,41 @@ const path = require('path');
 function groupContributionsByQuarter(contributions) {
   const grouped = {};
 
-  // --- Inject 403 data ---
-  const logPath = path.join(process.cwd(), 'data', 'failed-fetch.json');
-  if (fs.existsSync(logPath)) {
-    try {
-      const failedData = JSON.parse(fs.readFileSync(logPath, 'utf8'));
-      for (const [url, details] of Object.entries(failedData)) {
-        const urlObj = new URL(url);
-        const urlParts = urlObj.pathname.split('/').filter(Boolean); // filter removes empty strings
-
-        let repo = 'Unknown Repo';
-
-        if (urlObj.hostname === 'api.github.com' && urlParts[0] === 'repos') {
-          // API format: /repos/owner/repo/...
-          repo = `${urlParts[1]}/${urlParts[2]}`;
-        } else {
-          // Standard format: /owner/repo/...
-          repo = `${urlParts[0]}/${urlParts[1]}`;
-        }
-
-        // Add to collaborations as a "Ghost Row"
-        contributions.collaborations.push({
-          title: details.title || 'Unknown Title',
-          url: url.replace('api.github.com/repos/', 'github.com/').replace('/pulls/', '/pull/'),
-          repo: repo,
-          date: details.timestamp,
-          isInaccessible: true,
-          state: 'archived',
-        });
-      }
-    } catch (e) {
-      console.warn('Could not process failed-fetch.json for grouping');
+  // Normalized set of every URL we could already categorize, so a 403 that is
+  // ALSO present as a real row isn't shown twice (once as itself, once as a
+  // ghost). Matches the normalization used for the headline count in main.js.
+  const categorizedUrls = new Set();
+  for (const items of Object.values(contributions)) {
+    if (!Array.isArray(items)) continue;
+    for (const item of items) {
+      if (item?.url) categorizedUrls.add(item.url.replace(/\/$/, '').toLowerCase());
     }
+  }
+
+  /**
+   * Places one item into its quarter bucket.
+   */
+  function placeInQuarter(type, item, dateStr) {
+    const dateObj = new Date(dateStr);
+    const year = dateObj.getFullYear();
+    const month = dateObj.getMonth() + 1;
+    const quarter = `Q${Math.floor((month - 1) / 3) + 1}`;
+    const key = `${year}-${quarter}`;
+
+    if (!grouped[key]) {
+      grouped[key] = {
+        pullRequests: [],
+        issues: [],
+        reviewedPrs: [],
+        coAuthoredPrs: [],
+        collaborations: [],
+      };
+    }
+
+    if (!grouped[key][type]) {
+      grouped[key][type] = [];
+    }
+    grouped[key][type].push(item);
   }
 
   for (const [type, items] of Object.entries(contributions)) {
@@ -62,28 +65,67 @@ function groupContributionsByQuarter(contributions) {
         continue;
       }
 
-      const dateObj = new Date(dateStr);
-      const year = dateObj.getFullYear();
-      const month = dateObj.getMonth() + 1;
-      const quarter = `Q${Math.floor((month - 1) / 3) + 1}`;
-      const key = `${year}-${quarter}`;
-
-      if (!grouped[key]) {
-        grouped[key] = {
-          pullRequests: [],
-          issues: [],
-          reviewedPrs: [],
-          coAuthoredPrs: [],
-          collaborations: [],
-        };
-      }
-
-      if (!grouped[key][type]) {
-        grouped[key][type] = [];
-      }
-      grouped[key][type].push(item);
+      placeInQuarter(type, item, dateStr);
     }
   }
+
+  // --- Inject 403 data as "Ghost Rows" ---
+  // Built into the grouped output ONLY. We deliberately do not push these into
+  // `contributions`: that object is passed by reference and reused downstream
+  // (createStatsReadme / createIndexHtml) to compute the headline total, which
+  // adds uncategorized 403s separately — mutating it here would double-count
+  // them. See main.js for the headline math.
+  const logPath = path.join(process.cwd(), 'data', 'failed-fetch.json');
+  if (fs.existsSync(logPath)) {
+    try {
+      const failedData = JSON.parse(fs.readFileSync(logPath, 'utf8'));
+      for (const [url, details] of Object.entries(failedData)) {
+        const urlObj = new URL(url);
+        const urlParts = urlObj.pathname.split('/').filter(Boolean); // filter removes empty strings
+
+        let repo = 'Unknown Repo';
+
+        if (urlObj.hostname === 'api.github.com' && urlParts[0] === 'repos') {
+          // API format: /repos/owner/repo/...
+          repo = `${urlParts[1]}/${urlParts[2]}`;
+        } else {
+          // Standard format: /owner/repo/...
+          repo = `${urlParts[0]}/${urlParts[1]}`;
+        }
+
+        const ghostUrl = url
+          .replace('api.github.com/repos/', 'github.com/')
+          .replace('/pulls/', '/pull/');
+
+        // Already shown as a real, categorized row — don't duplicate it.
+        if (categorizedUrls.has(ghostUrl.replace(/\/$/, '').toLowerCase())) {
+          continue;
+        }
+
+        if (!details.timestamp) {
+          console.warn('Skipping 403 ghost row due to missing date:', details.title);
+          continue;
+        }
+
+        // Add to collaborations as a "Ghost Row"
+        placeInQuarter(
+          'collaborations',
+          {
+            title: details.title || 'Unknown Title',
+            url: ghostUrl,
+            repo: repo,
+            date: details.timestamp,
+            isInaccessible: true,
+            state: 'archived',
+          },
+          details.timestamp
+        );
+      }
+    } catch (e) {
+      console.warn('Could not process failed-fetch.json for grouping');
+    }
+  }
+
   return grouped;
 }
 

--- a/scripts/utils/github-helpers.js
+++ b/scripts/utils/github-helpers.js
@@ -193,9 +193,11 @@ async function getPrActivityMeta(
     // rate limit — see withRateLimitRetry) is worth remembering so we don't
     // re-attempt this PR on every future daily run.
     if (e.isPermanent403 && failedFetchCache) {
+      // Stamp with the PR's own updated_at, not the run time, so its ghost row
+      // in the historical reports lands in the quarter it was actually active.
       failedFetchCache.set(resolvedPrUrl, {
         status: '403 Forbidden',
-        timestamp: new Date().toISOString(),
+        timestamp: prMainUpdatedAt || new Date().toISOString(),
         title: prTitle || 'Unknown Title',
       });
     }

--- a/scripts/utils/http-helpers.js
+++ b/scripts/utils/http-helpers.js
@@ -6,6 +6,8 @@
  * abuse-detection / secondary rate limits instead of each reinventing it.
  */
 
+const https = require('https');
+
 const MAX_RATE_LIMIT_RETRIES = 6;
 
 // GitHub's own infra occasionally 502/503/504s — transient, unlike a 403
@@ -13,6 +15,42 @@ const MAX_RATE_LIMIT_RETRIES = 6;
 // 5xx usually clears in seconds, not the up-to-60s a secondary rate limit
 // needs.
 const RETRYABLE_SERVER_ERRORS = new Set([502, 503, 504]);
+
+// Transient network failures where the request never got an HTTP response at
+// all — the socket was reset / timed out / dropped mid-flight, typically when
+// a burst of concurrent TLS connections overwhelms the client or an
+// intermediary. Unlike a 4xx/5xx these carry no `err.response`, so they're
+// matched by `err.code` (or a couple of message-only variants). They almost
+// always succeed on a quick retry.
+const RETRYABLE_NETWORK_ERRORS = new Set([
+  'ECONNRESET',
+  'ETIMEDOUT',
+  'ECONNABORTED',
+  'ENOTFOUND',
+  'EAI_AGAIN',
+  'ENETUNREACH',
+  'EHOSTUNREACH',
+  'EPIPE',
+  'ERR_SOCKET_CONNECTION_TIMEOUT',
+]);
+
+function isRetryableNetworkError(err) {
+  if (err.response) return false; // got an HTTP response — not a network-level failure
+  if (RETRYABLE_NETWORK_ERRORS.has(err.code)) return true;
+  return /socket hang up|network socket disconnected/i.test(err.message || '');
+}
+
+// A shared keep-alive agent, reused across every axios instance. Two jobs:
+//   1. keepAlive reuses TCP/TLS connections instead of doing a fresh handshake
+//      per request — far fewer handshakes means far fewer resets.
+//   2. maxSockets caps how many connections can be open at once, so the
+//      per-PR fan-out (getPrActivityMeta fires 4 parallel calls) times the
+//      PR-level concurrency can't open dozens of sockets simultaneously and
+//      trip a connection reset. Extra requests queue at the socket layer. Set
+//      to 6 as a hard ceiling that matches the workbench's PR_CONCURRENCY of 3
+//      (3 PRs * up to ~2 in-flight of their 4 calls) and keeps the total
+//      simultaneous-connection count well under GitHub's abuse threshold.
+const keepAliveAgent = new https.Agent({ keepAlive: true, maxSockets: 6 });
 
 let rateLimitLogged = false;
 
@@ -90,6 +128,11 @@ async function withRateLimitRetry(
 ) {
   let attempt = 0;
   let quickAttempt = 0;
+  // Network-level failures (ECONNRESET etc.) get their OWN retry budget,
+  // independent of the rate-limit budget above. They have different root
+  // causes, so a run that already spent its rate-limit retries this call
+  // shouldn't die on the first unrelated socket reset (and vice versa).
+  let networkAttempt = 0;
   while (true) {
     try {
       return await fn();
@@ -133,6 +176,26 @@ async function withRateLimitRetry(
         continue;
       }
 
+      if (isRetryableNetworkError(err)) {
+        if (networkAttempt >= retries) throw err;
+        networkAttempt++;
+        // On a search endpoint a reset is almost always GitHub's abuse
+        // detection escalating from "403, slow down" to just killing the
+        // socket — so back off on the same long ladder as a rate limit
+        // rather than the short one a plain transport blip needs. Jitter so a
+        // batch of connections that reset together don't retry in lockstep
+        // and immediately re-storm the pool.
+        const base = assumeRateLimit
+          ? Math.min(60000, 2000 * 2 ** (networkAttempt - 1))
+          : Math.min(15000, 1000 * 2 ** (networkAttempt - 1));
+        const delay = base + Math.floor(Math.random() * 500);
+        console.log(
+          `[retry] network error (${err.code || err.message}) on ${label || 'request'} (attempt ${networkAttempt}/${retries}), backing off ${Math.round(delay / 1000)}s...`
+        );
+        await new Promise((resolve) => setTimeout(resolve, delay));
+        continue;
+      }
+
       throw err;
     }
   }
@@ -161,4 +224,5 @@ module.exports = {
   attachRateLimitLogger,
   withRateLimitRetry,
   mapWithConcurrency,
+  keepAliveAgent,
 };


### PR DESCRIPTION
## Summary
- Quarterly grouper no longer mutates its input when injecting 403 "ghost rows", which was double-counting them into the headline total (2754 instead of the correct 2744).
- Unverifiable (403) co-authored PRs are no longer kept indefinitely on the Active Workbench — dormant PRs from a permission-restricted org (e.g. SSO-enforcing) now correctly drop off instead of lingering as "current tasks."
- Workbench 403s are now timestamped with the PR's own `updated_at` instead of the run time, so they land in the quarter they were actually active in rather than scattering into the current one.
- `withRateLimitRetry` now retries transient network failures (`ECONNRESET`, `ETIMEDOUT`, etc.) on their own independent budget, separate from the rate-limit retry budget, so one can't starve the other and abort the whole run.
- Added a shared keep-alive `https.Agent` (capped socket count) and reduced `PR_CONCURRENCY` (6→3) so the per-PR fan-out stays well under GitHub's secondary rate limit / abuse-detection threshold.
- Removed the blanket pre-search delay in favor of pacing only between pages of a single query, cutting several minutes of fixed waiting from a full resync.

## Test plan
- [x] Verified the grouper no longer mutates `finalContributions` (collaborations count unchanged before/after grouping)
- [x] Verified headline total computes to 2744 against real `data/` snapshot
- [x] Confirmed no 403 ghost rows land in the wrong (current) quarter
- [x] Ran `npm run resync` end-to-end to completion (previously failing with uncaught `ECONNRESET`)
- [x] Confirmed stale 403 PR no longer appears in `ongoing-coauthored-prs.json`
- [x] `node -c` syntax check + `prettier --write` on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)