### PR TITLE
Fix: full-width landing cards, brand-colored article pill, and accessibility fixes

### DIFF
--- a/scripts/generators/html/blog-html-generator.js
+++ b/scripts/generators/html/blog-html-generator.js
@@ -93,7 +93,7 @@ function renderArticleItem(article, { showPlatform, headingTag }) {
     showPlatform && platform ? `<span class="wr-platform">${safePlatform}</span>` : '';
   return dedent`
     <li class="wr-item" data-platform="${safePlatform}">
-      <${headingTag} class="wr-item-t" title="${title}">
+      <${headingTag} class="wr-item-t">
         <a href="${escapeHtml(article.link)}" target="_blank" rel="noopener noreferrer">${title}</a>
       </${headingTag}>
       <div class="wr-meta">

--- a/scripts/generators/html/blog-html-generator.js
+++ b/scripts/generators/html/blog-html-generator.js
@@ -50,7 +50,7 @@ const WRITING_CSS = `
     background:var(--t-card);border:2.5px solid var(--t-brand)}
   .wr-org-h{display:flex;align-items:baseline;gap:9px;flex-wrap:wrap;margin:0}
   .wr-org-name{font-size:1.06rem;font-weight:800;letter-spacing:-.01em;color:var(--t-brand);overflow-wrap:anywhere}
-  .wr-org-n{font-family:ui-monospace,monospace;font-size:.75rem;color:var(--t-ink-3);background:var(--t-card-2);border:1px solid var(--t-line);border-radius:999px;padding:1px 9px}
+  .wr-org-n{font-family:ui-monospace,monospace;font-size:.75rem;font-weight:600;color:var(--t-on-brand);background:var(--t-brand);border:1px solid var(--t-brand);border-radius:999px;padding:1px 9px}
   .wr-personal-h-row{display:flex;align-items:baseline;gap:9px;flex-wrap:wrap;margin-bottom:16px}
   .wr-personal{max-width:760px}
   .wr-list{list-style:none;margin:6px 0 0;padding:0}

--- a/scripts/generators/html/contributions-report-html-generator.js
+++ b/scripts/generators/html/contributions-report-html-generator.js
@@ -24,6 +24,7 @@ const HTML_REPORTS_FILENAME = 'reports.html';
 // details[open]/:not([open]) selectors in that shared stylesheet.
 const REPORTS_EXTRA_CSS = `
   .rpt-card-link{background-color:var(--t-card)}
+  .rpt-stat{display:flex;flex-direction:column-reverse}
   @media (prefers-reduced-motion: reduce) {
     .report-card-link, details, summary { transition: none !important; }
   }
@@ -98,7 +99,7 @@ async function createHtmlReports(quarterlyFileLinks = []) {
       linkHtml += dedent`
             <details ${openAttribute} class="col-span-full mb-8 border rounded-2xl overflow-hidden transition duration-300" style="border-color: var(--t-line);">
                 <summary style="color: var(--t-ink);" class="text-2xl font-bold p-6 cursor-pointer transition duration-150 flex items-center">
-                    <span class="mr-3">📅</span> ${year} Reports
+                    <h2 class="m-0 text-2xl font-bold"><span class="mr-3" aria-hidden="true">📅</span> ${year} Reports</h2>
                 </summary>
                 <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6 p-8">
                 `;
@@ -109,9 +110,11 @@ async function createHtmlReports(quarterlyFileLinks = []) {
                 <a href="./${link.relativePath}"
                    style="border-color: var(--t-line);"
                    class="report-card-link rpt-card-link border rounded-xl shadow-sm hover:shadow-md transition-all duration-200 p-6">
-                    <p style="color: var(--t-brand);" class="text-sm font-semibold">${link.quarterText}</p>
-                    <p style="color: var(--t-ink);" class="text-3xl font-extrabold mt-1">${link.totalContributions}</p>
-                    <p style="color: var(--t-ink-3);" class="text-xs">Total Contributions</p>
+                    <h3 style="color: var(--t-brand);" class="m-0 text-sm font-semibold">${link.quarterText}</h3>
+                    <dl class="rpt-stat m-0 mt-1">
+                        <dd style="color: var(--t-ink);" class="text-3xl font-extrabold m-0">${link.totalContributions}</dd>
+                        <dt style="color: var(--t-ink-3);" class="text-xs font-normal">Total Contributions</dt>
+                    </dl>
                 </a>
                 `;
       }

--- a/scripts/generators/html/journey-html-generator.js
+++ b/scripts/generators/html/journey-html-generator.js
@@ -202,8 +202,13 @@ function renderExperience(roles) {
   }
   return roles
     .map((role) => {
+      // Adjacent roles at the same org (e.g. two Virtual Coffee entries in a
+      // row) would otherwise produce two links with identical text and
+      // destination back to back — a "redundant link" a screen reader user
+      // can't tell apart. The aria-label folds in the role title so each
+      // link's accessible name stays unique without changing what's shown.
       const orgHtml = role.orgUrl
-        ? `<a href="${role.orgUrl}" target="_blank" rel="noopener noreferrer">${escapeHtml(role.org)}</a>`
+        ? `<a href="${role.orgUrl}" target="_blank" rel="noopener noreferrer" aria-label="${escapeHtml(role.org)} — ${escapeHtml(role.title)}">${escapeHtml(role.org)}</a>`
         : escapeHtml(role.org || '');
       const period = role.active
         ? `${String(role.period || '').replace(/ ?- ?Present$/i, '')} — <b>present</b>`

--- a/scripts/generators/html/landing-page-html-generator.js
+++ b/scripts/generators/html/landing-page-html-generator.js
@@ -61,15 +61,6 @@ const LANDING_CSS = `
     background:linear-gradient(120deg,var(--t-brand-wash),var(--t-card-2) 62%)}
   .lp-impact-top h2{font-size:1.05rem;font-weight:800;margin:0;color:var(--t-ink)}
   .lp-impact-top h2 span{color:var(--t-ink-2);font-weight:400;font-size:.86rem}
-  /* Above the .lp-cols breakpoint, match the hero/impact card width to the
-     Contribution mix column exactly: that column is one of two
-     minmax(0,1fr) tracks with a 40px gap, so its width is always
-     calc(50% - 20px) of the same container these cards sit in. Below the
-     breakpoint .lp-cols collapses to one column (full width), so the cap
-     is scoped to only apply once that second column exists. */
-  @media (min-width:861px){
-    .lp-hero,.lp-impact{max-width:calc(50% - 20px)}
-  }
   .lp-live{display:inline-flex;align-items:center;gap:7px;font-family:ui-monospace,monospace;font-size:.75rem;letter-spacing:.09em;text-transform:uppercase;color:var(--t-positive)}
   .lp-live i{width:8px;height:8px;border-radius:50%;background:var(--t-positive);position:relative}
   .lp-live i::after{content:"";position:absolute;inset:-4px;border-radius:50%;border:1px solid var(--t-positive);animation:lp-ping 2.4s ease-out infinite}

--- a/scripts/generators/html/quarterly-reports-html-generator.js
+++ b/scripts/generators/html/quarterly-reports-html-generator.js
@@ -66,11 +66,11 @@ const QUARTERLY_EXTRA_CSS = `
   .qr-highlight-card{background:var(--t-card);border:1px solid var(--t-line);border-radius:12px;padding:16px;text-decoration:none;display:flex;flex-direction:column;gap:6px;transition:border-color .15s ease,box-shadow .15s ease}
   .qr-highlight-card:hover{border-color:var(--t-brand-line);box-shadow:var(--t-shadow)}
   .qr-highlight-card:focus-visible{outline:2px solid var(--t-brand);outline-offset:2px}
-  .qr-highlight-type{align-self:flex-start;font-family:ui-monospace,monospace;font-size:.68rem;letter-spacing:.05em;text-transform:uppercase;color:var(--t-brand);background:var(--t-brand-wash);border-radius:5px;padding:2px 8px}
+  .qr-highlight-type{align-self:flex-start;font-family:ui-monospace,monospace;font-size:.75rem;letter-spacing:.05em;text-transform:uppercase;color:var(--t-brand);background:var(--t-brand-wash);border-radius:5px;padding:2px 8px}
   .qr-highlight-repo{font-family:ui-monospace,monospace;font-size:.72rem;color:var(--t-ink-3)}
   .qr-highlight-title{font-size:.92rem;font-weight:700;color:var(--t-ink);line-height:1.35}
   .qr-highlight-card:hover .qr-highlight-title{color:var(--t-brand)}
-  .qr-highlight-meta{font-family:ui-monospace,monospace;font-size:.7rem;color:var(--t-ink-3)}
+  .qr-highlight-meta{font-family:ui-monospace,monospace;font-size:.75rem;color:var(--t-ink-3)}
 
   .qr-ink2{color:var(--t-ink-2)}
   .qr-ink3{color:var(--t-ink-3)}
@@ -139,7 +139,7 @@ const QUARTERLY_EXTRA_CSS = `
       content: attr(data-label);
       flex: 0 0 42%;
       font-family: ui-monospace, monospace;
-      font-size: .68rem;
+      font-size: .75rem;
       text-transform: uppercase;
       letter-spacing: .04em;
       color: var(--t-ink-3);
@@ -481,7 +481,7 @@ async function writeHtmlFiles(groupedContributions) {
       const prevPath = getReportPath(previousReport);
       previousButton = dedent`
         <a href="${prevPath}" class="${baseClasses} nav-report-button text-left" style="color: var(--t-brand);">
-          <span class="text-[10px] sm:text-xs font-medium" style="color: var(--t-ink-3);">Previous</span>
+          <span class="text-xs font-medium" style="color: var(--t-ink-3);">Previous</span>
           <span class="flex items-center space-x-1 font-bold text-sm sm:text-lg break-words whitespace-normal" style="color: var(--t-brand);">
             ${LEFT_ARROW_SVG}
             <span class="whitespace-normal min-w-0">${previousReport.fullQuarterName}</span>
@@ -498,7 +498,7 @@ async function writeHtmlFiles(groupedContributions) {
       const nextPath = getReportPath(nextReport);
       nextButton = dedent`
         <a href="${nextPath}" class="${baseClasses} nav-report-button text-right" style="color: var(--t-brand);">
-          <span class="text-[10px] sm:text-xs font-medium" style="color: var(--t-ink-3);">Next</span>
+          <span class="text-xs font-medium" style="color: var(--t-ink-3);">Next</span>
           <span class="flex items-center space-x-1 justify-end font-bold text-sm sm:text-lg break-words whitespace-normal" style="color: var(--t-brand);">
             <span class="whitespace-normal min-w-0">${nextReport.fullQuarterName}</span>
             ${RIGHT_ARROW_SVG}
@@ -689,7 +689,7 @@ ${navHtmlForReports}
         </section>
 
         <section class="mb-8">
-          <h3 class="text-2xl font-semibold mt-16 mb-4 border-l-4 pl-3" style="color: var(--t-ink); border-left-color: var(--t-positive);">Contribution Breakdown</h3>
+          <h2 class="text-2xl font-semibold mt-16 mb-4 border-l-4 pl-3" style="color: var(--t-ink); border-left-color: var(--t-positive);">Contribution Breakdown</h2>
           <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-4 text-sm">
             ${[
               {
@@ -741,7 +741,7 @@ ${navHtmlForReports}
         </section>
 
         <section class="mb-8">
-          <h3 class="text-2xl font-semibold mb-4 border-l-4 pl-3" style="color: var(--t-ink); border-left-color: var(--t-caution);">Top 3 Repositories</h3>
+          <h2 class="text-2xl font-semibold mb-4 border-l-4 pl-3" style="color: var(--t-ink); border-left-color: var(--t-caution);">Top 3 Repositories</h2>
           <div class="p-4 qr-surface2 rounded-lg shadow-sm">
             <ol class="list-decimal list-inside pl-4 qr-ink2 space-y-1">
               ${top3Repos}
@@ -857,7 +857,17 @@ ${navHtmlForReports}
           tableContent += `<td data-label="Project"><span class="qr-repo">${sanitizeAttribute(item.repo || '')}</span></td>`;
 
           // Title column (String type, contains hyperlink). Sort falls back to textContent.
-          tableContent += `<td data-label="Title"><a href="${sanitizeAttribute(item.url)}" target="_blank" rel="noopener noreferrer" class="qr-link">${safeTitle}</a></td>`;
+          // Backports/cherry-picks routinely reuse the exact same PR title
+          // across different PRs (see e.g. Q2-2026's "docs: Add Tags
+          // documentation for Contact management" filed 3 times) — two
+          // links with identical text but different destinations is
+          // exactly what WAVE's "suspicious link text" flags, since a
+          // screen reader's link list can't tell them apart. The number
+          // pulled from the PR/issue URL disambiguates the accessible name
+          // without changing what's shown.
+          const refMatch = String(item.url || '').match(/\/(pull|issues)\/(\d+)/);
+          const refSuffix = refMatch ? ` (#${refMatch[2]})` : '';
+          tableContent += `<td data-label="Title"><a href="${sanitizeAttribute(item.url)}" target="_blank" rel="noopener noreferrer" class="qr-link" aria-label="${sanitizeAttribute(item.title || '')}${refSuffix}">${safeTitle}</a></td>`;
 
           // Handle the remaining columns based on the contribution type.
           if (section === 'pullRequests') {

--- a/scripts/metadata/glossary.js
+++ b/scripts/metadata/glossary.js
@@ -21,6 +21,14 @@ const GLOSSARY_CONTENT = {
             'Adds the grand total of merged PRs, issues, reviewed PRs, co-authored PRs, and community collaborations.',
         },
         {
+          id: 'shippedChanges',
+          title: 'Shipped Changes',
+          description:
+            'How many of the Total Impact contributions were finished and accepted, not just started.',
+          howItIsCalculated:
+            'Counts contributions GitHub has marked as merged. The Total Impact number also includes work still open or in progress, so this smaller number shows what has actually been completed.',
+        },
+        {
           id: 'activeSince',
           title: 'Active Since',
           description: 'The year of the first recorded contribution found on GitHub.',


### PR DESCRIPTION
## Summary
- Landing page hero/impact cards now span the full width of the two-column section instead of being capped to one column.
- Writing page's article count pill uses the brand fill with the theme engine's validated on-brand text color, passing WCAG AA contrast in both light and dark themes.
- Addresses several WAVE accessibility warnings: redundant title attributes on writing page article links, ambiguous adjacent same-destination links on the journey page, stat text styled to look like headings (without real heading markup) on the reports and quarterly pages, a skipped heading level, and a few sub-11px text sizes.
- Adds a plain-language glossary entry explaining the landing page's "shipped changes" figure.

## Test plan
- [x] Regenerated the landing, writing, journey, reports, and quarterly pages locally from cached data and spot-checked the rendered HTML for each change.
- [x] Verified heading order (h1 → h2 → h3, no skips) on the reports and quarterly pages.
- [x] Verified the brand-colored pill's contrast is guaranteed by the theme engine's existing validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)