### PR TITLE
fix: UX consistency pass across Workbench, Journey, Writing, and Reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,13 @@ Manual data and preferences are managed within the `scripts/config/` and `conten
     | `critical` | Work that is blocked, and anything that failed |
     | `neutral` | The grays: quieter text, thin dividing lines, and items that have gone stale |
 
-    You can also set `accent`, `surface`, and `ink` in the same file, but you do not have to. Leave them out and they are worked out from the five above.
+    You can also set `accent`, `surface`, and `ink` in the same file, but you do not have to. Leave them out and they are worked out from the five above:
+
+    | Setting | Where you see it |
+    | :--- | :--- |
+    | `accent` | A playful highlight, separate from your main brand color: the last word of your name on the Home page, org names on the Journey page, the "Focused" persona seal, and the underline under every external link site-wide. Left out, it is worked out from `brand`. |
+    | `surface` | The page background behind every card, in light mode. Left out, it is a very light, brand-tinted off-white. |
+    | `ink` | The main text color, in light mode. Left out, it is a near-black tinted with `brand`. |
 
     If one of your colors would make text too hard to read against its background, the site refuses to build and tells you which color caused it, so you cannot accidentally publish a page people cannot read.
 

--- a/contents/courses.js
+++ b/contents/courses.js
@@ -1,11 +1,22 @@
 /**
- * Courses and curricula you authored, shown on the Journey milestones
- * timeline with a 🎓 Course tag.
+ * Courses — both ones you authored and ones you took — shown on the Journey
+ * milestones timeline with a 🎓 Course tag.
  *
  * Fields: title (req), org (req), year (req),
  *         yearEnd (optional: a year, or 'present'),
- *         url (req), description (optional),
+ *         description (optional),
  *         highlight (optional: shows before the "show more" control)
+ *
+ * Links — pick whichever fits the entry, both are optional and either can
+ * be left out without breaking anything:
+ *   url               a single link (e.g. a course you authored — the
+ *                      course page itself is the evidence)
+ *   courseUrl /
+ *   certificationUrl  for a course you took: the course page and the
+ *                      certificate you earned for completing it. The title
+ *                      links to whichever of the two exists; if both do,
+ *                      the other shows as a small "Certificate" link next
+ *                      to it.
  */
 module.exports = [
   {
@@ -16,4 +27,13 @@ module.exports = [
     description:
       "Wrote and published a full course taking contributors from their first change through to helping run a project — sorting incoming issues, reviewing other people's work, and keeping a community healthy.",
   },
+  // Example of a course you took rather than authored — course and
+  // certificate as two separate, both-optional links:
+  // {
+  //   title: 'Advanced Git',
+  //   org: 'Some Learning Platform',
+  //   year: 2025,
+  //   courseUrl: 'https://example.com/courses/advanced-git',
+  //   certificationUrl: 'https://example.com/certificates/abc123',
+  // },
 ];

--- a/contents/docs.js
+++ b/contents/docs.js
@@ -47,7 +47,7 @@ module.exports = [
     url: 'https://virtualcoffee.io/resources/virtual-coffee-handbook',
     highlight: true,
     description:
-      "Created and looked after Virtual Coffee's handbook for four years — from how to join through to finding your way around Slack — including a 2023 reorganization of every community resource on the site.",
+      "Created and looked after Virtual Coffee's handbook — from how to join through to finding your way around Slack — including a 2023 reorganization of every community resource on the site.",
   },
   {
     title: 'Virtual Coffee Monthly Challenges documentation',

--- a/contents/projects.js
+++ b/contents/projects.js
@@ -19,13 +19,13 @@ module.exports = [
   },
   {
     title: 'Mautic Docs PRs Tracker',
-    org: 'Mautic',
+    org: 'Personal / Mautic',
     year: 2026,
     yearEnd: 'present',
     url: 'https://github.com/adiati98/mautic-docs-prs-tracker',
     highlight: true,
     description:
-      'Built a board showing the Education Team which documentation changes are waiting on a review, with a reminder page that nudges developers to take a look.',
+      'Built an automated board showing the Education Team which documentation PRs are waiting on a review, with a reminder page that nudges developers to take a look.',
   },
   {
     title: 'OSS Portfolio Template',

--- a/scripts/components/footer.js
+++ b/scripts/components/footer.js
@@ -39,7 +39,7 @@ function createFooterHtml() {
       ${
         PROFILE.linkedIn
           ? `<div class="text-sm mt-3">
-          <a href="${PROFILE.linkedIn}" target="_blank" rel="noopener noreferrer" style="color: ${COLORS.primaryText};" class="hover:opacity-80 font-semibold underline underline-offset-4 transition duration-150">
+          <a href="${PROFILE.linkedIn}" target="_blank" rel="noopener noreferrer" style="color: ${COLORS.primaryText};" class="hover:opacity-80 font-semibold transition duration-150">
               Get in touch on LinkedIn
           </a>
       </div>`

--- a/scripts/components/navbar.js
+++ b/scripts/components/navbar.js
@@ -352,6 +352,19 @@ const SHARED_CHROME_CSS = `
     text-decoration:none;transition:top .15s ease}
   .skip-link:focus{top:10px}
   @media (prefers-reduced-motion: reduce){.skip-link{transition:none}}
+  /* Every external link, site-wide — one shared rule instead of each page
+     hand-rolling its own (Journey and Writing used to). Underlined at rest,
+     not just on hover: hover doesn't exist on touch, and an unstyled link
+     reads as plain text, hiding the affordance nobody can see otherwise.
+     The underline itself uses --t-accent — the seed a fork sets for a
+     playful highlight color, already falling back to a hue-rotated brand
+     when a fork leaves it unset (see theme.js/theme-engine.js), so this
+     needs no separate "is accent configured" branch. .no-underline opts a
+     link back out — for a card/tile where the whole multi-line block is the
+     link, underlining it would draw a line under every line inside. */
+  a[target="_blank"]:not(.no-underline){text-decoration:underline;text-decoration-color:var(--t-accent-line);
+    text-decoration-thickness:2px;text-underline-offset:3px}
+  a[target="_blank"]:not(.no-underline):hover{text-decoration-color:var(--t-accent)}
   .back-to-top{position:fixed;right:20px;bottom:20px;z-index:40;width:46px;height:46px;border-radius:50%;
     display:flex;align-items:center;justify-content:center;font-size:1.15rem;line-height:1;cursor:pointer;
     background:var(--t-brand);color:var(--t-on-brand);border:1px solid var(--t-brand-line);

--- a/scripts/config/constants.js
+++ b/scripts/config/constants.js
@@ -22,7 +22,9 @@ const {
  *
  * Semantic mapping (see design blueprint §01):
  *   primary            → brand seed
- *   success / merged   → positive ladder (the old violet "merged" is retired)
+ *   success            → positive ladder
+ *   merged (COLORS.status.purple / report MERGED badge) → the fixed `merged`
+ *                         ladder (GitHub's own purple, see theme-engine.js)
  *   error              → critical ladder
  *   take-action        → caution ladder      watching → brand ladder
  *   waiting / approved → positive ladder     stale/bot → neutral ladder
@@ -96,7 +98,7 @@ const { colors: COLORS, cssVarsBlock: PALETTE_CSS_VARS } = generateColorsObject(
  */
 COLORS.status = {
   green: { bg: 'var(--t-positive-wash)', text: 'var(--t-positive)' },
-  purple: { bg: 'var(--t-positive-wash)', text: 'var(--t-positive)' },
+  purple: { bg: 'var(--t-merged-wash)', text: 'var(--t-merged)' },
   red: { bg: 'var(--t-critical-wash)', text: 'var(--t-critical)' },
   gray: { bg: 'var(--t-neutral-wash)', text: 'var(--t-neutral)' },
 };

--- a/scripts/config/theme-engine.js
+++ b/scripts/config/theme-engine.js
@@ -175,7 +175,11 @@ function deriveTheme(seeds = SEEDS) {
 
   // --- Per-seed ladders ---
   const semantic = {};
-  const familyOf = { brand: seeds.brand, accent, ...pickSeeds(seeds) };
+  // `merged` isn't a brand seed — it's GitHub's own merged-PR purple
+  // (#8957E5, the same value the markdown badge generator already uses),
+  // fixed on purpose so a "merged" status always reads as GitHub's purple
+  // regardless of what a fork picks for its five brand seeds.
+  const familyOf = { brand: seeds.brand, accent, merged: '#8957E5', ...pickSeeds(seeds) };
   for (const [name, hex] of Object.entries(familyOf)) {
     // Text steps are derived readable in BOTH directions: darkened until AA
     // on the light grounds, lightened until AA on the dark ones. Each side is

--- a/scripts/generators/html/blog-html-generator.js
+++ b/scripts/generators/html/blog-html-generator.js
@@ -42,7 +42,7 @@ const { newestFirst, platformsIn, groupByOrg } = require('../../services/writing
 const WRITING_CSS = `
   ${THEME_CSS_VARS}
   .wr-eyebrow{font-family:ui-monospace,monospace;font-size:.75rem;letter-spacing:.14em;text-transform:uppercase;color:var(--t-ink-3)}
-  .wr-h1{font-weight:800;letter-spacing:-.01em;color:var(--t-ink)}
+  .wr-h1{font-weight:800;letter-spacing:-.01em;color:var(--t-brand)}
   .wr-sub{color:var(--t-ink-2);font-size:.95rem;max-width:64ch;margin:8px 0 0}
   .wr-sec-label{font-family:ui-monospace,monospace;font-size:.78rem;font-weight:400;letter-spacing:.13em;text-transform:uppercase;color:var(--t-ink-3);margin-bottom:16px}
   .wr-tl{position:relative;padding-left:26px;max-width:760px}
@@ -62,9 +62,8 @@ const WRITING_CSS = `
   .wr-item:last-child{border-bottom:0}
   .wr-item.wr-hidden{display:none}
   .wr-item-t{font-size:.95rem;font-weight:600;margin:0;line-height:1.4}
-  .wr-item-t a{color:var(--t-ink);text-decoration:underline;text-decoration-color:var(--t-brand-line);
-    text-decoration-thickness:2px;text-underline-offset:3px;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;overflow-wrap:anywhere}
-  .wr-item-t a:hover{color:var(--t-brand);text-decoration-color:var(--t-brand)}
+  .wr-item-t a{color:var(--t-ink);display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;overflow-wrap:anywhere}
+  .wr-item-t a:hover{color:var(--t-brand)}
   .wr-meta{display:flex;align-items:center;gap:8px;flex-wrap:wrap;font-family:ui-monospace,monospace;font-size:.75rem;color:var(--t-ink-3);margin-top:8px}
   .wr-platform{color:var(--t-ink-2);font-weight:600}
   .wr-tags{display:flex;flex-wrap:wrap;gap:6px}
@@ -91,9 +90,8 @@ const WRITING_CSS = `
   .wr-rec-sr{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
   @media (prefers-reduced-motion: reduce){.wr-rec-item::before{transition:none}}
   .wr-rec-item h3{font-size:1.16rem;font-weight:800;margin:0;line-height:1.32}
-  .wr-rec-item h3 a{color:var(--t-ink);text-decoration:underline;text-decoration-color:var(--t-brand-line);
-    text-decoration-thickness:2px;text-underline-offset:3px}
-  .wr-rec-item h3 a:hover{color:var(--t-brand);text-decoration-color:var(--t-brand)}
+  .wr-rec-item h3 a{color:var(--t-ink)}
+  .wr-rec-item h3 a:hover{color:var(--t-brand)}
   .wr-rec-item h3 a:focus-visible{outline:2px solid var(--t-brand);outline-offset:3px;border-radius:3px}
   .wr-rec-org{font-family:ui-monospace,monospace;font-size:.75rem;letter-spacing:.08em;color:var(--t-ink-3);margin:14px 0 7px}
   .wr-rec-org b{color:var(--t-accent);font-weight:400}

--- a/scripts/generators/html/glossary-html-generator.js
+++ b/scripts/generators/html/glossary-html-generator.js
@@ -76,10 +76,10 @@ async function createGlossaryHtml() {
           const processedNote = processText(rawNote);
 
           // Determine the Label dynamically
-          let label = 'Glossary Note';
-          if (item.entryMethod) label = 'Entry Method';
-          if (item.howItIsCalculated) label = 'Calculation Logic';
-          if (item.source) label = 'Data Source';
+          let label = 'Note';
+          if (item.entryMethod) label = 'How it’s added';
+          if (item.howItIsCalculated) label = 'How it’s worked out';
+          if (item.source) label = 'Where it comes from';
 
           return dedent`
             <div id="${item.id}" class="mb-16 last:mb-0">

--- a/scripts/generators/html/journey-html-generator.js
+++ b/scripts/generators/html/journey-html-generator.js
@@ -42,7 +42,7 @@ const FLAT_TIMELINE_MAX = 10;
 const JOURNEY_CSS = `
   ${THEME_CSS_VARS}
   .jy-eyebrow{font-family:ui-monospace,monospace;font-size:.75rem;letter-spacing:.14em;text-transform:uppercase;color:var(--t-ink-3)}
-  .jy-h2{font-family:inherit;font-weight:800;letter-spacing:-.01em;color:var(--t-ink)}
+  .jy-h2{font-family:inherit;font-weight:800;letter-spacing:-.01em;color:var(--t-brand)}
   .jy-tl{position:relative;padding-left:26px;max-width:660px}
   .jy-tl::before{content:"";position:absolute;left:6px;top:6px;bottom:6px;width:2px;border-radius:2px;
     background:linear-gradient(var(--t-brand-line),var(--t-line))}
@@ -63,16 +63,16 @@ const JOURNEY_CSS = `
   .jy-sr{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
   @media (prefers-reduced-motion: reduce){.jy-ms::before{transition:none}}
   .jy-ms h3{font-size:1.16rem;font-weight:800;margin:0;line-height:1.32}
-  /* Every title links to the evidence. Underlined at rest, not just on hover:
-     hover doesn't exist on touch, and an unstyled link reads as plain text —
-     which hides the proof behind an affordance nobody can see. */
-  .jy-ms h3 a{color:var(--t-ink);text-decoration:underline;text-decoration-color:var(--t-brand-line);
-    text-decoration-thickness:2px;text-underline-offset:3px}
-  .jy-ms h3 a:hover{color:var(--t-brand);text-decoration-color:var(--t-brand)}
+  /* Underline itself comes from the shared a[target="_blank"] rule
+     (navbar.js SHARED_CHROME_CSS) — only the text color is page-specific. */
+  .jy-ms h3 a{color:var(--t-ink)}
+  .jy-ms h3 a:hover{color:var(--t-brand)}
   .jy-ms h3 a:focus-visible{outline:2px solid var(--t-brand);outline-offset:3px;border-radius:3px}
   /* Roomier above than below: the title's underline sits close to its
      baseline, so 4px left the tag row crowding the link. */
   .jy-org{font-family:ui-monospace,monospace;font-size:.75rem;letter-spacing:.08em;color:var(--t-ink-3);margin:11px 0 7px}
+  .jy-ms-cert{color:var(--t-ink-3)}
+  .jy-ms-cert:hover{color:var(--t-brand)}
   .jy-org b{color:var(--t-accent);font-weight:400}
   .jy-ms-tag{display:inline-flex;align-items:center;gap:4px;font-family:ui-monospace,monospace;font-size:.75rem;color:var(--t-accent);background:var(--t-card-2);border:1px solid var(--t-line);border-radius:999px;padding:1px 8px;margin-right:6px}
   .jy-desc{font-size:.9rem;color:var(--t-ink-2);margin:0;max-width:60ch}
@@ -125,9 +125,23 @@ const JOURNEY_CSS = `
 
 function renderMilestone(ach, hidden) {
   const org = escapeHtml(ach.org || '');
-  const titleHtml = ach.url
-    ? `<a href="${ach.url}" target="_blank" rel="noopener noreferrer">${ach.title}</a>`
+  // Most milestones carry one `url`. Courses can instead carry two —
+  // `courseUrl` (the course itself) and `certificationUrl` (the certificate
+  // earned for completing it) — since a taken course's evidence is the
+  // certificate, not always the course listing. The title links to
+  // whichever exists first; if both do, the other gets a small secondary
+  // link next to the org line instead of being dropped.
+  const primaryUrl = ach.url || ach.courseUrl || ach.certificationUrl;
+  const titleHtml = primaryUrl
+    ? `<a href="${primaryUrl}" target="_blank" rel="noopener noreferrer">${ach.title}</a>`
     : ach.title;
+  const secondaryUrl =
+    ach.courseUrl && ach.certificationUrl && primaryUrl !== ach.certificationUrl
+      ? ach.certificationUrl
+      : null;
+  const certHtml = secondaryUrl
+    ? ` · <a class="jy-ms-cert" href="${secondaryUrl}" target="_blank" rel="noopener noreferrer">Certificate</a>`
+    : '';
   // Descriptions render in full — no clamp, so no `title` tooltip needed to
   // recover text the clamp had cut off.
   const descHtml = ach.description ? `<p class="jy-desc">${ach.description}</p>` : '';
@@ -141,7 +155,7 @@ function renderMilestone(ach, hidden) {
   return dedent`
     <article class="${classes}" data-earlier="${hidden ? '1' : '0'}">
       <h3>${starHtml}${titleHtml}</h3>
-      <div class="jy-org">${tagHtml}<b>${org}</b> · ${formatYears(ach)}</div>
+      <div class="jy-org">${tagHtml}<b>${org}</b> · ${formatYears(ach)}${certHtml}</div>
       ${descHtml}
     </article>
   `;
@@ -198,7 +212,12 @@ function renderTimeline(sorted) {
 
   // Both labels ship in the markup so the count stays server-side and the
   // script never has to compose copy.
-  const moreLabel = `Show ${hiddenCount} more milestone${hiddenCount === 1 ? '' : 's'} ↓`;
+  // Once highlights are the filtered default view, "show more" means "see
+  // everything, not just the picked highlights" — a count of hidden
+  // milestones doesn't communicate that as well as naming what's underneath.
+  const moreLabel = hasFlagged
+    ? 'Show all selected work ↓'
+    : `Show ${hiddenCount} more milestone${hiddenCount === 1 ? '' : 's'} ↓`;
   const lessLabel = hasFlagged ? 'Show highlights only ↑' : 'Show fewer ↑';
   const more =
     hiddenCount > 0
@@ -292,7 +311,7 @@ async function createJourneyHtml(rolesData, skills, content = {}) {
   const timeline = renderTimeline(milestones);
   const stats = summarize(milestones);
   const scaleLine = stats
-    ? `<p class="jy-scale">${stats.count} milestones across ${stats.orgs} organizations, ${stats.from}\u2013${stats.to}.</p>`
+    ? `<p class="jy-scale"><b>${stats.count}</b> entries across <b>${stats.orgs}</b> organizations, <b>${stats.from}</b>\u2013<b>${stats.to}</b>.</p>`
     : '';
   const { expertise, toolsSection, skillsSection } = renderExpertiseAndTools(skills || {});
   const experience = renderExperience(rolesData.roles || []);

--- a/scripts/generators/html/landing-page-html-generator.js
+++ b/scripts/generators/html/landing-page-html-generator.js
@@ -49,7 +49,7 @@ const LANDING_CSS = `
       radial-gradient(130% 170% at 10% -10%,var(--t-brand-wash),transparent 62%),
       radial-gradient(90% 140% at 100% 0%,var(--t-accent-wash),transparent 55%);
     border:1px solid var(--t-line);border-radius:16px;padding:30px 32px 26px}
-  .lp-hero h1{font-size:clamp(1.9rem,4.4vw,3rem);font-weight:800;letter-spacing:-.015em;line-height:1.12;margin:6px 0 8px;color:var(--t-ink)}
+  .lp-hero h1{font-size:clamp(1.9rem,4.4vw,3rem);font-weight:800;letter-spacing:-.015em;line-height:1.12;margin:6px 0 8px;color:var(--t-brand)}
   .lp-grad{background:linear-gradient(98deg,var(--t-brand) 10%,var(--t-accent) 90%);-webkit-background-clip:text;background-clip:text;color:transparent}
   .lp-hero p{color:var(--t-ink-2);font-size:.95rem;max-width:60ch;margin:0}
   /* container-type lets .lp-tiles react to the card's own rendered width
@@ -93,7 +93,7 @@ const LANDING_CSS = `
   .lp-m .bar i{display:block;height:100%;border-radius:2px;background:var(--t-brand);opacity:.85}
   .lp-focus{display:flex;justify-content:space-between;gap:10px;align-items:baseline;padding:9px 0;border-bottom:1px solid var(--t-line);max-width:520px}
   .lp-focus:last-of-type{border-bottom:0}
-  .lp-focus a{font-weight:600;color:var(--t-ink);text-decoration:none;min-width:0;overflow-wrap:anywhere}
+  .lp-focus a{font-weight:600;color:var(--t-ink);min-width:0;overflow-wrap:anywhere}
   .lp-focus a:hover{color:var(--t-brand)}
   .lp-focus a .o{color:var(--t-ink-3);font-weight:400}
   .lp-focus span{font-family:ui-monospace,monospace;font-size:.75rem;color:var(--t-ink-3);white-space:nowrap;flex-shrink:0}

--- a/scripts/generators/html/quarterly-reports-html-generator.js
+++ b/scripts/generators/html/quarterly-reports-html-generator.js
@@ -29,12 +29,12 @@ const { sanitizeAttribute } = require('../../utils/html-helpers');
 const { getThemeInitScript, getThemeStyleVariant } = require('../../components/theme-init');
 
 // Status badge colors route straight through the theme engine's semantic
-// ladder (see theme-engine.js) — no hex, no fallback chain. OPEN and MERGED
-// intentionally share the positive ladder (a design decision that predates
-// this migration, preserved as-is).
+// ladder (see theme-engine.js) — no hex, no fallback chain. MERGED uses the
+// `merged` ladder (GitHub's own merged-PR purple), matching GitHub's own
+// status color instead of sharing OPEN's green.
 const STATUS_BADGE_TOKENS = {
   OPEN: { bg: 'var(--t-positive-wash)', text: 'var(--t-positive)' },
-  MERGED: { bg: 'var(--t-positive-wash)', text: 'var(--t-positive)' },
+  MERGED: { bg: 'var(--t-merged-wash)', text: 'var(--t-merged)' },
   CLOSED: { bg: 'var(--t-critical-wash)', text: 'var(--t-critical)' },
   RECORDED: { bg: 'var(--t-neutral-wash)', text: 'var(--t-neutral)' },
 };
@@ -57,7 +57,7 @@ const QUARTERLY_EXTRA_CSS = `
   .qr-worked-with{display:flex;align-items:center;gap:12px;flex-wrap:wrap;margin-top:16px;padding-top:16px;border-top:1px solid var(--t-line)}
   .qr-worked-with-label{font-family:ui-monospace,monospace;font-size:.72rem;letter-spacing:.08em;text-transform:uppercase;color:var(--t-ink-3)}
   .qr-org-chips{display:flex;flex-wrap:wrap;gap:8px}
-  .qr-org-chip{font-family:ui-monospace,monospace;font-size:.75rem;color:var(--t-ink-2);background:var(--t-card-2);border:1px solid var(--t-line);border-radius:999px;padding:3px 11px;text-decoration:none;transition:border-color .15s ease,color .15s ease}
+  .qr-org-chip{font-family:ui-monospace,monospace;font-size:.75rem;color:var(--t-ink-2);background:var(--t-card-2);border:1px solid var(--t-line);border-radius:999px;padding:3px 11px;transition:border-color .15s ease,color .15s ease}
   .qr-org-chip:hover{border-color:var(--t-brand-line);color:var(--t-brand)}
   .qr-org-chip:focus-visible{outline:2px solid var(--t-brand);outline-offset:2px}
 
@@ -78,10 +78,11 @@ const QUARTERLY_EXTRA_CSS = `
   .qr-nav-card{background-color:var(--t-card)}
   .qr-details{border:1px solid var(--t-line)}
 
-  .qr-link{color:var(--t-brand);text-decoration:none}
-  .qr-link:hover{color:var(--t-brand-strong);text-decoration:underline}
+  .qr-link{color:var(--t-brand)}
+  .qr-link:hover{color:var(--t-brand-strong)}
   .qr-link:focus-visible{outline:2px solid var(--t-brand);outline-offset:2px}
   .qr-repo{font-family:ui-monospace,monospace;font-size:.75rem;color:var(--t-ink-2);background:var(--t-card-2);border:1px solid var(--t-line);border-radius:5px;padding:2px 7px}
+  .qr-status-cell{display:inline-block}
 
   /* Per-category "back to top" — resets that category's own table
      scroll container back to its first row, since each table scrolls
@@ -233,9 +234,14 @@ async function writeHtmlFiles(groupedContributions) {
     const statusWord = statusMatch && statusMatch[1] ? statusMatch[1] : 'N/A';
 
     const statusBadge = getStatusBadgeHtml(statusWord);
-    // Return both the HTML for display and the raw status text for sorting logic
+    // Wrapped in one element so the <br> keeps working once the mobile
+    // card layout switches this <td> to display:flex (below 640px) — a
+    // flex container turns each of ITS OWN direct children into a separate
+    // flex item, which would put the date and badge <span> side by side and
+    // silently defeat the <br> between them. Wrapping keeps date+badge as a
+    // single flex item, so the <br> still stacks them like it does on desktop.
     return {
-      html: `${date}<br>${statusBadge}`,
+      html: `<span class="qr-status-cell">${date}<br>${statusBadge}</span>`,
       statusText: statusWord,
     };
   }
@@ -374,7 +380,7 @@ async function writeHtmlFiles(groupedContributions) {
 
   function renderHighlightCard({ item, label, date }) {
     return dedent`
-      <a href="${sanitizeAttribute(item.url)}" target="_blank" rel="noopener noreferrer" class="qr-highlight-card">
+      <a href="${sanitizeAttribute(item.url)}" target="_blank" rel="noopener noreferrer" class="qr-highlight-card no-underline">
         <span class="qr-highlight-type">${label}</span>
         <span class="qr-highlight-repo">${sanitizeAttribute(item.repo || '')}</span>
         <span class="qr-highlight-title">${sanitizeAttribute(item.title)}</span>

--- a/scripts/generators/html/workbench-html-generator.js
+++ b/scripts/generators/html/workbench-html-generator.js
@@ -4,8 +4,9 @@
  *
  * Layer 1: plain-language impact header (any recruiter can read it).
  * Layer 2: five lanes ordered by what happens next —
- *   Needs your action / Approved — bring it home  (open by default)
- *   Waiting on others / Stalled 30+ days / Automated (folded)
+ *   Needs your action (open by default)
+ *   Approved — bring it home / Waiting on others / Stalled 30+ days /
+ *   Automated (folded)
  *
  * "Approved is not done": every ready-lane row shows who approved and its
  * remaining step (final review, backport check, maintainer nudge).
@@ -42,7 +43,7 @@ const LANES = [
     title: 'Approved — bring it home',
     explain:
       'Reviewed and approved, but not done: each still needs a final review, a backport check, or a maintainer nudge before it ships.',
-    open: true,
+    open: false,
     stripe: 'var(--t-positive)',
   },
   {
@@ -112,24 +113,46 @@ const WORKBENCH_CSS = `
   .wbx-banner b{color:var(--t-ink)}
   .wbx-lanes{display:flex;flex-direction:column;gap:12px}
   .wbx-lane{background:var(--t-card-2);border:1px solid var(--t-line);border-left-width:4px;border-radius:10px;overflow:hidden}
-  .wbx-lane summary{list-style:none;cursor:pointer;padding:13px 16px;display:flex;align-items:baseline;gap:10px;flex-wrap:wrap}
-  .wbx-lane summary::-webkit-details-marker{display:none}
-  .wbx-lane summary::after{content:"▸";margin-left:auto;color:var(--t-ink-3);font-size:.78rem;align-self:center;transition:transform .15s ease}
-  /* Two auto margins on the same line would split the free space between
-     them (pushing the sort icon and the chevron apart, not together) — when
-     the sort button is present it does the pushing instead, and the chevron
-     just sits directly after it. */
-  .wbx-lane summary:has(.wbx-sort-btn)::after{margin-left:0}
-  .wbx-lane[open] summary::after{transform:rotate(90deg)}
-  @media (prefers-reduced-motion: reduce){.wbx-lane summary::after{transition:none}}
+  /* No list-style:none / hidden ::-webkit-details-marker here — kept as the
+     browser's native disclosure triangle, same as the Quarterly Reports list
+     page (reports.html), instead of a hand-rolled character. Getting that
+     marker to sit inline, to the left of the row (not hidden, not stacked
+     above it) took three wrong tries, each confirmed wrong with an actual
+     rendered screenshot:
+       - summary{display:flex} directly: removes the native marker outright
+         — flex layout on summary itself suppresses it, full stop.
+       - summary > a block-level <div> wrapper: the marker DOES render, but
+         summary then has no inline content of its own to share a line with,
+         so the marker sits alone on its own line above the block.
+       - .wbx-lane-row{width:100%}: Chrome's UA stylesheet sets
+         list-style-position:inside on <summary>, so the marker box shares
+         the SAME content box the row sits in — claiming 100% of it leaves
+         no room for the marker, pushing it onto its own line. Forcing
+         list-style-position:outside instead (to make the marker stop
+         competing for that space) made it disappear completely — outside
+         positioning needs indent space this card layout doesn't reserve,
+         so the marker rendered further left than the lane's own
+         overflow:hidden edge and got clipped, no matter how much left
+         padding summary was given.
+     The fix: leave list-style-position at its (inside) default, and don't
+     force .wbx-lane-row to 100% width at all — let it shrink-to-fit like
+     any inline-flex box normally would. The marker gets its room back, and
+     .wbx-lane-explain's flex-basis:100% still wraps it onto its own line
+     below, because that's resolved against the row's own flex layout, not
+     a specific pixel width. */
+  .wbx-lane summary{cursor:pointer;padding:13px 16px;color:var(--t-ink-3)}
+  .wbx-lane summary:focus-visible{outline:2px solid var(--t-brand);outline-offset:-2px}
+  .wbx-lane-row{display:inline-flex;align-items:baseline;gap:10px;flex-wrap:wrap;max-width:calc(100% - 24px)}
   .wbx-lane-title{font-size:1.02rem;font-weight:800;color:var(--t-ink)}
   .wbx-lane-count{font-family:ui-monospace,monospace;font-size:.75rem;color:var(--t-ink-3);background:var(--t-surface);border:1px solid var(--t-line);border-radius:999px;padding:1px 9px}
-  /* Icon-only, pushed to the far right of the summary row (margin-left:auto,
-     same trick the ▸ chevron uses) — text like "Idle ▼" competed with the
-     row's other labels and read as another status pill. Static ↕ glyph that
-     only changes opacity/color/weight once clicked, matching the sort icon
-     on the quarterly report table (.sort-icon / th.sort-asc) rather than
-     inventing a new visual language for the same concept. */
+  /* Icon-only, pushed to the far right of the summary row (margin-left:auto).
+     Text like "Idle ▼" competed with the row's other labels and read as
+     another status pill. Static ↕ glyph that only changes opacity/color/
+     weight once clicked, matching the sort icon on the quarterly report
+     table (.sort-icon / th.sort-asc) rather than inventing a new visual
+     language for the same concept. Hidden while the lane is folded — nothing
+     to reorder if the rows aren't showing. */
+  .wbx-lane:not([open]) .wbx-sort-btn{display:none}
   .wbx-sort-btn{display:inline-flex;align-items:center;align-self:center;margin-left:auto;background:none;border:none;padding:2px 4px;cursor:pointer;border-radius:4px}
   .wbx-sort-btn:focus-visible{outline:2px solid var(--t-brand);outline-offset:2px}
   .wbx-sort-icon{display:inline-flex;align-items:center;font-size:1.15rem;line-height:1;color:var(--t-ink-3);opacity:.4;transition:opacity .15s ease,color .15s ease}
@@ -261,10 +284,12 @@ function renderLane(lane, records) {
   return dedent`
     <details class="wbx-lane" id="wbx-lane-${lane.id}" style="border-left-color:${lane.stripe}" ${lane.open && records.length ? 'open' : ''}>
       <summary>
-        <span class="wbx-lane-title">${lane.title}</span>
-        <span class="wbx-lane-count">${records.length}</span>
-        ${sortBtn}
-        <p class="wbx-lane-explain">${lane.explain}</p>
+        <span class="wbx-lane-row">
+          <span class="wbx-lane-title">${lane.title}</span>
+          <span class="wbx-lane-count">${records.length}</span>
+          ${sortBtn}
+          <p class="wbx-lane-explain">${lane.explain}</p>
+        </span>
       </summary>
       ${body}
     </details>

--- a/scripts/generators/html/workbench-html-generator.js
+++ b/scripts/generators/html/workbench-html-generator.js
@@ -94,7 +94,11 @@ const WORKBENCH_CSS = `
   @media (max-width:760px){.wbx-tiles{grid-template-columns:repeat(2,1fr)}}
   .wbx-tile{padding:15px 18px;border-right:1px solid var(--t-line);display:flex;flex-direction:column;gap:2px}
   .wbx-tile:last-child{border-right:0}
-  @media (max-width:760px){.wbx-tile{border-top:1px solid var(--t-line)}.wbx-tile:nth-child(2n){border-right:0}}
+  /* border-bottom (not just border-top on the next tile) because 5 tiles in
+     a 2-column grid leaves an odd last row — the tile above that empty cell
+     (e.g. "contributions helped ship this month") has no sibling below it
+     to supply a border-top, so it reads as missing its bottom edge. */
+  @media (max-width:760px){.wbx-tile{border-top:0;border-bottom:1px solid var(--t-line)}.wbx-tile:nth-child(2n){border-right:0}}
   .wbx-tile .n{font-weight:800;font-size:2.05rem;line-height:1.08;letter-spacing:-.02em;font-variant-numeric:tabular-nums;color:var(--t-ink)}
   .wbx-tile .c{font-size:.76rem;color:var(--t-ink-2);line-height:1.35}
   .wbx-tile--hero{background:linear-gradient(150deg,var(--t-brand-strong),var(--t-brand))}
@@ -111,16 +115,36 @@ const WORKBENCH_CSS = `
   .wbx-lane summary{list-style:none;cursor:pointer;padding:13px 16px;display:flex;align-items:baseline;gap:10px;flex-wrap:wrap}
   .wbx-lane summary::-webkit-details-marker{display:none}
   .wbx-lane summary::after{content:"▸";margin-left:auto;color:var(--t-ink-3);font-size:.78rem;align-self:center;transition:transform .15s ease}
+  /* Two auto margins on the same line would split the free space between
+     them (pushing the sort icon and the chevron apart, not together) — when
+     the sort button is present it does the pushing instead, and the chevron
+     just sits directly after it. */
+  .wbx-lane summary:has(.wbx-sort-btn)::after{margin-left:0}
   .wbx-lane[open] summary::after{transform:rotate(90deg)}
   @media (prefers-reduced-motion: reduce){.wbx-lane summary::after{transition:none}}
   .wbx-lane-title{font-size:1.02rem;font-weight:800;color:var(--t-ink)}
   .wbx-lane-count{font-family:ui-monospace,monospace;font-size:.75rem;color:var(--t-ink-3);background:var(--t-surface);border:1px solid var(--t-line);border-radius:999px;padding:1px 9px}
+  /* Icon-only, pushed to the far right of the summary row (margin-left:auto,
+     same trick the ▸ chevron uses) — text like "Idle ▼" competed with the
+     row's other labels and read as another status pill. Static ↕ glyph that
+     only changes opacity/color/weight once clicked, matching the sort icon
+     on the quarterly report table (.sort-icon / th.sort-asc) rather than
+     inventing a new visual language for the same concept. */
+  .wbx-sort-btn{display:inline-flex;align-items:center;align-self:center;margin-left:auto;background:none;border:none;padding:2px 4px;cursor:pointer;border-radius:4px}
+  .wbx-sort-btn:focus-visible{outline:2px solid var(--t-brand);outline-offset:2px}
+  .wbx-sort-icon{display:inline-flex;align-items:center;font-size:1.15rem;line-height:1;color:var(--t-ink-3);opacity:.4;transition:opacity .15s ease,color .15s ease}
+  .wbx-sort-btn:hover .wbx-sort-icon{opacity:.8;color:var(--t-brand)}
+  .wbx-sort-btn[data-active="1"] .wbx-sort-icon{opacity:1;color:var(--t-brand);font-weight:bold}
+  @media (prefers-reduced-motion: reduce){.wbx-sort-icon{transition:none}}
   .wbx-lane-explain{flex-basis:100%;margin:2px 0 0;color:var(--t-ink-3);font-size:.82rem}
   .wbx-rows{border-top:1px solid var(--t-line)}
-  .wbx-row{display:grid;grid-template-columns:150px 1fr;gap:6px 16px;padding:12px 16px;border-top:1px solid var(--t-line);align-items:start;background:var(--t-card)}
+  .wbx-row{display:grid;grid-template-columns:minmax(150px,max-content) 1fr;gap:6px 16px;padding:16px;border-top:1px solid var(--t-line);align-items:start;background:var(--t-card)}
   .wbx-row:first-child{border-top:0}
   @media (max-width:620px){.wbx-row{grid-template-columns:1fr}}
-  .wbx-pill{display:inline-flex;align-items:center;gap:6px;font-family:ui-monospace,monospace;font-size:.75rem;letter-spacing:.05em;text-transform:uppercase;padding:2px 9px;border-radius:999px;border:1px solid var(--t-line);white-space:nowrap;align-self:start}
+  /* justify-self:start — without it, a grid item defaults to stretch, so on
+     the single-column mobile layout the pill fills the whole row width
+     instead of sizing to its own text. */
+  .wbx-pill{display:inline-flex;align-items:center;gap:6px;font-family:ui-monospace,monospace;font-size:.75rem;letter-spacing:.05em;text-transform:uppercase;padding:2px 9px;border-radius:999px;border:1px solid var(--t-line);white-space:nowrap;align-self:start;justify-self:start}
   .wbx-pill i{width:7px;height:7px;border-radius:50%;flex:0 0 auto}
   .wbx-pill--act{color:var(--t-caution);border-color:var(--t-caution-line);background:var(--t-caution-wash)}.wbx-pill--act i{background:var(--t-caution)}
   .wbx-pill--ok{color:var(--t-positive);border-color:var(--t-positive-line);background:var(--t-positive-wash)}.wbx-pill--ok i{background:var(--t-positive)}
@@ -131,9 +155,9 @@ const WORKBENCH_CSS = `
   .wbx-repo{font-family:ui-monospace,monospace;font-size:.75rem;color:var(--t-ink-3);background:var(--t-surface);border:1px solid var(--t-line);border-radius:5px;padding:1px 7px}
   .wbx-rel{font-family:ui-monospace,monospace;font-size:.75rem;letter-spacing:.05em;color:var(--t-ink-3)}
   .wbx-task{font-size:.92rem;line-height:1.4;overflow-wrap:anywhere}
-  .wbx-task a{color:var(--t-ink);font-weight:600;text-decoration:none}
+  .wbx-task a{color:var(--t-ink);font-weight:600}
   .wbx-task a:hover{color:var(--t-brand)}
-  .wbx-next{display:flex;align-items:center;gap:6px;flex-wrap:wrap;margin-top:5px;font-size:.78rem;color:var(--t-ink-2)}
+  .wbx-next{display:flex;align-items:center;gap:6px;flex-wrap:wrap;margin-top:10px;font-size:.78rem;color:var(--t-ink-2)}
   .wbx-step{font-family:ui-monospace,monospace;font-size:.75rem;letter-spacing:.05em;text-transform:uppercase;padding:1px 8px;border-radius:5px}
   .wbx-step--do{color:var(--t-caution);background:var(--t-caution-wash)}
   .wbx-step--ship{color:var(--t-positive);background:var(--t-positive-wash)}
@@ -143,11 +167,19 @@ const WORKBENCH_CSS = `
   .wbx-live--stale{color:var(--t-caution)}
   .wbx-live--stale i{background:var(--t-caution)}
   .wbx-live--stale i::after{content:none}
-  .wbx-lane-index{display:flex;gap:6px;flex-wrap:wrap;margin:0 0 16px}
+  /* Sticky so the lane shortcuts stay reachable while scrolling down the
+     board — same treatment as .jy-index on the Journey page. Sits below
+     the fixed navbar (4rem) and clears its own height. */
+  .wbx-lane-index{display:flex;gap:6px;flex-wrap:wrap;margin:0 0 16px;
+    position:sticky;top:4rem;z-index:30;background:var(--t-surface);
+    padding:10px 0 9px;border-bottom:1px solid var(--t-line)}
   .wbx-lane-index a{display:inline-flex;align-items:center;gap:5px;font-family:ui-monospace,monospace;font-size:.75rem;color:var(--t-ink-3);border:1px solid var(--t-line);border-radius:6px;padding:3px 10px;text-decoration:none;transition:border-color .15s ease,color .15s ease}
   .wbx-lane-index a:hover{color:var(--t-brand);border-color:var(--t-brand-line)}
   .wbx-lane-index-n{color:var(--t-ink-3)}
   @media (prefers-reduced-motion: reduce){.wbx-lane-index a{transition:none}}
+  /* Clears both the fixed navbar and the sticky lane index, so jumping to
+     a lane doesn't land it underneath them. */
+  .wbx-lane{scroll-margin-top:8rem}
 `;
 
 function relLabel(record) {
@@ -197,7 +229,7 @@ function renderRow(record) {
   const nextHtml = nextBits.length ? `<div class="wbx-next">${nextBits.join(' · ')}</div>` : '';
 
   return dedent`
-    <div class="wbx-row">
+    <div class="wbx-row" data-idle="${record.idleDays}">
       <span class="wbx-pill ${pillClass}"><i></i>${escapeHtml(record.ball)}${idleBadge}</span>
       <div>
         <div class="wbx-meta">
@@ -218,11 +250,20 @@ function renderLane(lane, records) {
     records.length > 0
       ? `<div class="wbx-rows">${rows}</div>`
       : '';
+  // Sorts by idle time, not the lane's own default order (idle desc for
+  // action/stalled, recency for the rest) — a manual override for anyone
+  // who wants to work oldest-first or newest-first regardless of lane.
+  // Skipped below one row: nothing to reorder.
+  const sortBtn =
+    records.length > 1
+      ? `<button type="button" class="wbx-sort-btn" data-lane-sort="${lane.id}" data-dir="desc" data-active="0" title="Sort by idle time" aria-label="Sort ${escapeHtml(lane.title)} by idle time, currently oldest first"><span class="wbx-sort-icon" aria-hidden="true">↕</span></button>`
+      : '';
   return dedent`
     <details class="wbx-lane" id="wbx-lane-${lane.id}" style="border-left-color:${lane.stripe}" ${lane.open && records.length ? 'open' : ''}>
       <summary>
         <span class="wbx-lane-title">${lane.title}</span>
         <span class="wbx-lane-count">${records.length}</span>
+        ${sortBtn}
         <p class="wbx-lane-explain">${lane.explain}</p>
       </summary>
       ${body}
@@ -341,7 +382,7 @@ async function createWorkbenchHtml({ records, impact, feed }) {
           <div class="max-w-6xl mx-auto">
             <header class="mt-16 mb-10">
               <p style="font-family:ui-monospace,monospace;font-size:.75rem;letter-spacing:.14em;text-transform:uppercase;color:var(--t-ink-3)">active workbench</p>
-              <h1 class="text-4xl sm:text-5xl font-extrabold mt-2 mb-4" style="color:var(--t-ink);letter-spacing:-.01em">Organized by what happens next</h1>
+              <h1 class="text-4xl sm:text-5xl font-extrabold mt-2 mb-4" style="color:var(--t-brand);letter-spacing:-.01em">Organized by what happens next</h1>
             </header>
             ${renderImpact(impact, feed)}
             ${humanRecords.length > 0 ? renderLaneIndex(records) : ''}
@@ -373,6 +414,37 @@ async function createWorkbenchHtml({ records, impact, feed }) {
             textEl.textContent = 'cached · ' + diffD + 'd old';
           }
           // Beyond 7 days the server-rendered absolute date stays as-is.
+        })();
+      </script>
+      <script>
+        (function () {
+          document.querySelectorAll('.wbx-sort-btn').forEach(function (btn) {
+            btn.addEventListener('click', function (e) {
+              // The button lives inside a <summary> — without these, clicking
+              // it would also toggle the lane open/closed.
+              e.preventDefault();
+              e.stopPropagation();
+              var lane = document.getElementById('wbx-lane-' + btn.getAttribute('data-lane-sort'));
+              var container = lane && lane.querySelector('.wbx-rows');
+              if (!container) return;
+              var dir = btn.getAttribute('data-dir') === 'asc' ? 'desc' : 'asc';
+              btn.setAttribute('data-dir', dir);
+              btn.setAttribute('data-active', '1');
+              var rows = Array.prototype.slice.call(container.children);
+              rows.sort(function (a, b) {
+                var av = parseFloat(a.getAttribute('data-idle')) || 0;
+                var bv = parseFloat(b.getAttribute('data-idle')) || 0;
+                return dir === 'asc' ? av - bv : bv - av;
+              });
+              rows.forEach(function (row) {
+                container.appendChild(row);
+              });
+              btn.setAttribute(
+                'aria-label',
+                'Sort by idle time, currently ' + (dir === 'asc' ? 'newest first' : 'oldest first')
+              );
+            });
+          });
         })();
       </script>
       ${footerHtml}

--- a/scripts/generators/markdown/community-markdown-generator.js
+++ b/scripts/generators/markdown/community-markdown-generator.js
@@ -97,11 +97,20 @@ async function createJourneyMarkdown(rolesData, skills = {}, content = {}) {
     const orgDisplay = ach.orgUrl
       ? `[${mdEscapeLinkText(ach.org)}](${ach.orgUrl})`
       : mdEscapeCell(ach.org);
-    const title = ach.url
-      ? `[${mdEscapeLinkText(ach.title)}](${ach.url})`
+    // Mirrors renderMilestone's fallback in journey-html-generator.js: most
+    // milestones carry one `url`, but courses can carry `courseUrl` and
+    // `certificationUrl` instead.
+    const primaryUrl = ach.url || ach.courseUrl || ach.certificationUrl;
+    const title = primaryUrl
+      ? `[${mdEscapeLinkText(ach.title)}](${primaryUrl})`
       : mdEscapeCell(ach.title);
+    const secondaryUrl =
+      ach.courseUrl && ach.certificationUrl && primaryUrl !== ach.certificationUrl
+        ? ach.certificationUrl
+        : null;
+    const certSuffix = secondaryUrl ? ` — [Certificate](${secondaryUrl})` : '';
     const tagPrefix = ach.tag ? `${ach.tag} — ` : '';
-    let out = `* ${tagPrefix}**${title}** (${formatYears(ach)}) — *${orgDisplay}*\n`;
+    let out = `* ${tagPrefix}**${title}** (${formatYears(ach)}) — *${orgDisplay}*${certSuffix}\n`;
     if (ach.description) out += `  * ${mdEscapeCell(ach.description)}\n`;
     return out;
   };

--- a/scripts/generators/markdown/contributions-readme-generator.js
+++ b/scripts/generators/markdown/contributions-readme-generator.js
@@ -223,14 +223,14 @@ async function createStatsReadme(finalContributions, articles = [], failedFetchC
   let glossarySectionsMd = '';
 
   groups.forEach((group) => {
-    let noteHeader = 'Glossary Note';
+    let noteHeader = 'Note';
     const hasEntryMethod = group.items.some((i) => i.entryMethod);
     const hasCalculation = group.items.some((i) => i.howItIsCalculated);
     const hasSource = group.items.some((i) => i.source);
 
-    if (hasEntryMethod) noteHeader = 'Entry Method';
-    else if (hasCalculation) noteHeader = 'Calculation Logic';
-    else if (hasSource) noteHeader = 'Data Source';
+    if (hasEntryMethod) noteHeader = 'How it’s added';
+    else if (hasCalculation) noteHeader = 'How it’s worked out';
+    else if (hasSource) noteHeader = 'Where it comes from';
 
     glossarySectionsMd += `## ${group.title}\n\n`;
     glossarySectionsMd += `_${personalize(group.description)}_\n\n`;

--- a/scripts/metadata/glossary.js
+++ b/scripts/metadata/glossary.js
@@ -3,199 +3,109 @@
  */
 const GLOSSARY_CONTENT = {
   title: 'Glossary',
-  subtitle: `A comprehensive explanation of the terms and categories used to track open source impact, detailing how contribution data is collected, sorted, and calculated within Open Source Portfolio.`,
+  subtitle: `Plain-English explanations of the terms used across this portfolio — what each one means, and how it's worked out from the underlying GitHub activity.`,
 
   sections: [
     {
       id: 'portfolioWide',
       title: 'Portfolio-wide Metrics',
       description:
-        'Terms used in this portfolio to show the total work done across the full span of open source activity.',
+        'Terms for the numbers that sum up all the open source work shown here, from the very first contribution to now.',
       items: [
         {
           id: 'totalImpact',
           title: 'Total Impact',
-          description:
-            'The total number of all recorded contributions since the very first activity on GitHub.',
+          description: 'Every contribution counted together, going back to the very first one on GitHub.',
           howItIsCalculated:
-            'Adds the grand total of merged PRs, issues, reviewed PRs, co-authored PRs, and community collaborations.',
+            'Adds up merged pull requests, issues, reviewed pull requests, co-authored pull requests, and collaborations.',
         },
         {
           id: 'shippedChanges',
           title: 'Shipped Changes',
           description:
-            'How many of the Total Impact contributions were finished and accepted, not just started.',
+            'How many of those contributions were actually finished and accepted — not just opened.',
           howItIsCalculated:
-            'Counts contributions GitHub has marked as merged. The Total Impact number also includes work still open or in progress, so this smaller number shows what has actually been completed.',
+            'Counts only the contributions GitHub marked as merged. Total Impact also includes work that\'s still open, so this number is smaller — it\'s what\'s actually done.',
         },
         {
           id: 'activeSince',
           title: 'Active Since',
-          description: 'The year of the first recorded contribution found on GitHub.',
+          description: 'The year of the very first recorded contribution on GitHub.',
           howItIsCalculated:
-            'Identifies the date of the very first contribution found in the data to set the starting point for the history.',
+            'Finds the earliest contribution in the data and uses its year as the starting point.',
         },
         {
           id: 'totalImpactedRepos',
           title: 'Impacted Repos',
           description:
-            'The total number of open source projects — and the distinct organizations they belong to — with at least one contribution.',
+            'How many different projects are represented here, and how many organizations those projects belong to.',
           howItIsCalculated:
-            'Identifies every unique external repository containing at least one recorded contribution. Each project\'s organization is identified by the account name that owns it — for example, "octocat" in octocat/Hello-World.',
+            'Counts every different external repo with at least one recorded contribution. A project\'s organization is whoever owns the repo — the "octocat" in octocat/Hello-World, for example.',
         },
         {
           id: 'helpedShip',
           title: 'Helped Ship',
           description:
-            "How many pull requests were reviewed or co-authored that a maintainer actually merged — work that helped land someone else's contribution, not solo PRs.",
+            "How many reviewed or co-authored pull requests actually got merged — work that helped someone else's contribution land, not solo PRs.",
           howItIsCalculated:
-            'Counts every reviewed or co-authored PR that was actually merged, across the full contribution history. One that is still open, or that closed without merging, does not count yet.',
+            "Counts every reviewed or co-authored pull request that got merged, across the full contribution history. One that's still open, or was closed without merging, doesn't count yet.",
         },
         {
           id: 'primaryFocusProjects',
           title: 'Primary Focus Projects',
-          description:
-            'The top three repositories where the highest contributions have occurred since the first year of contribution.',
+          description: 'The three projects with the most contributions, over the full history.',
           howItIsCalculated:
-            'Ranks all tracked repositories by lifetime contribution volume and selects the top three.',
+            'Sorts every tracked repo by how many contributions it has, and picks the top three.',
         },
         {
           id: 'persona',
           title: 'Collaboration Profile',
-          description: 'A role assigned based on the primary way of contributing to the community.',
+          description: 'A label for the primary way of contributing to the community.',
           howItIsCalculated:
-            'Analyzes contribution frequency across all categories to assign a role, such as "Community Mentor" for high review volumes.',
-        },
-      ],
-    },
-    {
-      id: 'quarterlyReports',
-      title: 'Quarterly Reports',
-      description: 'How the data is organized into quarters to make it easy to find and read.',
-      items: [
-        {
-          id: 'reportsIndex',
-          title: 'Reports Index',
-          description:
-            'The main list of the portfolio. It organizes all work into separate pages grouped by year and three-month periods (quarters).',
-          source:
-            'The **Quarterly Reports** page works like a folder, displaying the total contributions for each year and its corresponding three-month periods.',
-        },
-      ],
-    },
-    {
-      id: 'quarterlyMetrics',
-      title: 'Quarterly Report Metrics',
-      description:
-        'Terms used inside individual reports to explain work done during a specific three-month window.',
-      items: [
-        {
-          id: 'quarterInBrief',
-          title: 'Quarter in brief',
-          description:
-            'A plain-language summary at the top of each quarterly report: a sentence or two on what happened, which organizations were worked with, and a few highlighted contributions.',
-          howItIsCalculated:
-            'Composed from the same counts as the tables below (merged, reviewed, and co-authored PRs, issues) into narrative sentences, a "Worked with" row of organization names, and up to three highlighted contributions. The Markdown version of each report shows the same underlying counts as a **Quarterly Statistics** table instead, within Markdown\'s styling limits.',
-        },
-        {
-          id: 'stats',
-          title: 'Quarterly Statistics',
-          description:
-            'A summary that shows the total work and the projects involved during a specific three-month period.',
-          howItIsCalculated:
-            'Aggregates all contribution types and unique repositories involved within a specific three-month window.',
-        },
-        {
-          id: 'focusProjects',
-          title: 'Top 3 Repositories',
-          description:
-            'The projects that received the most work and attention within each quarter.',
-          howItIsCalculated:
-            'Ranks repositories by the volume of contributions performed during the quarter.',
-        },
-        {
-          id: 'merged',
-          title: 'Merged PRs',
-          description: 'A record of PRs that were accepted and added to external repositories.',
-          howItIsCalculated:
-            'Identifies PRs with a merged status and calculates the **Review Period** as the time from the first proposal to final acceptance.',
-        },
-        {
-          id: 'issues',
-          title: 'Issues',
-          description:
-            'A record of technical discoveries, bug reports, and feature proposals created on external repositories.',
-          howItIsCalculated:
-            'Collects all authored issues regardless of assignment. It calculates the **Closing Period** as the time from the initial opening until the issue is finished.',
-        },
-        {
-          id: 'reviewed',
-          title: 'Reviewed PRs',
-          description: 'A record of formal reviews provided on PRs within external repositories.',
-          howItIsCalculated:
-            'Measures the **Review Period** from the creation of the PR to the submission of the formal review, while tracking the **Status** and **Last Update** columns for the current state and the most recent activity.',
-        },
-        {
-          id: 'coAuthored',
-          title: 'Co-authored PRs',
-          description:
-            'A record of PRs where contributions were made directly to the code alongside other developers.',
-          howItIsCalculated:
-            'Identifies credit via co-author commit information. The **Commit Period** spans from the creation of the PR to the first code contribution to indicate when the collaboration started. The **Status** and **Last Update** columns track the current state and the most recent activity.',
-        },
-        {
-          id: 'collaborations',
-          title: 'Collaborations',
-          description:
-            'A record of participation in discussions within issues or PRs authored by others in external repositories.',
-          howItIsCalculated:
-            'Tracks comments on PRs and issues unless or until they are officially reviewed.',
+            'Looks at contribution frequency across every category, then picks the label that fits best — for example, "Community Mentor" for a high volume of reviews.',
         },
       ],
     },
     {
       id: 'journey',
       title: 'Journey',
-      description:
-        'Terms used on the Journey page — milestones, talks, expertise, and the roles behind them.',
+      description: 'Terms used on the Journey page — selected work, talks, expertise, and the roles behind them.',
       items: [
         {
           id: 'milestonesAwards',
-          title: 'Milestones, Awards & Talks',
+          title: 'Selected Work, Awards & Talks',
           description:
-            'A showcase of ecosystem honors, significant achievements, and speaking engagements within the open source community, on one continuous timeline.',
+            'A showcase of notable work and recognition within the open source community, on one continuous timeline.',
           entryMethod:
-            'Achievements are manually maintained in files within the contents folder — each record includes the title, the granting organization, and the year it was received. Talks join the same timeline from a separate contents file, tagged **🎤 Talk**, and carry the event name, year, and a short blurb in place of an organization and description. An empty talks list simply contributes nothing — no placeholder or empty section appears.',
+            'Each one is added manually. What can be found here: awards, courses and certifications, projects, documentation work, talks, and videos — each one tagged for quick identification.',
         },
         {
           id: 'expertise',
           title: 'Expertise, Tools & Skills',
           description:
-            'The named competency areas behind the work, plus the tools and languages used to do it — no self-graded proficiency bars, since the rest of the portfolio is the evidence.',
+            'The skill areas behind the work, plus the tools and languages used to do it. No self-rated skill bars — the rest of the portfolio is the proof.',
           entryMethod:
-            'Expertise areas are manually maintained in a contents file as a title and a short blurb. Tools and skills each render as their own list only when non-empty — an empty list hides its whole heading rather than showing it bare. A small set of entries can be marked for a highlighted (bolded / accented) treatment to call out the two or three most identity-defining items.',
+            'Expertise areas are entered manually in a contents file, each with a title and a short blurb. Tools and skills each show as their own list, but only if there\'s something in it — an empty list just doesn\'t show, heading and all. A few entries can be marked to stand out (bold, in the accent color) to call out the two or three that matter most.',
         },
         {
           id: 'advocacyRoles',
           title: 'Experience & Roles',
-          description: 'A record of formal positions held within open source organizations.',
+          description: 'A record of official roles held within open source organizations.',
           entryMethod:
-            'Entries originate from files within the contents folder. Roles are marked as **Active** or **Past** based on the recorded dates.',
+            'Each role is added by hand in a contents file, along with its dates. Whether it shows as **Active** or **Past** is worked out automatically from those dates.',
         },
       ],
     },
     {
       id: 'workbench',
       title: 'Active Workbench',
-      description:
-        'Terms used on the Active Workbench page — the live board of maintainer and contribution work in progress.',
+      description: 'Terms used on the Active Workbench page — the live board of maintainer and contribution work in progress.',
       items: [
         {
           id: 'activeWorkbench',
           title: 'Board & Lanes',
-          description:
-            'A live triage board of maintainer and contribution work in progress, organized by what happens next.',
-          entryMethod: `Open pull requests, assigned issues, and review requests are combined with a live external status feed into a single board, then sorted into five lanes, ordered by what happens next:
+          description: 'A live board of work in progress, organized by what happens next.',
+          entryMethod: `Open pull requests, assigned issues, and review requests are pulled together with live status updates into one board, then sorted into five lanes, ordered by what happens next:
 
 * **Needs your action:** Feedback to address, a review still pending, or a note left after approval.
 * **Approved — bring it home:** Reviewed and approved, but not shipped yet — something still needs to happen first, like a final check or a reminder to a maintainer.
@@ -203,25 +113,24 @@ const GLOSSARY_CONTENT = {
 * **Stalled · 30+ days:** No movement in a month — each needs a decision: nudge or close.
 * **Automated:** Automatic updates from bots, like routine dependency or security updates — grouped together and kept out of the way.
 
-Only open items are shown; they are removed once they are merged or closed. An empty board reads "Your court is clear" — a positive state, not an error.
+Only open items are shown; they're removed once they're merged or closed. An empty board reads "Your court is clear" — a good sign, not an error.
 
-A freshness badge in the header reads "Updated Xh ago" (or "Updated just now" / "Updated yesterday") when the board's data loaded live, and "cached · Nd old" when that data is temporarily unavailable and the board is showing the last good saved copy — a banner explains why whenever that happens.`,
+A freshness badge in the header reads "Updated Xh ago" (or "Updated just now" / "Updated yesterday") when the board's data loaded live, and "cached · Nd old" when that data isn't available right now and the board is showing the last good saved copy — a banner explains why whenever that happens.`,
         },
         {
           id: 'workbenchStatus',
           title: 'Workbench Status & Ball Tracking',
-          description:
-            'Visual indicators on each Workbench row showing who needs to act next, whether it is a draft, and how long it has waited.',
+          description: "A badge on each row showing whose turn it is, whether it's a draft, and how long it's been waiting.",
           entryMethod: `Each task carries a "ball" badge showing whose move it is:
 * **Take Action:** New feedback to address, a requested review, or a reply that needs an answer.
 * **To Write:** An issue that's assigned, with no pull request opened yet.
 * **Approved:** The PR has a formal approval and is heading toward merge. An approval dismissed after a later push still counts — its note names the approver and adds "dismissed after update", asking for a fresh look rather than a from-scratch re-review.
 * **Watching:** The ball is with another maintainer or contributor; participation continues in the background.
 * **Waiting:** That side of the work is done, and the row is idle by design — a draft not yet marked ready, or work blocked on someone else.
-* **Stale:** No substantive activity for 30+ days on a row where the next move belongs to someone else.
+* **Stale:** No real activity for 30+ days on a row where the next move belongs to someone else.
 * **Bot:** An automatic update to a dependency or security patch, submitted by a bot, kept in its own lane.
 
-A **Draft** chip marks a pull request still in draft state. **The day count** shown next to a Stalled (or otherwise long-idle) badge reflects the time elapsed since the last substantive update.
+A **Draft** chip marks a pull request still in draft state. **The day count** shown next to a Stalled (or otherwise long-idle) badge is the time since the last real update.
 
 **Note on Timers:** "Idle" ignores noise such as labels, reviewer pings, or base-branch merges. The clock only resets on a new commit, a code review (human or bot), or a discussion comment.`,
         },
@@ -230,16 +139,101 @@ A **Draft** chip marks a pull request still in draft state. **The day count** sh
     {
       id: 'writing',
       title: 'Writing',
-      description:
-        'Terms used on the Writing page, covering published articles and how they are grouped.',
+      description: 'Terms used on the Writing page, covering recognitions and published articles and how they are grouped.',
       items: [
+        {
+          id: 'recognitions',
+          title: 'Recognitions',
+          description:
+            'External recognition for individual pieces of writing — top-of-the-week picks, challenge wins, and similar mentions. Shown at the top of the page, above the article lists, and only when at least one exists.',
+          entryMethod:
+            'Each one is added manually in a contents file, with a title, the platform that gave it, and a link. A standout entry can be marked with a star.',
+        },
         {
           id: 'articles',
           title: 'Articles Written',
           description:
-            'Blog posts and articles around open source written to support and advocate for the open source ecosystem.',
+            'Blog posts and articles about open source, written to support and promote the community. Grouped into **Written for organizations**, for pieces written for a specific org, and **Personal writing**, for everything else.',
           entryMethod:
-            'Data is aggregated from Dev.to via automated API fetches and combined with manual entries (such as freeCodeCamp) maintained in the contents folder. Pieces written for a specific organization are grouped under a **Written for organizations** heading, newest organization first; everything else lists as personal writing, newest article first.',
+            'Articles are pulled in automatically from Dev.to, plus added directly for other platforms (like freeCodeCamp) in the contents folder. Pieces written for a specific organization are grouped under **Written for organizations**, newest organization first; everything else is listed under **Personal writing**, newest first.',
+        },
+      ],
+    },
+    {
+      id: 'quarterlyReports',
+      title: 'Quarterly Reports',
+      description: 'How contributions are grouped into three-month periods, making them easier to find and read.',
+      items: [
+        {
+          id: 'reportsIndex',
+          title: 'Reports Index',
+          description:
+            'The main list of the portfolio. It organizes all work into separate pages grouped by year and three-month periods (quarters).',
+          source:
+            'The **Quarterly Reports** page works like a folder, showing every year and, inside each year, its three-month periods.',
+        },
+      ],
+    },
+    {
+      id: 'quarterlyMetrics',
+      title: 'Quarterly Report Metrics',
+      description: 'Terms used inside a single report, covering the work done in that three-month period.',
+      items: [
+        {
+          id: 'quarterInBrief',
+          title: 'Quarter in brief',
+          description:
+            'A plain-language summary at the top of each quarterly report: a sentence or two on what happened, which organizations were worked with, and a few highlighted contributions.',
+          howItIsCalculated:
+            'Built from the same counts as the tables below — merged, reviewed, and co-authored pull requests, and issues — turned into a few sentences, a list of organizations worked with, and up to three highlighted contributions. The Markdown version of the report shows the same numbers as a **Quarterly Statistics** table instead, since Markdown can\'t do the same layout.',
+        },
+        {
+          id: 'stats',
+          title: 'Quarterly Statistics',
+          description: 'A summary that shows the total work and the projects involved during a specific three-month period.',
+          howItIsCalculated:
+            'Adds up every type of contribution and every different repo touched during that three-month period.',
+        },
+        {
+          id: 'focusProjects',
+          title: 'Top 3 Repositories',
+          description: 'The projects that received the most work and attention within each quarter.',
+          howItIsCalculated: 'Sorts repos by how many contributions happened in them that quarter.',
+        },
+        {
+          id: 'merged',
+          title: 'Merged PRs',
+          description: 'A record of pull requests that got accepted and merged into other people\'s repos.',
+          howItIsCalculated:
+            'Finds every pull request marked as merged, and works out the **Review Period** — the time from opening it to it being accepted.',
+        },
+        {
+          id: 'issues',
+          title: 'Issues',
+          description: 'A record of bugs, ideas, and problems reported on other people\'s repos.',
+          howItIsCalculated:
+            'Collects every issue opened, whether or not it was assigned. Works out the **Closing Period** — the time from opening to closing.',
+        },
+        {
+          id: 'reviewed',
+          title: 'Reviewed PRs',
+          description: 'A record of formal reviews left on other people\'s pull requests.',
+          howItIsCalculated:
+            'Works out the **Review Period** — from the pull request opening to the formal review being submitted — and tracks its current **Status** and **Last Update**.',
+        },
+        {
+          id: 'coAuthored',
+          title: 'Co-authored PRs',
+          description: 'A record of pull requests where code was contributed alongside other developers.',
+          howItIsCalculated:
+            'Finds commits credited to a co-author. The **Commit Period** is the time from the pull request opening to the first commit on it — showing when the collaboration started. **Status** and **Last Update** track where it stands now.',
+        },
+        {
+          id: 'collaborations',
+          title: 'Collaborations',
+          description: 'A record of comments left on issues or pull requests opened by other people.',
+          howItIsCalculated:
+            'Tracks comments on pull requests and issues, up until one gets a formal review.',
         },
       ],
     },


### PR DESCRIPTION
## Summary
- Fixed several UX issues on the Workbench (overflowing idle-day pills, missing tile border, full-width status pill on small screens, sort control, sticky lane nav)
- Gave "merged" its own GitHub-purple status color instead of sharing green with "open"
- Unified H1 color and external-link underline styling across pages into shared rules
- Added support for recording courses taken (with certificates), not just courses authored
- Rewrote the Glossary in plain English, reordered its sections to match actual page order, and documented the Writing page's Recognitions section
- Small small-screen layout fix for Reviewed/Co-Authored/Collaborations tables (date and status badge no longer collide)
- Documented the accent/surface/ink theme seeds and the new underline feature in the README

## Test plan
- [ ] `npm run build` locally and spot-check Workbench, Journey, Writing, Reports, and Glossary pages
- [ ] Verify Workbench sort control and sticky lane nav work as expected
- [ ] Verify external links show an underline in the accent color
- [ ] Verify the Glossary reads correctly and section order matches site navigation
- [ ] Confirm `node scripts/services/workbench-merge.test.js` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)