### PR TITLE
fix: self-healing must not skip PRs that already merged or closed

### DIFF
--- a/scripts/api/fetch-historical-contributions.js
+++ b/scripts/api/fetch-historical-contributions.js
@@ -75,6 +75,18 @@ async function fetchContributions(
     coAuthoredPrs: new Set(),
   };
 
+  // PRs this run successfully re-checked for commit authorship and found NONE
+  // by the user (a clean, definitive verdict — never a fetchFailed "unknown").
+  // The caller uses this to self-heal a stale coAuthoredPrs entry left over
+  // from before a fix to the matching rules, or from a PR that was force-pushed
+  // after being wrongly flagged. This complements the Active Workbench's own
+  // rejection signal: the Workbench only re-checks PRs that are STILL OPEN, so
+  // it can never correct an entry for a PR that has since merged or closed —
+  // this crawler re-examines a PR's commits regardless of its current state
+  // whenever the PR falls in the year range being fetched, so it's the only
+  // signal that can heal a stale entry after the PR is no longer open.
+  const rejectedCoAuthorUrls = new Set();
+
   // Mutate the caller's map directly (not a clone) so that if this function
   // throws partway through the year loop, whatever commits it already
   // fetched are still visible to the caller and can be persisted instead of
@@ -467,6 +479,8 @@ async function fetchContributions(
             state: pr.state,
           });
           seenUrls.coAuthoredPrs.add(pr.html_url);
+        } else if (commitDetails && !commitDetails.fetchFailed) {
+          rejectedCoAuthorUrls.add(pr.html_url);
         }
 
         const myFirstReviewDate = await getPrMyFirstReviewDate(
@@ -587,6 +601,8 @@ async function fetchContributions(
             state: item.state,
           });
           seenUrls.coAuthoredPrs.add(item.html_url);
+        } else if (commitDetails && !commitDetails.fetchFailed) {
+          rejectedCoAuthorUrls.add(item.html_url);
         }
       }
 
@@ -656,7 +672,7 @@ async function fetchContributions(
     }
   }
 
-  return { contributions, prCache, commitCache };
+  return { contributions, prCache, commitCache, rejectedCoAuthorUrls };
 }
 
 module.exports = {

--- a/scripts/src/main.js
+++ b/scripts/src/main.js
@@ -282,12 +282,8 @@ async function main() {
       console.log('Clearing persistent PR cache for a full fetch.');
     }
 
-    const { contributions: newContributions } = await fetchContributions(
-      fetchStartYear,
-      prCache,
-      mergedCommitCache,
-      failedFetchCache
-    );
+    const { contributions: newContributions, rejectedCoAuthorUrls: historicalRejectedUrls } =
+      await fetchContributions(fetchStartYear, prCache, mergedCommitCache, failedFetchCache);
 
     let finalContributions = {
       pullRequests: [],
@@ -339,17 +335,31 @@ async function main() {
     // Co-authored is the only category whose evidence (a commit in the PR
     // branch) can be erased after the fact by a force-push, squash, or rebase.
     // When that happens the preserve step above would otherwise re-add the old
-    // "co-authored" entry forever, since nothing in a normal merge removes it
-    // (that's how mautic/user-documentation#838 got stuck). The live workbench
-    // just re-checked every OPEN commented-on PR against fresh commits, so any
-    // still-open co-authored entry it examined and rejected is now known-bad and
-    // is dropped here. Removing it from globalLoadedBy too lets the merge below
-    // re-file the PR into its rightful bucket (e.g. collaborations) this run.
-    // Only open PRs are touched: merged/closed history is frozen and can't rot.
-    if (coAuthoredRejectedUrls && coAuthoredRejectedUrls.size > 0) {
+    // "co-authored" entry forever, since nothing in a normal merge removes it.
+    //
+    // Two independent signals feed this, and BOTH matter:
+    //  - The live Workbench re-checks every currently OPEN commented-on PR
+    //    against fresh commits every run, regardless of whether that PR falls
+    //    in this run's fetch-year window.
+    //  - The historical crawler re-checks any PR — open OR closed/merged —
+    //    that falls within the year(s) it fetched this run.
+    // A PR that was wrongly flagged while open, then merged, falls out of the
+    // Workbench's is:open query the moment it merges — the Workbench can never
+    // heal it again after that. Only the historical crawler still re-examines
+    // it (this is exactly how a merged-and-reviewed docs PR was found stuck as
+    // "co-authored" — it merged before a self-heal pass using only the
+    // Workbench's signal could catch the stale entry). So this must NOT be
+    // restricted to open PRs —
+    // either signal, for a PR in any state, is a confident "not co-authored"
+    // verdict from a fresh, successful commit fetch this run.
+    const allCoAuthorRejectedUrls = new Set([
+      ...(coAuthoredRejectedUrls || []),
+      ...(historicalRejectedUrls || []),
+    ]);
+    if (allCoAuthorRejectedUrls.size > 0) {
       const before = finalContributions.coAuthoredPrs.length;
       finalContributions.coAuthoredPrs = finalContributions.coAuthoredPrs.filter((item) => {
-        const stale = item.state === 'open' && coAuthoredRejectedUrls.has(item.url);
+        const stale = allCoAuthorRejectedUrls.has(item.url);
         if (stale) {
           const seen = globalLoadedBy.get(item.url);
           if (seen) {

--- a/scripts/utils/commit-helpers.js
+++ b/scripts/utils/commit-helpers.js
@@ -3,11 +3,10 @@
  *
  * Used by BOTH the historical crawler and the Active Workbench so the two share
  * one set of matching rules. Historically these lived as two slightly different
- * inline copies, which is how a PR the user only commented on
- * (mautic/user-documentation#838) slipped into the co-authored bucket: a commit
- * that was never really theirs matched a loose substring rule, and once the
- * branch was force-pushed the evidence vanished, leaving an entry nothing could
- * disprove.
+ * inline copies, which is how a PR the user only commented on slipped into the
+ * co-authored bucket: a commit that was never really theirs matched a loose
+ * substring rule, and once the branch was force-pushed the evidence vanished,
+ * leaving an entry nothing could disprove.
  *
  * Strictness is the whole point. Co-authored is the only contribution category
  * whose evidence — a commit in the PR branch — can later be erased by a


### PR DESCRIPTION
## Problem

After the previous co-authored-detection fix was merged and a full sync ran, the reviewed-not-authored docs PR from that fix reappeared under **co-authored PRs**.

The self-healing merge added in that fix only pruned a stale co-authored entry when the Active Workbench's live re-scan rejected it — and that scan only covers PRs that are **still open** (`is:pr is:open ...`). The PR in question merged before the full sync ran, so it had already fallen out of that query; the Workbench could never examine it again, and the `state === 'open'` guard on the self-heal filter blocked it too.

Meanwhile the historical crawler *does* re-check that PR's commits every run it falls within the fetched year range, and correctly finds none by the user — that verdict was just never surfaced to the merge step that could act on it.

## Fix

- `fetch-historical-contributions.js` now tracks `rejectedCoAuthorUrls`: PRs whose commits were freshly and successfully re-checked this run (never a `fetchFailed` "unknown") and found to contain none by the user, regardless of the PR's open/closed state.
- `main.js` unions this with the Workbench's own rejection signal and drops the `state === 'open'` restriction on the self-heal filter. Either signal, for a PR in any state, is a confident verdict from a fresh, successful check.
- Removed a leftover bare cross-repo issue reference from a source comment added in the previous fix. Source comments aren't autolinked by GitHub, but the pattern shouldn't be written into anything committed regardless.

## Verification

Simulated the corrected self-heal filter against the actual current (stale) data: with the affected PR's URL in the rejected set, filtering removes exactly that one entry and nothing else.

No manual data patch needed this time — the commit-details cache already holds the correct verdict, so the next sync (daily or full) will self-heal the stale entry automatically once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)