### PR TITLE
Feat: Add Recognitions section to the Writing page

### DIFF
--- a/contents/recognitions.js
+++ b/contents/recognitions.js
@@ -1,0 +1,95 @@
+/**
+ * External recognition for individual pieces of writing — top-of-the-week
+ * picks, challenge wins, editor's choice, etc. Shown at the top of the
+ * Writing page, above the article lists.
+ *
+ * Fields: title (req — the recognized piece's title, or the recognition
+ *         itself), org (req — the platform/publication that recognized it),
+ *         month (req — 1–12), year (req), url (req — link to the piece or
+ *         the recognition), description (optional — may include a raw <a>
+ *         link to the specific article that was selected), highlight
+ *         (optional: renders with a ★ marker for a standout entry)
+ */
+module.exports = [
+  {
+    title: 'Top 7 Featured DEV Posts of the Week',
+    org: 'DEV Community',
+    month: 11,
+    year: 2021,
+    url: 'https://dev.to/devteam/top-7-featured-dev-posts-from-the-past-week-35fb',
+    description:
+      'Featured for <a href="https://dev.to/adiatiayu/contributing-to-open-source-101-2dnm" target="_blank" rel="noopener noreferrer">"Contributing to Open Source 101"</a>.',
+  },
+  {
+    title: 'OSS Grant Badge Winners',
+    org: 'Hashnode',
+    month: 11,
+    year: 2021,
+    url: 'https://townhall.hashnode.com/oss-grant-badge-winners',
+    description:
+      "Placed 2nd for the OSS Documentarian badge and was recognized among the OSS Mentor badge winners, as part of Hashnode's Open Source October.",
+  },
+  {
+    title: 'Top 7 Featured DEV Posts of the Week',
+    org: 'DEV Community',
+    month: 9,
+    year: 2022,
+    url: 'https://dev.to/devteam/top-7-featured-dev-posts-from-the-past-week-4phi',
+    description:
+      'Featured for <a href="https://dev.to/adiatiayu/mini-portfolio-bring-your-github-profile-to-the-next-level-5c8n" target="_blank" rel="noopener noreferrer">"Mini Portfolio: Bring Your GitHub Profile to the Next Level"</a>.',
+  },
+  {
+    title: 'Top Featured CodeNewbie Posts',
+    org: 'CodeNewbie',
+    month: 8,
+    year: 2023,
+    url: 'https://dev.to/codenewbieteam/top-featured-codenewbie-posts-81723-48i4',
+    description:
+      'Featured for <a href="https://dev.to/adiatiayu/how-to-communicate-better-in-open-source-3hdj" target="_blank" rel="noopener noreferrer">"How to Communicate Better in Open Source"</a>.',
+  },
+  {
+    title: "Quincy Larson's Weekly Email — Sep 22, 2023",
+    org: 'freeCodeCamp',
+    month: 9,
+    year: 2023,
+    url: 'https://github.com/freeCodeCamp/awesome-quincy-larson-emails#sep-22-2023',
+    description:
+      'Recommended in the newsletter for <a href="https://www.freecodecamp.org/news/how-to-contribute-to-open-source/" target="_blank" rel="noopener noreferrer">"How to Contribute to Open Source Projects – Non-Technical Things You Should Know"</a>.',
+  },
+  {
+    title: 'Top Open Source Contributors 2023',
+    org: 'freeCodeCamp',
+    month: 11,
+    year: 2023,
+    url: 'https://www.freecodecamp.org/news/top-open-source-contributors-2023/',
+    description: "Listed among freeCodeCamp's top publication contributors of the year.",
+  },
+  {
+    title: 'Top 7 Featured DEV Posts of the Week',
+    org: 'DEV Community',
+    month: 4,
+    year: 2025,
+    url: 'https://dev.to/devteam/top-7-featured-dev-posts-of-the-week-4idc',
+    description:
+      'Featured for <a href="https://dev.to/adiatiayu/the-curated-automated-open-source-portfolio-how-its-going-5f98" target="_blank" rel="noopener noreferrer">"The Curated, Automated Open Source Portfolio: How It\'s Going"</a>.',
+  },
+  {
+    title: 'Top 7 Featured DEV Posts of the Week',
+    org: 'DEV Community',
+    month: 10,
+    year: 2025,
+    url: 'https://dev.to/devteam/top-7-featured-dev-posts-of-the-week-53an',
+    description:
+      'Featured for <a href="https://dev.to/adiatiayu/how-i-built-a-curated-automated-open-source-portfolio-18o0" target="_blank" rel="noopener noreferrer">"How I Built a Curated, Automated Open Source Portfolio"</a>.',
+  },
+  {
+    title: '2025 Hacktoberfest Writing Challenge Winners',
+    org: 'DEV Community',
+    month: 11,
+    year: 2025,
+    url: 'https://dev.to/devteam/congrats-to-the-2025-hacktoberfest-writing-challenge-winners-1hpn/#open-source-reflections-winners',
+    highlight: true,
+    description:
+      'Winner in the Open Source Reflections category for <a href="https://dev.to/adiatiayu/beyond-hacktoberfest-building-a-true-open-source-journey-3pci" target="_blank" rel="noopener noreferrer">"Beyond Hacktoberfest: Building a True Open Source Journey"</a>.',
+  },
+];

--- a/scripts/generators/html/blog-html-generator.js
+++ b/scripts/generators/html/blog-html-generator.js
@@ -3,11 +3,15 @@
  * Journey timeline (design blueprint) — no Talks chip, no talks slot here.
  *
  * Structural contract:
- *   1. "Written for organizations" timeline — every article with `org` set
+ *   1. Recognitions — external recognition for individual pieces (top picks,
+ *      challenge wins), same spine/marker/star design as the Journey page's
+ *      "Selected work" timeline. Leads the page. Renders only when at least
+ *      one recognition exists.
+ *   2. "Written for organizations" timeline — every article with `org` set
  *      (freeCodeCamp + Dev.to org posts), grouped into one node per org on a
  *      continuous spine, orgs ordered by their most recent piece. Renders
  *      only when at least one org article exists.
- *   2. Personal writing list — only articles with org = null/missing, newest
+ *   3. Personal writing list — only articles with org = null/missing, newest
  *      first: title (2-line clamp, full text in `title`), date, tags.
  * An article renders in exactly one place — the timeline or the list, never
  * both.
@@ -58,9 +62,10 @@ const WRITING_CSS = `
   .wr-item:last-child{border-bottom:0}
   .wr-item.wr-hidden{display:none}
   .wr-item-t{font-size:.95rem;font-weight:600;margin:0;line-height:1.4}
-  .wr-item-t a{color:var(--t-ink);text-decoration:none;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;overflow-wrap:anywhere}
-  .wr-item-t a:hover{color:var(--t-brand)}
-  .wr-meta{display:flex;align-items:center;gap:8px;flex-wrap:wrap;font-family:ui-monospace,monospace;font-size:.75rem;color:var(--t-ink-3);margin-top:4px}
+  .wr-item-t a{color:var(--t-ink);text-decoration:underline;text-decoration-color:var(--t-brand-line);
+    text-decoration-thickness:2px;text-underline-offset:3px;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;overflow-wrap:anywhere}
+  .wr-item-t a:hover{color:var(--t-brand);text-decoration-color:var(--t-brand)}
+  .wr-meta{display:flex;align-items:center;gap:8px;flex-wrap:wrap;font-family:ui-monospace,monospace;font-size:.75rem;color:var(--t-ink-3);margin-top:8px}
   .wr-platform{color:var(--t-ink-2);font-weight:600}
   .wr-tags{display:flex;flex-wrap:wrap;gap:6px}
   .wr-tag{font-family:ui-monospace,monospace;font-size:.75rem;color:var(--t-ink-2);background:var(--t-card-2);border:1px solid var(--t-line);border-radius:6px;padding:1px 8px}
@@ -72,6 +77,31 @@ const WRITING_CSS = `
   .wr-chip-n{opacity:.75}
   .wr-empty{color:var(--t-ink-3);font-style:italic;font-size:.9rem}
   @media (prefers-reduced-motion: reduce){.wr-chip{transition:none}}
+  /* Recognitions — same spine/marker/title/meta/description design as the
+     Journey page's "Selected work" timeline (journey-html-generator.js). */
+  .wr-rec-tl{position:relative;padding-left:26px;max-width:660px}
+  .wr-rec-tl::before{content:"";position:absolute;left:6px;top:6px;bottom:6px;width:2px;border-radius:2px;
+    background:linear-gradient(var(--t-brand-line),var(--t-line))}
+  .wr-rec-item{position:relative;padding:14px 0 10px}
+  .wr-rec-item::before{content:"";position:absolute;left:-24.5px;top:23px;width:11px;height:11px;border-radius:50%;
+    background:var(--t-card);border:2.5px solid var(--t-brand);transition:transform .15s ease}
+  .wr-rec-item:hover::before{transform:scale(1.25)}
+  .wr-rec-item--hl::before{background:var(--t-brand);border-color:var(--t-brand);width:13px;height:13px;left:-25.5px;top:22px}
+  .wr-rec-star{color:var(--t-caution);margin-right:3px}
+  .wr-rec-sr{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
+  @media (prefers-reduced-motion: reduce){.wr-rec-item::before{transition:none}}
+  .wr-rec-item h3{font-size:1.16rem;font-weight:800;margin:0;line-height:1.32}
+  .wr-rec-item h3 a{color:var(--t-ink);text-decoration:underline;text-decoration-color:var(--t-brand-line);
+    text-decoration-thickness:2px;text-underline-offset:3px}
+  .wr-rec-item h3 a:hover{color:var(--t-brand);text-decoration-color:var(--t-brand)}
+  .wr-rec-item h3 a:focus-visible{outline:2px solid var(--t-brand);outline-offset:3px;border-radius:3px}
+  .wr-rec-org{font-family:ui-monospace,monospace;font-size:.75rem;letter-spacing:.08em;color:var(--t-ink-3);margin:14px 0 7px}
+  .wr-rec-org b{color:var(--t-accent);font-weight:400}
+  .wr-rec-desc{font-size:.9rem;color:var(--t-ink-2);margin:0;max-width:60ch}
+  .wr-rec-desc a{color:var(--t-accent);text-decoration:underline;text-decoration-color:var(--t-brand-line);
+    text-decoration-thickness:2px;text-underline-offset:2px}
+  .wr-rec-desc a:hover{color:var(--t-brand);text-decoration-color:var(--t-brand)}
+  .wr-rec-desc a:focus-visible{outline:2px solid var(--t-brand);outline-offset:2px;border-radius:3px}
 `;
 
 function formatDate(dateStr) {
@@ -102,6 +132,57 @@ function renderArticleItem(article, { showPlatform, headingTag }) {
         ${tagsHtml ? `<span class="wr-tags">${tagsHtml}</span>` : ''}
       </div>
     </li>
+  `;
+}
+
+const MONTH_NAMES = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+];
+
+function formatMonthYear(rec) {
+  return `${MONTH_NAMES[rec.month - 1]} ${rec.year}`;
+}
+
+function renderRecognitionItem(rec) {
+  const org = escapeHtml(rec.org || '');
+  const titleHtml = rec.url
+    ? `<a href="${escapeHtml(rec.url)}" target="_blank" rel="noopener noreferrer">${rec.title}</a>`
+    : rec.title;
+  const descHtml = rec.description ? `<p class="wr-rec-desc">${rec.description}</p>` : '';
+  const starHtml = rec.highlight
+    ? `<span class="wr-rec-sr">Highlighted: </span><span class="wr-rec-star" aria-hidden="true">★</span>`
+    : '';
+  return dedent`
+    <article class="wr-rec-item${rec.highlight ? ' wr-rec-item--hl' : ''}">
+      <h3>${starHtml}${titleHtml}</h3>
+      <div class="wr-rec-org"><b>${org}</b> · ${formatMonthYear(rec)}</div>
+      ${descHtml}
+    </article>
+  `;
+}
+
+function renderRecognitions(recognitions) {
+  if (!recognitions || recognitions.length === 0) return '';
+  const sorted = [...recognitions].sort(
+    (a, b) => b.year - a.year || b.month - a.month
+  );
+  const items = sorted.map(renderRecognitionItem).join('');
+  return dedent`
+    <section aria-labelledby="wr-rec-h" class="mb-16">
+      <h2 id="wr-rec-h" class="wr-sec-label">Recognitions</h2>
+      <div class="wr-rec-tl">${items}</div>
+    </section>
   `;
 }
 
@@ -170,7 +251,7 @@ function renderPersonalSection(personalArticles, hasOrgArticles) {
   `;
 }
 
-async function createBlogHtml(articles) {
+async function createBlogHtml(articles, recognitions) {
   const htmlBaseDir = path.join(BASE_DIR, 'html-generated');
   // Renamed to writing.html in the IA restructure (design blueprint §02);
   // blog.html is kept as a redirect stub for old links (see main.js).
@@ -208,6 +289,8 @@ async function createBlogHtml(articles) {
               <h1 class="wr-h1 text-4xl sm:text-5xl mt-2 mb-4">Articles on open source and GitHub</h1>
               <p class="wr-sub">Guides and blog posts covering open source, its community, and the GitHub ecosystem.</p>
             </header>
+
+            ${renderRecognitions(recognitions)}
 
             ${renderOrgTimeline(orgArticles)}
 

--- a/scripts/generators/markdown/blog-markdown-generator.js
+++ b/scripts/generators/markdown/blog-markdown-generator.js
@@ -2,7 +2,7 @@ const fs = require('fs/promises');
 const path = require('path');
 const { GITHUB_USERNAME, BASE_DIR } = require('../../config/config');
 const { newestFirst, platformsIn, groupByOrg } = require('../../services/writing-model');
-const { mdEscapeLinkText } = require('./md-escape');
+const { mdEscapeLinkText, mdEscapeCell } = require('./md-escape');
 
 function formatDate(dateStr) {
   return new Date(dateStr).toLocaleDateString('en-US', {
@@ -24,6 +24,39 @@ function articleBullet(article, { showPlatform }) {
   const platformBit =
     showPlatform && article.platform ? `Published on **${article.platform}** — ` : '';
   md += `  ${platformBit}${formatDate(article.date)}\n`;
+  return md + '\n';
+}
+
+const MONTH_NAMES = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+];
+
+/** Mirrors renderRecognitions: newest first, ★ prefix on highlighted entries. */
+function renderRecognitionsSection(recognitions) {
+  if (!recognitions || recognitions.length === 0) return '';
+  let md = `## 🏅 Recognitions\n\n`;
+  [...recognitions]
+    .sort((a, b) => b.year - a.year || b.month - a.month)
+    .forEach((rec) => {
+      const title = rec.url
+        ? `[${mdEscapeLinkText(rec.title)}](${rec.url})`
+        : mdEscapeCell(rec.title);
+      const starPrefix = rec.highlight ? '★ ' : '';
+      const monthYear = `${MONTH_NAMES[rec.month - 1]} ${rec.year}`;
+      md += `* ${starPrefix}**${title}** (${monthYear}) — *${mdEscapeCell(rec.org)}*\n`;
+      if (rec.description) md += `  * ${mdEscapeCell(rec.description)}\n`;
+    });
   return md + '\n';
 }
 
@@ -63,14 +96,16 @@ function renderPersonalSection(personalArticles, hasOrgArticles) {
  * Generates and writes a Markdown report of articles written by the user.
  * Mirrors writing.html — renamed from blog.md in the IA restructure
  * (design blueprint §02). Talks live exclusively on the Journey timeline,
- * not here. Structure matches writing.html exactly: an org timeline (one
- * heading per org with `org` set, newest org first) above a personal list
- * (only articles with org = null/missing); an article appears in exactly
- * one section, never both. Grouping/sort rules live in
- * services/writing-model.js, shared with the HTML generator.
+ * not here. Structure matches writing.html exactly: recognitions (from
+ * contents/recognitions.js) lead, then an org timeline (one heading per org
+ * with `org` set, newest org first) above a personal list (only articles
+ * with org = null/missing); an article appears in exactly one section,
+ * never both. Grouping/sort rules live in services/writing-model.js, shared
+ * with the HTML generator.
  * @param {Array} articles Sorted list of article objects.
+ * @param {Array} recognitions contents/recognitions.js
  */
-async function writeArticlesMarkdown(articles) {
+async function writeArticlesMarkdown(articles, recognitions) {
   const mdBaseDir = path.join(BASE_DIR, 'markdown-generated');
   const outputPath = path.join(mdBaseDir, 'writing.md');
 
@@ -82,6 +117,7 @@ async function writeArticlesMarkdown(articles) {
 
   let markdownContent = `# Writing\n\n`;
   markdownContent += `Articles by **${GITHUB_USERNAME}**, covering insights and tutorials regarding the Open Source and GitHub ecosystem.\n\n`;
+  markdownContent += renderRecognitionsSection(recognitions);
   markdownContent += renderOrgSection(orgArticles);
   markdownContent += renderPersonalSection(personalArticles, orgArticles.length > 0);
 

--- a/scripts/src/main.js
+++ b/scripts/src/main.js
@@ -50,6 +50,7 @@ const { createRedirectStubs } = require('../generators/html/redirect-stub-genera
 const { createGlossaryHtml } = require('../generators/html/glossary-html-generator');
 const { loadMergedWorkbench } = require('../services/workbench-merge');
 const skillsData = require('../../contents/skills');
+const recognitionsData = require('../../contents/recognitions');
 // Milestone sources — keys must match MILESTONE_SOURCES in
 // services/milestones-model.js, which maps each to its timeline tag.
 const milestoneContent = {
@@ -512,8 +513,8 @@ async function main() {
     await createHtmlReports(quarterlyHtmlLinks);
 
     // 7. Generate Writing (HTML and Markdown) — talks live on Journey, not here
-    await createBlogHtml(articles);
-    await writeArticlesMarkdown(articles);
+    await createBlogHtml(articles, recognitionsData);
+    await writeArticlesMarkdown(articles, recognitionsData);
 
     // --- 8. Generate Journey + Workbench pages (IA split of the old
     // Community & Activity page — design blueprint §02) ---


### PR DESCRIPTION
## Summary
- Adds a "Recognitions" section at the top of the Writing page (HTML + Markdown mirror), for external recognition of individual articles — weekly features, challenge wins, badges, newsletter mentions — styled after the Journey page's "Selected work" timeline (spine, marker, underlined title, org/month/year meta, description).
- Adds `contents/recognitions.js` with nine real entries, each carrying a month + year.
- Underlines added to writing-page article title links and inline description links for consistency, with adjusted title-to-meta spacing.
- `data/` and `contributions/` output is intentionally left untouched here — regenerated separately via GH Actions.

## Test plan
- [x] Generated `writing.html`/`writing.md` locally from existing data and confirmed the Recognitions section renders correctly, sorted newest month/year first, with the highlight star on the challenge win
- [x] Confirmed link underlines and spacing render as expected
- [ ] Visual check once GH Actions regenerates the live pages