### PR TITLE
Render titles, linked code PRs, and issue/PR numbers on Workbench and quarterly reports

### DIFF
--- a/scripts/api/fetch-tracker-titles.js
+++ b/scripts/api/fetch-tracker-titles.js
@@ -1,0 +1,116 @@
+/**
+ * TRACKER-ONLY TITLE ENRICHMENT
+ *
+ * The upstream docs-PR tracker cache (adiati98/mautic-docs-prs-tracker) only
+ * carries activity arrays (reviews, comments, review requests), never a PR's
+ * title or body — see workbench-merge.js's tracker-only row construction.
+ * For a docs PR that's watched by the tracker but isn't in the local
+ * workbench (e.g. someone else's PR triaged as maintainer), that leaves
+ * nothing to render but "owner/repo#number".
+ *
+ * This fetches the one thing missing — title, and any linked code PR named
+ * in the body — directly from the GitHub PR detail endpoint, for exactly
+ * those tracker-only keys. Results are cached forever: a merged docs PR's
+ * title and linked code PR never change retroactively, so every run after
+ * the first costs zero API calls for a PR already seen. A fetch failure
+ * (rate limit, 404 on a since-deleted PR, an SSO-gated org) is left
+ * uncached rather than poisoned with a null — the row falls back to the
+ * pre-existing repo#number rendering this run, and gets retried next time.
+ */
+const fs = require('fs/promises');
+const path = require('path');
+const axios = require('axios');
+const { BASE_URL } = require('../config/config');
+const { extractLinkedCodePr } = require('../utils/github-helpers');
+const {
+  attachRateLimitLogger,
+  withRateLimitRetry,
+  mapWithConcurrency,
+  keepAliveAgent,
+} = require('../utils/http-helpers');
+
+const CACHE_FILE = path.join('data', 'tracker-titles-cache.json');
+const CONCURRENCY = 3;
+
+function buildAxiosInstance(timeoutMs) {
+  const token = process.env.GITHUB_TOKEN;
+  return attachRateLimitLogger(
+    axios.create({
+      baseURL: BASE_URL,
+      httpsAgent: keepAliveAgent,
+      timeout: timeoutMs,
+      headers: {
+        ...(token ? { Authorization: `token ${token}` } : {}),
+        Accept: 'application/vnd.github.v3+json',
+      },
+    })
+  );
+}
+
+async function readCache(cacheFile) {
+  try {
+    return JSON.parse(await fs.readFile(cacheFile, 'utf8'));
+  } catch (e) {
+    return {};
+  }
+}
+
+/**
+ * @param {string[]} keys  "owner/repo#number" keys to enrich (tracker-only —
+ *                         callers should exclude keys already covered by a
+ *                         local record, which already carries its own title).
+ * @returns {Promise<object>} map keyed by the same "owner/repo#number" →
+ *                            { title, linkedCodePr }, ready to pass as
+ *                            mergeWorkbench's `titles` input.
+ */
+async function fetchTrackerTitleInfo(keys, { cacheFile = CACHE_FILE, timeoutMs = 10000 } = {}) {
+  const cache = await readCache(cacheFile);
+  const result = {};
+
+  const pending = (keys || []).filter((key) => {
+    if (cache[key]) {
+      result[key] = cache[key];
+      return false;
+    }
+    return true;
+  });
+
+  if (pending.length === 0) return result;
+
+  const axiosInstance = buildAxiosInstance(timeoutMs);
+  let dirty = false;
+
+  await mapWithConcurrency(pending, CONCURRENCY, async (key) => {
+    const match = key.match(/^([^/]+\/[^#]+)#(\d+)$/);
+    if (!match) return;
+    const [, repo, number] = match;
+    try {
+      const res = await withRateLimitRetry(
+        () => axiosInstance.get(`/repos/${repo}/pulls/${number}`),
+        { label: `tracker-title ${key}` }
+      );
+      const entry = {
+        title: res.data.title || null,
+        linkedCodePr: extractLinkedCodePr(res.data.body, repo),
+      };
+      cache[key] = entry;
+      result[key] = entry;
+      dirty = true;
+    } catch (err) {
+      // Not cached — falls back to repo#number this run, retried next run.
+    }
+  });
+
+  if (dirty) {
+    try {
+      await fs.mkdir(path.dirname(cacheFile), { recursive: true });
+      await fs.writeFile(cacheFile, JSON.stringify(cache, null, 2), 'utf8');
+    } catch (e) {
+      /* cache write is best-effort */
+    }
+  }
+
+  return result;
+}
+
+module.exports = { fetchTrackerTitleInfo, CACHE_FILE };

--- a/scripts/generators/html/quarterly-reports-html-generator.js
+++ b/scripts/generators/html/quarterly-reports-html-generator.js
@@ -6,6 +6,7 @@ const { GITHUB_USERNAME, BASE_DIR } = require('../../config/config');
 const {
   formatDate,
   calculatePeriodInDays,
+  getIssueOrPrNumber,
   getPrStatusContent,
   getCollaborationStatusContent,
 } = require('../../utils/contribution-formatters');
@@ -859,20 +860,23 @@ ${navHtmlForReports}
           // No. column (not sortable, styled via the :first-child rule).
           tableContent += `<td>${counter++}.</td>`;
 
-          // Repo column (String type). Sort falls back to textContent, so no data-value is needed.
-          tableContent += `<td data-label="Project"><span class="qr-repo">${sanitizeAttribute(item.repo || '')}</span></td>`;
-
-          // Title column (String type, contains hyperlink). Sort falls back to textContent.
           // Backports/cherry-picks routinely reuse the exact same PR title
           // across different PRs (see e.g. Q2-2026's "docs: Add Tags
           // documentation for Contact management" filed 3 times) — two
           // links with identical text but different destinations is
           // exactly what WAVE's "suspicious link text" flags, since a
           // screen reader's link list can't tell them apart. The number
-          // pulled from the PR/issue URL disambiguates the accessible name
-          // without changing what's shown.
-          const refMatch = String(item.url || '').match(/\/(pull|issues)\/(\d+)/);
-          const refSuffix = refMatch ? ` (#${refMatch[2]})` : '';
+          // pulled from the PR/issue URL disambiguates both the accessible
+          // name below AND the visible repo chip, so a sighted reader gets
+          // the same disambiguation a screen reader does.
+          const issueOrPrNumber = getIssueOrPrNumber(item.url);
+          const numberSuffix = issueOrPrNumber ? ` #${issueOrPrNumber}` : '';
+
+          // Repo column (String type). Sort falls back to textContent, so no data-value is needed.
+          tableContent += `<td data-label="Project"><span class="qr-repo">${sanitizeAttribute(item.repo || '')}${numberSuffix}</span></td>`;
+
+          // Title column (String type, contains hyperlink). Sort falls back to textContent.
+          const refSuffix = issueOrPrNumber ? ` (#${issueOrPrNumber})` : '';
           tableContent += `<td data-label="Title"><a href="${sanitizeAttribute(item.url)}" target="_blank" rel="noopener noreferrer" class="qr-link" aria-label="${sanitizeAttribute(item.title || '')}${refSuffix}">${safeTitle}</a></td>`;
 
           // Handle the remaining columns based on the contribution type.

--- a/scripts/generators/html/workbench-html-generator.js
+++ b/scripts/generators/html/workbench-html-generator.js
@@ -215,13 +215,20 @@ function relLabel(record) {
   return map[record.relationship] || escapeHtml(record.relationship) || '';
 }
 
+/** "owner/repo#123" → "owner/repo #123" — a space between the repo and the
+ * issue/PR number reads better than GitHub's own crammed-together convention. */
+function spaceBeforeNumber(key) {
+  return String(key || '').replace(/#(\d+)$/, ' #$1');
+}
+
 function renderRow(record) {
   const pillClass = PILL_CLASS[record.ball] || 'wbx-pill--stale';
   const idleBadge =
     record.lane === 'stalled' || record.idleDays >= 7
       ? ` · ${Math.floor(record.idleDays)}d`
       : '';
-  const title = escapeHtml(record.title || record.key);
+  const repoLabel = record.key ? spaceBeforeNumber(record.key) : record.repo || '';
+  const title = escapeHtml(record.title || repoLabel);
   const nextBits = [];
   if (record.approval && record.approval.by) {
     // An approval dismissed after a push is still worth surfacing — it just
@@ -256,7 +263,7 @@ function renderRow(record) {
       <span class="wbx-pill ${pillClass}"><i></i>${escapeHtml(record.ball)}${idleBadge}</span>
       <div>
         <div class="wbx-meta">
-          <span class="wbx-repo">${escapeHtml(record.repo || '')}</span>
+          <span class="wbx-repo">${escapeHtml(repoLabel)}</span>
           <span class="wbx-rel">${relLabel(record)}</span>
           ${record.isDraft ? '<span class="wbx-chip-draft">Draft</span>' : ''}
         </div>

--- a/scripts/generators/markdown/community-markdown-generator.js
+++ b/scripts/generators/markdown/community-markdown-generator.js
@@ -202,9 +202,15 @@ function statusCell(record) {
   return `${badge}${idleBadge}`;
 }
 
+/** "owner/repo#123" → "owner/repo #123" — mirrors the HTML renderer's spacing. */
+function spaceBeforeNumber(key) {
+  return String(key || '').replace(/#(\d+)$/, ' #$1');
+}
+
 /** Mirrors the wbx-meta row: repo chip, relationship label, Draft badge. */
 function repoCell(record) {
-  const bits = [`**${mdEscapeCell(record.repo || '')}**`];
+  const repoLabel = record.key ? spaceBeforeNumber(record.key) : record.repo || '';
+  const bits = [`**${mdEscapeCell(repoLabel)}**`];
   const rel = REL_LABEL[record.relationship] || record.relationship;
   if (rel) bits.push(rel);
   if (record.isDraft) bits.push('`Draft`');
@@ -237,7 +243,7 @@ function nextCell(record) {
 }
 
 function taskCell(record) {
-  const title = mdEscapeLinkText(record.title || record.key || '');
+  const title = mdEscapeLinkText(record.title || spaceBeforeNumber(record.key) || '');
   return record.url ? `[${title}](${record.url})` : title;
 }
 

--- a/scripts/generators/markdown/quarterly-reports-generator.js
+++ b/scripts/generators/markdown/quarterly-reports-generator.js
@@ -4,6 +4,7 @@ const { BASE_DIR } = require('../../config/config');
 const {
   formatDate,
   calculatePeriodInDays,
+  getIssueOrPrNumber,
   getPrStatusContent,
   getCollaborationStatusContent,
 } = require('../../utils/contribution-formatters');
@@ -205,9 +206,12 @@ ${index + 1}. [**${item[0]}**](${repoUrl}) (${item[1]} contributions)`;
         let counter = 1;
         // Iterate over each contribution item to build table rows
         for (const item of items) {
+          const issueOrPrNumber = getIssueOrPrNumber(item.url);
+          const numberSuffix = issueOrPrNumber ? ` #${issueOrPrNumber}` : '';
+
           tableContent += `    <tr>\n`;
           tableContent += `      <td>${counter++}.</td>\n`;
-          tableContent += `      <td>${item.repo}</td>\n`;
+          tableContent += `      <td>${item.repo}${numberSuffix}</td>\n`;
           // Add a hyperlink to the title
           tableContent += `      <td><a href='${item.url}'>${item.title}</a></td>\n`;
 

--- a/scripts/services/workbench-merge.js
+++ b/scripts/services/workbench-merge.js
@@ -25,6 +25,8 @@ const path = require('path');
 const axios = require('axios');
 const { GITHUB_USERNAME } = require('../config/config');
 const { isAllowedBotLogin, isBotLogin } = require('../utils/bot-helpers');
+const { extractLinkedCodePr } = require('../utils/github-helpers');
+const { fetchTrackerTitleInfo } = require('../api/fetch-tracker-titles');
 
 const TRACKER_RAW_URL =
   'https://raw.githubusercontent.com/adiati98/mautic-docs-prs-tracker/main/data/pr-cache.json';
@@ -118,16 +120,6 @@ async function fetchTrackerFeed({ url = TRACKER_RAW_URL, timeoutMs = 10000 } = {
 function taskKey(record) {
   if (!record.repo || record.number == null) return null;
   return `${record.repo}#${record.number}`;
-}
-
-/** Extracts a linked code-PR reference from a docs PR body, if present. */
-function extractLinkedCodePr(body, ownRepo) {
-  if (!body) return null;
-  const urlMatch = body.match(/github\.com\/([\w.-]+\/[\w.-]+)\/pull\/(\d+)/);
-  if (urlMatch && urlMatch[1] !== ownRepo) return `${urlMatch[1]}#${urlMatch[2]}`;
-  const shortMatch = body.match(/([\w.-]+\/[\w.-]+)#(\d+)/);
-  if (shortMatch && shortMatch[1] !== ownRepo) return `${shortMatch[1]}#${shortMatch[2]}`;
-  return null;
 }
 
 /**
@@ -639,9 +631,23 @@ function deriveTurn(record, me, botPingSignal = null) {
  * @param {object} input.feed      { data, fetchedAt, degraded, reason }
  * @param {string} [input.username]
  * @param {Date}   [input.now]
+ * @param {object} [input.titles]  tracker-only enrichment, keyed by
+ *                                 "owner/repo#number" → { title, linkedCodePr }
+ *                                 (see fetchTrackerTitleInfo). Never required —
+ *                                 an absent key just keeps today's null-title
+ *                                 fallback.
  * @returns {{ records: Array, feed: object }}
  */
-function mergeWorkbench({ tasks = [], issues = [], prs = [], coauthored = [], feed, username, now }) {
+function mergeWorkbench({
+  tasks = [],
+  issues = [],
+  prs = [],
+  coauthored = [],
+  feed,
+  username,
+  now,
+  titles = {},
+}) {
   const me = String(username || GITHUB_USERNAME || '').toLowerCase();
   const nowDate = now || new Date();
   const tracker = (feed && feed.data) || {};
@@ -716,10 +722,13 @@ function mergeWorkbench({ tasks = [], issues = [], prs = [], coauthored = [], fe
 
   // Tracker-only rows: the tracker watches them but they aren't in the local
   // workbench (e.g. someone else's docs PR you triage as maintainer). The
-  // cache carries activity, not titles — renderers show repo#number.
+  // cache itself carries activity, not titles — `titles` is a separate,
+  // optional enrichment (fetchTrackerTitleInfo/loadMergedWorkbench) that
+  // looks the PR up directly; without it, renderers fall back to repo#number.
   for (const [key, upstream] of Object.entries(tracker)) {
     if (matchedKeys.has(key)) continue;
     const [repo, number] = key.split('#');
+    const titleInfo = titles[key] || null;
     const approval = deriveApproval(null, upstream);
     const reviewRequest = deriveReviewRequest(upstream, me);
     const reviewedNote = deriveReviewedNote(upstream, approval, me);
@@ -729,7 +738,7 @@ function mergeWorkbench({ tasks = [], issues = [], prs = [], coauthored = [], fe
     const record = {
       key,
       source: 'tracker',
-      title: null,
+      title: titleInfo?.title || null,
       url: `https://github.com/${repo}/pull/${number}`,
       repo,
       relationship: 'reviewing',
@@ -751,7 +760,11 @@ function mergeWorkbench({ tasks = [], issues = [], prs = [], coauthored = [], fe
       // Tracker-only rows have no local author/last-actor, so no bot-ping can be
       // derived — kept present and null for a uniform record contract.
       botPing: null,
-      linkedCodePr: upstream.codeUpdatedAt ? { ref: null, hasActivity: true } : null,
+      linkedCodePr: titleInfo?.linkedCodePr
+        ? { ref: titleInfo.linkedCodePr, hasActivity: Boolean(upstream.codeUpdatedAt) }
+        : upstream.codeUpdatedAt
+          ? { ref: null, hasActivity: true }
+          : null,
       upstream: {
         docsUpdatedAt: upstream.docsUpdatedAt || null,
         codeUpdatedAt: upstream.codeUpdatedAt || null,
@@ -913,7 +926,24 @@ async function loadMergedWorkbench({ dataDir = 'data', fetchOptions } = {}) {
     readJsonOr({}, path.join(dataDir, 'all-contributions.json')),
   ]);
   const feed = await fetchTrackerFeed(fetchOptions);
-  const { records, feed: feedMeta } = mergeWorkbench({ tasks, issues, prs, coauthored, feed });
+
+  // Only tracker-only rows need the title enrichment fetch — a row already
+  // covered by a local record carries its own title, so re-fetching it would
+  // just burn an API call for something we already have.
+  const localKeys = new Set(
+    [...tasks, ...issues, ...prs, ...coauthored].map(taskKey).filter(Boolean)
+  );
+  const trackerOnlyKeys = Object.keys(feed.data || {}).filter((key) => !localKeys.has(key));
+  const titles = await fetchTrackerTitleInfo(trackerOnlyKeys);
+
+  const { records, feed: feedMeta } = mergeWorkbench({
+    tasks,
+    issues,
+    prs,
+    coauthored,
+    feed,
+    titles,
+  });
   const impact = computeImpact(records, contributions);
   return { records, impact, feed: feedMeta };
 }
@@ -922,6 +952,7 @@ module.exports = {
   TRACKER_RAW_URL,
   fetchTrackerFeed,
   isValidTrackerShape,
+  taskKey,
   extractLinkedCodePr,
   extractIssueRefs,
   buildIssuePrLinks,

--- a/scripts/services/workbench-merge.test.js
+++ b/scripts/services/workbench-merge.test.js
@@ -98,6 +98,35 @@ run(
   }
 );
 
+// 3b. Tracker-only row enriched with a fetched title + linked code PR (see
+// fetchTrackerTitleInfo) renders both instead of falling back to repo#number.
+run(
+  'tracker-only row enriched by titles',
+  {
+    tracker: {
+      'mautic/user-documentation#880': {
+        docsUpdatedAt: daysAgo(3),
+        codeUpdatedAt: daysAgo(2),
+        rawDocsReviews: [],
+        rawDocsComments: [],
+      },
+    },
+    titles: {
+      'mautic/user-documentation#880': {
+        title: 'Update the campaign builder docs',
+        linkedCodePr: 'mautic/mautic#16760',
+      },
+    },
+  },
+  ({ records }) => {
+    const r = records.find((x) => x.key === 'mautic/user-documentation#880');
+    assert.equal(r.source, 'tracker');
+    assert.equal(r.title, 'Update the campaign builder docs');
+    assert.equal(r.linkedCodePr.ref, 'mautic/mautic#16760');
+    assert.equal(r.linkedCodePr.hasActivity, true);
+  }
+);
+
 // 4. Approved + linked code PR → ready lane, code-aware next step
 run(
   'approved with linked code PR → ready, bring-it-home step',

--- a/scripts/utils/contribution-formatters.js
+++ b/scripts/utils/contribution-formatters.js
@@ -43,6 +43,18 @@ function calculatePeriodInDays(startDateString, endDateString, status = null) {
 }
 
 /**
+ * Extracts the issue/PR number from a GitHub URL, e.g.
+ * ".../pull/123" or ".../issues/123" → "123". Returns null when the URL
+ * doesn't match (missing, malformed, or not an issue/PR URL).
+ * @param {string} url
+ * @returns {string|null}
+ */
+function getIssueOrPrNumber(url) {
+  const match = String(url || '').match(/\/(?:pull|issues)\/(\d+)/);
+  return match ? match[1] : null;
+}
+
+/**
  * Generates Last Update / Status content for reviewed and co-authored PRs.
  * @param {object} item PR item with date, mergedAt, and state fields.
  * @returns {string} Formatted date with status badge.
@@ -84,6 +96,7 @@ function getCollaborationStatusContent(item) {
 module.exports = {
   formatDate,
   calculatePeriodInDays,
+  getIssueOrPrNumber,
   getPrStatusContent,
   getCollaborationStatusContent,
 };

--- a/scripts/utils/github-helpers.js
+++ b/scripts/utils/github-helpers.js
@@ -15,6 +15,16 @@ function getLinkedIssueNumbers(prBody) {
   return matches;
 }
 
+/** Extracts a linked code-PR reference from a docs PR body, if present. */
+function extractLinkedCodePr(body, ownRepo) {
+  if (!body) return null;
+  const urlMatch = body.match(/github\.com\/([\w.-]+\/[\w.-]+)\/pull\/(\d+)/);
+  if (urlMatch && urlMatch[1] !== ownRepo) return `${urlMatch[1]}#${urlMatch[2]}`;
+  const shortMatch = body.match(/([\w.-]+\/[\w.-]+)#(\d+)/);
+  if (shortMatch && shortMatch[1] !== ownRepo) return `${shortMatch[1]}#${shortMatch[2]}`;
+  return null;
+}
+
 /**
  * HELPER: Fetches specific activity metadata for a PR to determine "Who has the ball".
  * Merges timeline processing with explicit fallback comment checking to guarantee review replies are caught,
@@ -208,5 +218,6 @@ async function getPrActivityMeta(
 
 module.exports = {
   getLinkedIssueNumbers,
+  extractLinkedCodePr,
   getPrActivityMeta,
 };


### PR DESCRIPTION
## Summary
- Tracker-only Workbench rows (docs PRs the upstream tracker watches but that aren't in the local workbench) were rendering as bare `repo#number` because the tracker cache only ever carried activity data, never a title or body. Added a small, permanently-cached fetch that pulls the title and any linked code PR directly from GitHub for exactly those rows, and threaded it through `mergeWorkbench` as an optional enrichment.
- Both the Workbench and the quarterly reports already had the issue/PR number available (a record's key, or parseable from its URL) but never showed it — a row's identity was title-only. Folded `#123` into each surface's existing repo chip (e.g. `owner/repo #123`) instead of adding new UI, so identity and title stay visually separate. Added one shared helper for the URL-based number extraction instead of duplicating it a third time.

## Test plan
- [x] `node scripts/services/workbench-merge.test.js` — all fixtures pass, including new coverage for tracker-only title/linked-code-PR enrichment
- [x] Live-fetched a real tracker-only PR to confirm the title + linked code PR resolve correctly end to end
- [x] Rendered all four surfaces (Workbench HTML/Markdown, quarterly report HTML/Markdown) against fixture data (fs writes stubbed in a throwaway script, no generated files touched) to confirm the repo chip shows `owner/repo #123` with a space, including the title-fallback case