### PR TITLE
Fix mobile layout overflow and polish landing/writing pages

### DIFF
--- a/scripts/generators/html/blog-html-generator.js
+++ b/scripts/generators/html/blog-html-generator.js
@@ -49,7 +49,7 @@ const WRITING_CSS = `
   .wr-org::before{content:"";position:absolute;left:-24.5px;top:9px;width:11px;height:11px;border-radius:50%;
     background:var(--t-card);border:2.5px solid var(--t-brand)}
   .wr-org-h{display:flex;align-items:baseline;gap:9px;flex-wrap:wrap;margin:0}
-  .wr-org-name{font-size:1.06rem;font-weight:800;letter-spacing:-.01em;color:var(--t-ink);overflow-wrap:anywhere}
+  .wr-org-name{font-size:1.06rem;font-weight:800;letter-spacing:-.01em;color:var(--t-brand);overflow-wrap:anywhere}
   .wr-org-n{font-family:ui-monospace,monospace;font-size:.75rem;color:var(--t-ink-3);background:var(--t-card-2);border:1px solid var(--t-line);border-radius:999px;padding:1px 9px}
   .wr-personal-h-row{display:flex;align-items:baseline;gap:9px;flex-wrap:wrap;margin-bottom:16px}
   .wr-personal{max-width:760px}
@@ -60,8 +60,6 @@ const WRITING_CSS = `
   .wr-item-t{font-size:.95rem;font-weight:600;margin:0;line-height:1.4}
   .wr-item-t a{color:var(--t-ink);text-decoration:none;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;overflow-wrap:anywhere}
   .wr-item-t a:hover{color:var(--t-brand)}
-  .wr-arr{display:inline-block;color:var(--t-brand);margin-left:4px;transition:transform .18s ease}
-  .wr-item:hover .wr-arr{transform:translate(3px,-3px)}
   .wr-meta{display:flex;align-items:center;gap:8px;flex-wrap:wrap;font-family:ui-monospace,monospace;font-size:.75rem;color:var(--t-ink-3);margin-top:4px}
   .wr-platform{color:var(--t-ink-2);font-weight:600}
   .wr-tags{display:flex;flex-wrap:wrap;gap:6px}
@@ -73,7 +71,7 @@ const WRITING_CSS = `
   .wr-chip[aria-pressed="true"]{color:var(--t-brand);background:var(--t-brand-wash);border-color:var(--t-brand-line)}
   .wr-chip-n{opacity:.75}
   .wr-empty{color:var(--t-ink-3);font-style:italic;font-size:.9rem}
-  @media (prefers-reduced-motion: reduce){.wr-arr,.wr-chip{transition:none}}
+  @media (prefers-reduced-motion: reduce){.wr-chip{transition:none}}
 `;
 
 function formatDate(dateStr) {
@@ -96,7 +94,7 @@ function renderArticleItem(article, { showPlatform, headingTag }) {
   return dedent`
     <li class="wr-item" data-platform="${safePlatform}">
       <${headingTag} class="wr-item-t" title="${title}">
-        <a href="${escapeHtml(article.link)}" target="_blank" rel="noopener noreferrer">${title}<span class="wr-arr" aria-hidden="true">↗</span></a>
+        <a href="${escapeHtml(article.link)}" target="_blank" rel="noopener noreferrer">${title}</a>
       </${headingTag}>
       <div class="wr-meta">
         ${platformHtml}

--- a/scripts/generators/html/journey-html-generator.js
+++ b/scripts/generators/html/journey-html-generator.js
@@ -48,8 +48,6 @@ const JOURNEY_CSS = `
   .jy-ms h3{font-size:1.16rem;font-weight:800;margin:0;line-height:1.25}
   .jy-ms h3 a{color:var(--t-ink);text-decoration:none}
   .jy-ms h3 a:hover{color:var(--t-brand)}
-  .jy-ms .jy-arr{display:inline-block;color:var(--t-brand);transition:transform .18s ease;margin-left:4px}
-  .jy-ms:hover .jy-arr{transform:translate(3px,-3px)}
   .jy-org{font-family:ui-monospace,monospace;font-size:.75rem;letter-spacing:.08em;color:var(--t-ink-3);margin:4px 0 6px}
   .jy-org b{color:var(--t-accent);font-weight:400}
   .jy-ms-tag{display:inline-flex;align-items:center;gap:4px;font-family:ui-monospace,monospace;font-size:.75rem;color:var(--t-accent);background:var(--t-card-2);border:1px solid var(--t-line);border-radius:999px;padding:1px 8px;margin-right:6px}
@@ -69,7 +67,7 @@ const JOURNEY_CSS = `
   .jy-chip{font-family:ui-monospace,monospace;font-size:.76rem;color:var(--t-ink-2);background:var(--t-card-2);border:1px solid var(--t-line);border-radius:8px;padding:5px 13px;transition:border-color .15s ease,color .15s ease}
   .jy-chip:hover{border-color:var(--t-brand-line);color:var(--t-brand)}
   .jy-chip--hd{color:var(--t-brand);background:var(--t-brand-wash);border-color:var(--t-brand-line)}
-  @media (prefers-reduced-motion: reduce){.jy-chip,.jy-ms .jy-arr{transition:none}}
+  @media (prefers-reduced-motion: reduce){.jy-chip{transition:none}}
   .jy-xp{padding:12px 0 12px 18px;border-left:2px solid var(--t-line);position:relative}
   .jy-xp::before{content:"";position:absolute;left:-5px;top:20px;width:8px;height:8px;border-radius:50%;background:var(--t-neutral)}
   .jy-xp--active::before{background:var(--t-positive)}
@@ -85,7 +83,7 @@ const JOURNEY_CSS = `
 function renderMilestone(ach, hidden) {
   const org = escapeHtml(ach.org || '');
   const titleHtml = ach.url
-    ? `<a href="${ach.url}" target="_blank" rel="noopener noreferrer">${ach.title}<span class="jy-arr" aria-hidden="true">↗</span></a>`
+    ? `<a href="${ach.url}" target="_blank" rel="noopener noreferrer">${ach.title}</a>`
     : ach.title;
   const descHtml = ach.description
     ? `<p class="jy-desc" title="${escapeHtml(ach.description)}">${ach.description}</p>`

--- a/scripts/generators/html/landing-page-html-generator.js
+++ b/scripts/generators/html/landing-page-html-generator.js
@@ -52,11 +52,24 @@ const LANDING_CSS = `
   .lp-hero h1{font-size:clamp(1.9rem,4.4vw,3rem);font-weight:800;letter-spacing:-.015em;line-height:1.12;margin:6px 0 8px;color:var(--t-ink)}
   .lp-grad{background:linear-gradient(98deg,var(--t-brand) 10%,var(--t-accent) 90%);-webkit-background-clip:text;background-clip:text;color:transparent}
   .lp-hero p{color:var(--t-ink-2);font-size:.95rem;max-width:60ch;margin:0}
-  .lp-impact{background:var(--t-card);border:1px solid var(--t-line);border-radius:14px;overflow:hidden;margin-top:22px;box-shadow:var(--t-shadow)}
+  /* container-type lets .lp-tiles react to the card's own rendered width
+     (below) instead of the viewport's — the card no longer tracks the
+     viewport 1:1 now that it's capped to the Contribution mix column
+     width on wide screens. */
+  .lp-impact{container-type:inline-size;background:var(--t-card);border:1px solid var(--t-line);border-radius:14px;overflow:hidden;margin-top:22px;box-shadow:var(--t-shadow)}
   .lp-impact-top{display:flex;align-items:center;justify-content:space-between;gap:12px;flex-wrap:wrap;padding:14px 18px;border-bottom:1px solid var(--t-line);
     background:linear-gradient(120deg,var(--t-brand-wash),var(--t-card-2) 62%)}
   .lp-impact-top h2{font-size:1.05rem;font-weight:800;margin:0;color:var(--t-ink)}
   .lp-impact-top h2 span{color:var(--t-ink-2);font-weight:400;font-size:.86rem}
+  /* Above the .lp-cols breakpoint, match the hero/impact card width to the
+     Contribution mix column exactly: that column is one of two
+     minmax(0,1fr) tracks with a 40px gap, so its width is always
+     calc(50% - 20px) of the same container these cards sit in. Below the
+     breakpoint .lp-cols collapses to one column (full width), so the cap
+     is scoped to only apply once that second column exists. */
+  @media (min-width:861px){
+    .lp-hero,.lp-impact{max-width:calc(50% - 20px)}
+  }
   .lp-live{display:inline-flex;align-items:center;gap:7px;font-family:ui-monospace,monospace;font-size:.75rem;letter-spacing:.09em;text-transform:uppercase;color:var(--t-positive)}
   .lp-live i{width:8px;height:8px;border-radius:50%;background:var(--t-positive);position:relative}
   .lp-live i::after{content:"";position:absolute;inset:-4px;border-radius:50%;border:1px solid var(--t-positive);animation:lp-ping 2.4s ease-out infinite}
@@ -65,20 +78,20 @@ const LANDING_CSS = `
   .lp-live--stale{color:var(--t-caution)}
   .lp-live--stale i{background:var(--t-caution)}
   .lp-live--stale i::after{content:none}
-  .lp-tiles{display:grid;grid-template-columns:repeat(4,1fr)}
-  @media (max-width:760px){.lp-tiles{grid-template-columns:repeat(2,1fr)}}
-  .lp-tile{padding:16px 18px;border-right:1px solid var(--t-line);display:flex;flex-direction:column;gap:3px;transition:background .18s ease}
+  .lp-tiles{display:grid;grid-template-columns:repeat(4,minmax(0,1fr))}
+  @container (max-width:600px){.lp-tiles{grid-template-columns:repeat(2,minmax(0,1fr))}}
+  .lp-tile{min-width:0;padding:16px 18px;border-right:1px solid var(--t-line);display:flex;flex-direction:column;gap:3px;transition:background .18s ease}
   .lp-tile:last-child{border-right:0}
-  @media (max-width:760px){.lp-tile{border-top:1px solid var(--t-line)}.lp-tile:nth-child(2n){border-right:0}}
-  .lp-tile .n{font-weight:800;font-size:2.05rem;line-height:1.08;letter-spacing:-.02em;font-variant-numeric:tabular-nums;color:var(--t-ink)}
+  @container (max-width:600px){.lp-tile{border-top:1px solid var(--t-line)}.lp-tile:nth-child(2n){border-right:0}}
+  .lp-tile .n{font-weight:800;font-size:2.05rem;line-height:1.08;letter-spacing:-.02em;font-variant-numeric:tabular-nums;color:var(--t-ink);overflow-wrap:anywhere}
   .lp-tile .n small{font-size:1.05rem;color:var(--t-ink-2)}
   .lp-tile .c{font-size:.76rem;color:var(--t-ink-2);line-height:1.35}
   .lp-tile--hero{background:linear-gradient(150deg,var(--t-brand-strong),var(--t-brand))}
   .lp-tile--hero .n,.lp-tile--hero .n small,.lp-tile--hero .c{color:var(--t-on-brand)}
   .lp-tile--hero .c2{color:var(--t-on-brand);font-size:.7rem;font-weight:500;margin-top:1px}
   @media (prefers-reduced-motion: reduce){.lp-tile{transition:none}}
-  .lp-cols{display:grid;grid-template-columns:1fr 1fr;gap:40px;align-items:start;margin-top:30px}
-  @media (max-width:860px){.lp-cols{grid-template-columns:1fr;gap:30px}}
+  .lp-cols{display:grid;grid-template-columns:minmax(0,1fr) minmax(0,1fr);gap:40px;align-items:start;margin-top:30px}
+  @media (max-width:860px){.lp-cols{grid-template-columns:minmax(0,1fr)}}
   .lp-h3{font-family:ui-monospace,monospace;font-size:.75rem;letter-spacing:.13em;text-transform:uppercase;color:var(--t-ink-3);margin:0 0 12px}
   .lp-meters{max-width:520px}
   .lp-m{display:flex;flex-direction:column;gap:4px;padding:7px 0}
@@ -93,7 +106,7 @@ const LANDING_CSS = `
   .lp-focus a:hover{color:var(--t-brand)}
   .lp-focus a .o{color:var(--t-ink-3);font-weight:400}
   .lp-focus span{font-family:ui-monospace,monospace;font-size:.75rem;color:var(--t-ink-3);white-space:nowrap;flex-shrink:0}
-  .lp-persona{display:grid;grid-template-columns:72px 1fr;gap:18px;align-items:center}
+  .lp-persona{display:grid;grid-template-columns:72px minmax(0,1fr);gap:18px;align-items:center}
   .lp-seal{width:72px;height:72px;border-radius:50%;position:relative;display:flex;align-items:center;justify-content:center;
     background:conic-gradient(from 210deg,var(--t-brand),var(--t-accent),var(--t-brand));animation:lp-spin 26s linear infinite}
   @keyframes lp-spin{to{transform:rotate(360deg)}}

--- a/scripts/generators/html/quarterly-reports-html-generator.js
+++ b/scripts/generators/html/quarterly-reports-html-generator.js
@@ -144,6 +144,17 @@ const QUARTERLY_EXTRA_CSS = `
       letter-spacing: .04em;
       color: var(--t-ink-3);
     }
+    /* A flex item's default min-width is its content's min-content size —
+       for an unbroken string (a long repo slug, a raw URL used as a PR
+       title) that can exceed the card, forcing this row (and the whole
+       table) to scroll horizontally instead of wrapping. min-width:0 lets
+       the item actually shrink; overflow-wrap:anywhere makes it wrap even
+       mid-word when there's no earlier break opportunity. */
+    .report-table td[data-label] > * {
+      flex: 1 1 0%;
+      min-width: 0;
+      overflow-wrap: anywhere;
+    }
     .report-table td:first-child { font-weight: 800; border-bottom: 0; padding-bottom: 2px; }
     .report-table td:nth-child(3) { font-weight: 600; }
   }


### PR DESCRIPTION
## Summary
- Landing page: hardened grid tracks (Impact tiles, Contribution mix / Collaboration profile columns) with `minmax(0,1fr)` so long content can no longer force horizontal page scroll on narrow viewports.
- Quarterly reports: fixed the mobile stacked-card table so a long repo slug or a raw-URL PR title wraps instead of forcing the table to scroll horizontally (the flex children were missing `min-width:0`).
- Removed the arrow icon from Journey milestones and Writing articles.
- Matched the Hero and Impact card widths to the Contribution mix column on desktop, and switched the Impact tiles' column-count breakpoint to a container query so the tiles still fit now that the card's width is decoupled from the viewport.
- Colored organization names on the Writing page with the brand token instead of the default ink color.

## Test plan
- [x] Verified in headless Chromium at a 360×780 viewport that the landing page, journey page, writing page, and a quarterly report page all render with `scrollWidth === clientWidth` (no horizontal page scroll).
- [x] Verified the quarterly report's mobile card table wraps long titles/repo names instead of scrolling.
- [x] Verified the Hero/Impact/Contribution-mix column widths match exactly (492px each) at a 1280px desktop viewport, and that the Impact tiles stay on a single line without regressing to 2-column at that width.
- [x] Verified mobile layout (360px) is unaffected — Hero/Impact still span full width there.
- [ ] Manual check in a real mobile browser once deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)