### PR TITLE
fix: stop mis-filing reviewed PRs as co-authored

### DIFF
--- a/scripts/api/fetch-historical-contributions.js
+++ b/scripts/api/fetch-historical-contributions.js
@@ -8,6 +8,7 @@ const {
   withRateLimitRetry,
   keepAliveAgent,
 } = require('../utils/http-helpers');
+const { isCommitByUser } = require('../utils/commit-helpers');
 
 /**
  * Fetches the year the user joined GitHub to set the baseline for discovery.
@@ -257,42 +258,10 @@ async function fetchContributions(
         }
       }
 
-      function isCommitByUser(c) {
-        try {
-          // --- Ignore stale historical commits from wrong base branches ---
-          if (prCreatedAt && new Date(c.commit?.author?.date) < new Date(prCreatedAt)) {
-            return false;
-          }
-
-          const lowerUsername = username.toLowerCase();
-          const commitMessage = c.commit?.message || '';
-          const isBranchUpdate = /^Merge branch '.+' into .+/i.test(commitMessage);
-          if (isBranchUpdate) return false;
-          if (c.author?.login === username) return true;
-          const authorEmail = c.commit?.author?.email?.toLowerCase();
-          if (authorEmail) {
-            if (
-              authorEmail.endsWith('@users.noreply.github.com') &&
-              authorEmail.includes(`+${lowerUsername}@`)
-            )
-              return true;
-            if (authorEmail === `${lowerUsername}@users.noreply.github.com`) return true;
-            if (authorEmail.includes(lowerUsername)) return true;
-          }
-          if (c.commit?.author?.name && c.commit.author.name.toLowerCase().includes(lowerUsername))
-            return true;
-          if (
-            /Co-authored-by:/i.test(commitMessage) &&
-            commitMessage.toLowerCase().includes(lowerUsername)
-          )
-            return true;
-        } catch (e) {
-          return false;
-        }
-        return false;
-      }
-
-      const userCommits = allCommits.filter(isCommitByUser);
+      // The historical record credits genuine edits the user made through the
+      // GitHub web UI, so web-flow commits are NOT excluded here (unlike the
+      // Active Workbench). See scripts/utils/commit-helpers.js.
+      const userCommits = allCommits.filter((c) => isCommitByUser(c, username, { prCreatedAt }));
 
       if (userCommits.length > 0) {
         userCommits.sort((a, b) => new Date(a.commit.author.date) - new Date(b.commit.author.date));

--- a/scripts/api/fetch-ongoing-workbench.js
+++ b/scripts/api/fetch-ongoing-workbench.js
@@ -8,6 +8,7 @@ const {
   mapWithConcurrency,
   keepAliveAgent,
 } = require('../utils/http-helpers');
+const { isCommitByUser } = require('../utils/commit-helpers');
 
 /**
  * SHARED AXIOS CONFIGURATION
@@ -63,49 +64,6 @@ async function searchAll(query) {
 }
 
 /**
- * LOCAL HELPER: isCommitByUser (Ongoing Workbench Version)
- * Strict logic to ignore web-flow and suggestions.
- */
-function isCommitByUser(c, username) {
-  try {
-    const lowerUsername = username.toLowerCase();
-    const commitMessage = c.commit?.message || '';
-
-    // Ignore GitHub Web-flow actions and branch updates
-    if (c.committer?.login === 'web-flow') return false;
-    if (/suggestion|Merge branch|Merge remote-tracking|Merge pull request/i.test(commitMessage))
-      return false;
-
-    // Author check
-    const authorLogin = c.author?.login || '';
-    const authorEmail = c.commit?.author?.email?.toLowerCase() || '';
-    const authorName = c.commit?.author?.name?.toLowerCase() || '';
-
-    const isAuthorMatch =
-      authorLogin === username ||
-      authorEmail === `${lowerUsername}@users.noreply.github.com` ||
-      (authorEmail.endsWith('@users.noreply.github.com') &&
-        authorEmail.includes(`+${lowerUsername}@`)) ||
-      authorEmail.includes(lowerUsername) ||
-      authorName.includes(lowerUsername);
-
-    if (isAuthorMatch) return true;
-
-    // Co-authored check
-    if (
-      /Co-authored-by:/i.test(commitMessage) &&
-      commitMessage.toLowerCase().includes(lowerUsername)
-    ) {
-      return true;
-    }
-
-    return false;
-  } catch (e) {
-    return false;
-  }
-}
-
-/**
  * LOCAL HELPER: getFirstCommitDetails (Ongoing Workbench Version)
  */
 async function getFirstCommitDetails(
@@ -150,16 +108,30 @@ async function getFirstCommitDetails(
       }
     }
 
-    const userCommits = allCommits.filter((c) => isCommitByUser(c, username));
+    // The Active Workbench is about current authoring tasks, so applying a
+    // reviewer's suggestion (a web-flow commit) is treated as reviewing, not
+    // authoring — excludeWebFlow keeps those off the co-authoring list.
+    const userCommits = allCommits.filter((c) =>
+      isCommitByUser(c, username, { excludeWebFlow: true })
+    );
+
+    // Separately, evaluate the same commits under the HISTORICAL rule (which
+    // does count web-flow work, e.g. a suggestion of yours the author committed
+    // — GitHub credits that with a real Co-authored-by trailer). The historical
+    // reports are pruned against this verdict, never against the workbench's
+    // stricter one; conflating them deletes genuinely co-authored PRs.
+    const historicalMatch = allCommits.some((c) => isCommitByUser(c, username));
+
     if (userCommits.length > 0) {
       userCommits.sort((a, b) => new Date(a.commit.author.date) - new Date(b.commit.author.date));
       result = {
         firstCommitDate: userCommits[0].commit.author.date,
         commitCount: userCommits.length,
         prUpdatedAt,
+        historicalMatch,
       };
     } else {
-      result = { firstCommitDate: null, commitCount: 0, prUpdatedAt };
+      result = { firstCommitDate: null, commitCount: 0, prUpdatedAt, historicalMatch };
     }
   } catch (err) {
     // A confirmed permanent 403 (not a rate limit) is worth remembering so
@@ -387,6 +359,18 @@ async function fetchOngoingCoAuthoredPrs(commitCache, activityCache, failedFetch
     return owner !== GITHUB_USERNAME;
   });
 
+  // Open PRs we fetched commits for and confirmed hold NO commit by the user
+  // *under the historical rule* (a clean verdict, not a fetch we couldn't
+  // complete). This is the authoritative "not co-authored" signal for open PRs,
+  // and the caller uses it to self-heal stale historical co-authored entries —
+  // e.g. a PR that was co-authored, then force-pushed so the commit vanished.
+  //
+  // It deliberately does NOT key off this function's own workbench verdict:
+  // that rule is stricter (it ignores web-flow commits), so reusing it here
+  // would prune history by a definition history never used and silently delete
+  // real co-authored work, such as a review suggestion the PR author committed.
+  const examinedRejectedUrls = new Set();
+
   const results = await mapWithConcurrency(candidates, PR_CONCURRENCY, async (pr) => {
     const repoParts = new URL(pr.repository_url).pathname.split('/');
     const owner = repoParts[repoParts.length - 2];
@@ -403,6 +387,13 @@ async function fetchOngoingCoAuthoredPrs(commitCache, activityCache, failedFetch
       pr.title
     );
 
+    // Record the historical-rule verdict for the caller's self-healing pass.
+    // Only a clean "no" counts: a fetch we couldn't complete (fetchFailed) is
+    // "unknown", and must never demote a real entry.
+    if (!commitDetails?.fetchFailed && !commitDetails?.historicalMatch) {
+      examinedRejectedUrls.add(pr.html_url);
+    }
+
     // Only a confirmed commit by the user keeps a PR on the Active Workbench.
     // A fetch we couldn't complete (fetchFailed, e.g. a permanently-403ing
     // repo) is NOT kept here: those are almost always old, dormant PRs we
@@ -415,10 +406,11 @@ async function fetchOngoingCoAuthoredPrs(commitCache, activityCache, failedFetch
       formatted.body = pr.body;
       return formatted;
     }
+
     return null;
   });
 
-  return results.filter(Boolean);
+  return { prs: results.filter(Boolean), examinedRejectedUrls };
 }
 
 module.exports = {

--- a/scripts/src/main.js
+++ b/scripts/src/main.js
@@ -165,11 +165,8 @@ async function main() {
     // Pass a fresh Map() instead of commitCacheFromDisk.
     // This forces a fresh look at the commits for OPEN PRs only,
     // ensuring the 'web-flow' fix is applied to the Workbench without affecting historical data.
-    const rawOngoingCoAuthoredPRs = await fetchOngoingCoAuthoredPrs(
-      new Map(),
-      activityCache,
-      failedFetchCache
-    );
+    const { prs: rawOngoingCoAuthoredPRs, examinedRejectedUrls: coAuthoredRejectedUrls } =
+      await fetchOngoingCoAuthoredPrs(new Map(), activityCache, failedFetchCache);
 
     const ongoingCoAuthoredPRs = rawOngoingCoAuthoredPRs.filter((pr) => {
       const repoName = pr.repo.toLowerCase();
@@ -335,6 +332,38 @@ async function main() {
             }
           }
         }
+      }
+    }
+
+    // --- Self-heal stale co-authored entries ---
+    // Co-authored is the only category whose evidence (a commit in the PR
+    // branch) can be erased after the fact by a force-push, squash, or rebase.
+    // When that happens the preserve step above would otherwise re-add the old
+    // "co-authored" entry forever, since nothing in a normal merge removes it
+    // (that's how mautic/user-documentation#838 got stuck). The live workbench
+    // just re-checked every OPEN commented-on PR against fresh commits, so any
+    // still-open co-authored entry it examined and rejected is now known-bad and
+    // is dropped here. Removing it from globalLoadedBy too lets the merge below
+    // re-file the PR into its rightful bucket (e.g. collaborations) this run.
+    // Only open PRs are touched: merged/closed history is frozen and can't rot.
+    if (coAuthoredRejectedUrls && coAuthoredRejectedUrls.size > 0) {
+      const before = finalContributions.coAuthoredPrs.length;
+      finalContributions.coAuthoredPrs = finalContributions.coAuthoredPrs.filter((item) => {
+        const stale = item.state === 'open' && coAuthoredRejectedUrls.has(item.url);
+        if (stale) {
+          const seen = globalLoadedBy.get(item.url);
+          if (seen) {
+            seen.delete('coAuthoredPrs');
+            if (seen.size === 0) globalLoadedBy.delete(item.url);
+          }
+        }
+        return !stale;
+      });
+      const removed = before - finalContributions.coAuthoredPrs.length;
+      if (removed > 0) {
+        console.log(
+          `Self-healed ${removed} stale co-authored PR(s) no longer authored by the user.`
+        );
       }
     }
 

--- a/scripts/utils/commit-helpers.js
+++ b/scripts/utils/commit-helpers.js
@@ -1,0 +1,88 @@
+/**
+ * SHARED: strict "is this commit the user's own authored work?" test.
+ *
+ * Used by BOTH the historical crawler and the Active Workbench so the two share
+ * one set of matching rules. Historically these lived as two slightly different
+ * inline copies, which is how a PR the user only commented on
+ * (mautic/user-documentation#838) slipped into the co-authored bucket: a commit
+ * that was never really theirs matched a loose substring rule, and once the
+ * branch was force-pushed the evidence vanished, leaving an entry nothing could
+ * disprove.
+ *
+ * Strictness is the whole point. Co-authored is the only contribution category
+ * whose evidence — a commit in the PR branch — can later be erased by a
+ * force-push, squash, or rebase, so a false positive here is uniquely damaging.
+ * We therefore only count a commit when authorship is *positively* the user's:
+ * GitHub resolved the account, an unambiguous `noreply` e-mail, or a real
+ * `Co-authored-by:` trailer line — never a loose substring of an email or name.
+ *
+ * @param {object} commit    A GitHub commit object from the `/commits` endpoint.
+ * @param {string} username  The tracked GitHub login (e.g. `adiati98`).
+ * @param {object} [opts]
+ * @param {string|null} [opts.prCreatedAt]  When set, commits authored before the
+ *   PR was opened are ignored — stale commits inherited from a wrong or rebased
+ *   base branch, not work done on this PR.
+ * @param {boolean} [opts.excludeWebFlow=false]  When true, commits committed
+ *   through the GitHub web UI (`web-flow`: applied review suggestions, edits made
+ *   on github.com) are not counted. The Active Workbench sets this — for the
+ *   "what's an active authoring task" view, applying a reviewer's suggestion is
+ *   reviewing, not authoring. The historical record leaves it false, so a genuine
+ *   edit the user made through the web UI still counts as their contribution.
+ * @returns {boolean}
+ */
+function isCommitByUser(commit, username, { prCreatedAt = null, excludeWebFlow = false } = {}) {
+  try {
+    const lowerUsername = String(username || '').toLowerCase();
+    if (!lowerUsername) return false;
+
+    const commitAuthorDate = commit?.commit?.author?.date;
+    // Ignore stale commits inherited from a wrong/rebased base branch.
+    if (prCreatedAt && commitAuthorDate && new Date(commitAuthorDate) < new Date(prCreatedAt)) {
+      return false;
+    }
+
+    const message = commit?.commit?.message || '';
+
+    // Merge commits are plumbing, never authored content — always ignored.
+    if (/^Merge (branch|remote-tracking|pull request)\b/i.test(message)) return false;
+
+    // Optional: ignore GitHub web-UI commits (see opts.excludeWebFlow).
+    if (excludeWebFlow) {
+      if (commit?.committer?.login === 'web-flow') return false;
+      if (/^Apply suggestions from code review\b/i.test(message)) return false;
+    }
+
+    // 1. Authoritative: GitHub resolved this commit's author to the user's
+    //    account. Catches the common case, including commits made under a
+    //    personal email GitHub has linked to the account.
+    if (commit?.author?.login && commit.author.login.toLowerCase() === lowerUsername) return true;
+
+    // 2. GitHub `noreply` email forms, which encode the login unambiguously:
+    //      <login>@users.noreply.github.com
+    //      <id>+<login>@users.noreply.github.com
+    const authorEmail = (commit?.commit?.author?.email || '').toLowerCase();
+    if (authorEmail === `${lowerUsername}@users.noreply.github.com`) return true;
+    if (
+      authorEmail.endsWith('@users.noreply.github.com') &&
+      authorEmail.includes(`+${lowerUsername}@`)
+    ) {
+      return true;
+    }
+
+    // 3. A real `Co-authored-by:` trailer line that names the user. We require an
+    //    actual trailer line rather than the login merely appearing somewhere in
+    //    the message body, so an unrelated mention (a "Reported-by", a link, a
+    //    quoted comment) can never promote a PR to "co-authored".
+    const namesUserInTrailer = message.split(/\r?\n/).some((line) => {
+      const l = line.trim().toLowerCase();
+      return l.startsWith('co-authored-by:') && l.includes(lowerUsername);
+    });
+    if (namesUserInTrailer) return true;
+
+    return false;
+  } catch (e) {
+    return false;
+  }
+}
+
+module.exports = { isCommitByUser };


### PR DESCRIPTION
## Problem

An external PR (docs repo, PR `#838`) appeared under **co-authored PRs** despite never being co-authored — it was reviewed (9 reviews, ending in an approval).

Two independent causes:

**1. Co-author detection was too loose.** A commit counted as yours if the author's email or name merely *contained* your username, or if a message had a `Co-authored-by:` trailer **and** mentioned your username anywhere. A bot commit saying `Address @adiati98 review` alongside an unrelated trailer was enough to qualify.

**2. A wrong verdict could never self-correct.** Co-authored is the only category whose evidence — a commit in the PR branch — can be erased afterwards by a force-push, squash, or rebase (that PR was force-pushed). Because the merge step only ever *preserved* existing entries, and `coAuthoredPrs` outranks `collaborations`, a bad entry was stuck permanently.

## Changes

- **New `scripts/utils/commit-helpers.js`** — one strict `isCommitByUser`, shared by the historical crawler and the Active Workbench, which previously kept two diverging inline copies. It counts only positively-established authorship: a GitHub-resolved account, an unambiguous `noreply` email, or a real `Co-authored-by:` **trailer line**. Merge commits never count — merging a target branch into a contributor's branch isn't authoring.
- **Web-flow policy stays per-caller** via `excludeWebFlow`. History still credits genuine web-UI edits, including a review suggestion the PR author committed (GitHub records those with a real trailer). The Workbench keeps treating applying a suggestion as reviewing, not authoring.
- **Self-healing merge in `main.js`** — the Workbench already re-reads commits for every open commented-on PR each run, so it now also reports which it examined and rejected *under the historical rule*; the merge drops those and lets the PR re-file into its correct bucket the same run. Only open PRs are touched (merged history is frozen), and a failed fetch counts as unknown, never a rejection.

> The last point is deliberate and load-bearing: the Workbench's rule is stricter than history's, so pruning history with the Workbench's verdict deletes real co-authored work (it removed an entry whose co-authorship rests on an accepted review suggestion). The two verdicts are computed separately for that reason.

## Verification

Re-audited **all 275** stored co-authored PRs against live commit data:

- **273 re-confirmed genuine.**
- Only two fall out: the reviewed-not-authored PR above, and one other entry whose sole user commit is a branch merge.
- All 7 remaining open co-authored PRs correctly retained under the new rule — including the ones whose credit comes from accepted review suggestions.
- No category-hierarchy violations; grouper runs clean.

Data and generated report files are intentionally excluded from this PR — the pipeline regenerates them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
