### PR TITLE
Fix Primary focus title/count overlap on mobile

### DIFF
--- a/scripts/generators/html/landing-page-html-generator.js
+++ b/scripts/generators/html/landing-page-html-generator.js
@@ -106,6 +106,14 @@ const LANDING_CSS = `
   .lp-focus a:hover{color:var(--t-brand)}
   .lp-focus a .o{color:var(--t-ink-3);font-weight:400}
   .lp-focus span{font-family:ui-monospace,monospace;font-size:.75rem;color:var(--t-ink-3);white-space:nowrap;flex-shrink:0}
+  /* On narrow screens a long org/repo name wraps onto two lines, but as a
+     row-flex sibling the count stays baseline-aligned to that first line —
+     it visually lands between the org name and the repo name instead of
+     next to the whole title. Stacking the count under the title once the
+     column is this narrow keeps the two from reading as jumbled together. */
+  @media (max-width:640px){
+    .lp-focus{flex-direction:column;align-items:flex-start;gap:2px}
+  }
   .lp-persona{display:grid;grid-template-columns:72px minmax(0,1fr);gap:18px;align-items:center}
   .lp-seal{width:72px;height:72px;border-radius:50%;position:relative;display:flex;align-items:center;justify-content:center;
     background:conic-gradient(from 210deg,var(--t-brand),var(--t-accent),var(--t-brand));animation:lp-spin 26s linear infinite}


### PR DESCRIPTION
## Summary
- On the landing page's Primary focus list, a long org/repo name (e.g. `OpenSource-Communities / guestbook`) wraps onto two lines at mobile widths, but the contribution count sat as a row-flex sibling baseline-aligned to the first line — visually reading as jammed between the org name and the repo name instead of belonging with the title.
- Below 640px, the row now stacks vertically: title on top (full row width, so it wraps less), count below. Above 640px the layout is unchanged.

## Test plan
- [x] Verified in headless Chromium at 360×780 with real cached data (`OpenSource-Communities / guestbook`, `mautic / developer-documentation-new`) that the title and count boxes no longer overlap/interleave, and the title now gets the full row width to wrap in.
- [x] Verified at a 1280px desktop viewport (492px card width) that the side-by-side layout is unchanged.
- [ ] Manual check in a real mobile browser once deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)