### PR TITLE
feat: detailed Active Workbench next-step wording for every repo

### DIFF
--- a/contents/docs-workflow-repos.js
+++ b/contents/docs-workflow-repos.js
@@ -1,0 +1,41 @@
+module.exports = {
+  /**
+   * Docs-Workflow Repositories
+   * --------------------------
+   * Some projects run a documentation workflow with housekeeping steps that
+   * mean nothing anywhere else — a release milestone on every PR, a label that
+   * marks a docs PR as waiting on its code PR. Prompting for those on a repo
+   * that has never used them is pure noise, so each rule below is scoped to an
+   * explicit list of repos.
+   *
+   * The scope is deliberately a list, never an inference: a PR that happens to
+   * carry a milestone (or happens not to) says nothing about whether its
+   * project expects one, so the presence of the field can't be used to decide
+   * this. Same for labels.
+   *
+   * Matching follows the same convention as excludedRepos in
+   * repo-exclusions.js and allowedBot in allowed-bot.js — case-insensitive
+   * .includes(), so:
+   *   'mautic/'                    matches every repo in the mautic org
+   *   'mautic/user-documentation'  matches only that repository
+   *
+   * Leave a list empty to switch that rule off entirely.
+   */
+
+  /** Repos whose release process runs on milestones. Emits "Add milestone". */
+  milestoneRepos: ['mautic/user-documentation', 'mautic/developer-documentation-new'],
+
+  /**
+   * Repos that mark a docs PR as waiting on its code PR with a label. Emits
+   * "Add <pendingLabel> label" on DRAFT PRs that don't carry it yet — a draft
+   * docs PR is, by definition, still pending something.
+   *
+   * The prompt is a live read of the PR's labels every build, not a stored
+   * flag: add the label on GitHub and the chip is gone on the next run, with
+   * nothing to clear by hand.
+   */
+  pendingLabelRepos: ['mautic/user-documentation', 'mautic/developer-documentation-new'],
+
+  /** The label name those repos use. */
+  pendingLabel: 'pending-pr-merge',
+};

--- a/scripts/api/fetch-ongoing-workbench.js
+++ b/scripts/api/fetch-ongoing-workbench.js
@@ -288,6 +288,22 @@ const formatTask = async (pr, status, activityCache, failedFetchCache) => {
     approvedBy: activity.approvedBy,
     lastSubstantiveDate: activity.lastSubstantiveDate,
     author: pr.user.login,
+    // Widened activity + PR detail, carried through to the merge engine so it
+    // can derive specific next steps ("changes requested by X", "X mentioned
+    // you", "no reviewer assigned", "conflicts with main") for EVERY repo,
+    // not only the ones the external docs tracker covers. Already capped and
+    // body-stripped upstream (see getPrActivityMeta / fetchPrDetail); a cached
+    // activity object predating those fields degrades to an empty/null value
+    // rather than an undefined one, so consumers can read them unguarded.
+    reviews: Array.isArray(activity.reviews) ? activity.reviews : [],
+    comments: Array.isArray(activity.comments) ? activity.comments : [],
+    reviewRequests: Array.isArray(activity.reviewRequests) ? activity.reviewRequests : [],
+    requestedReviewers: Array.isArray(activity.requestedReviewers)
+      ? activity.requestedReviewers
+      : [],
+    mergeableState: activity.mergeableState ?? null,
+    baseRef: activity.baseRef ?? null,
+    milestone: activity.milestone ?? null,
   };
 };
 

--- a/scripts/api/fetch-ongoing-workbench.js
+++ b/scripts/api/fetch-ongoing-workbench.js
@@ -32,7 +32,7 @@ const axiosInstance = attachRateLimitLogger(
 // unlimited Promise.all) so we don't fire hundreds of simultaneous requests
 // at GitHub's secondary rate limiter when a user has thousands of open PRs
 // to track. Each PR's activity fetch fans out to 4 parallel calls, plus one
-// authoritative draft-state call (see fetchDraftState) = 5, so the real peak is
+// authoritative draft-state call (see fetchPrDetail) = 5, so the real peak is
 // PR_CONCURRENCY * 5 sockets — kept at 3 (=> ~15 in flight, further capped by
 // the agent's maxSockets) to stay under GitHub's abuse-detection threshold.
 // Going higher reliably tripped secondary rate limits and ECONNRESET storms
@@ -158,34 +158,54 @@ async function getFirstCommitDetails(
 }
 
 /**
- * SHARED HELPER: fetchDraftState
- * Authoritative draft flag for a PR, read from the PR detail endpoint.
+ * SHARED HELPER: fetchPrDetail
+ * Authoritative PR detail fields, read from the single PR detail endpoint call.
  *
  * Three of the four Workbench fetchers get their PR objects from the Search API
  * (fetchOngoingReviews, fetchOngoingCoAuthoredPrs) or the `/issues` list
  * (fetchOngoingAuthoredPrs), and neither reliably carries `draft` — the field
  * can be absent or lag GitHub's search index, so a real draft would silently
  * render as ready-for-review. `/repos/:owner/:repo/pulls/:number` always reports
- * the true `draft`, so it is the source of truth here; the search/issues item's
- * own `draft` is only the fallback for when the detail call can't be made (a
- * permanent 403 on an SSO-gated org, or any transient failure). Callers cache
- * the result alongside the activity meta, gated by the PR's updated_at — and a
- * draft toggle always bumps updated_at — so this costs an API call only when a
- * PR actually changed since the last run.
+ * the true `draft` plus the live pending-reviewer list, mergeable state, base
+ * branch, and milestone — all read from this one call rather than issuing a
+ * second request per field. The search/issues item's own `draft` is only the
+ * fallback for when the detail call can't be made (a permanent 403 on an
+ * SSO-gated org, or any transient failure). Callers cache the result alongside
+ * the activity meta, gated by the PR's updated_at — and any of these fields
+ * changing always bumps updated_at — so this costs an API call only when a PR
+ * actually changed since the last run.
  */
-async function fetchDraftState(owner, repo, pr, failedFetchCache) {
-  const fallback = pr.draft === true;
+async function fetchPrDetail(owner, repo, pr, failedFetchCache) {
+  const fallback = {
+    isDraft: pr.draft === true,
+    requestedReviewers: [],
+    mergeableState: null,
+    baseRef: null,
+    milestone: null,
+  };
   // Skip a PR we already know permanently 403s — reuse the search/issues value.
   if (failedFetchCache?.has(pr.html_url)) return fallback;
   try {
     const resp = await withRateLimitRetry(
       () => axiosInstance.get(`/repos/${owner}/${repo}/pulls/${pr.number}`),
-      { label: `pr-draft#${pr.number}` }
+      { label: `pr-detail#${pr.number}` }
     );
-    return resp.data.draft === true;
+    const data = resp.data;
+    return {
+      isDraft: data.draft === true,
+      requestedReviewers: Array.isArray(data.requested_reviewers)
+        ? data.requested_reviewers
+            .map((u) => u.login)
+            .filter(Boolean)
+            .slice(0, 30)
+        : [],
+      mergeableState: data.mergeable_state ?? null,
+      baseRef: data.base?.ref ?? null,
+      milestone: data.milestone?.title ?? null,
+    };
   } catch (err) {
     // getPrActivityMeta runs the same PR in parallel and records any permanent
-    // 403; here we only need a truthful-as-possible boolean, so degrade to the
+    // 403; here we only need a truthful-as-possible result, so degrade to the
     // fetch-layer item's own draft rather than failing the PR.
     return fallback;
   }
@@ -204,14 +224,14 @@ async function getCachedActivity(owner, repo, pr, activityCache, failedFetchCach
   const cacheKey = pr.html_url;
   if (activityCache) {
     const cached = activityCache.get(cacheKey);
-    if (cached && cached.updatedAt === pr.updated_at) {
+    if (cached && cached.updatedAt === pr.updated_at && cached.schemaVersion >= 2) {
       return cached.activity;
     }
   }
 
-  // The 4-call activity fetch and the draft read are independent, so run them
-  // in parallel; the draft result is folded onto the activity object.
-  const [activity, isDraft] = await Promise.all([
+  // The 4-call activity fetch and the PR detail read are independent, so run
+  // them in parallel; the detail fields are folded onto the activity object.
+  const [activity, prDetail] = await Promise.all([
     getPrActivityMeta(
       owner,
       repo,
@@ -223,12 +243,16 @@ async function getCachedActivity(owner, repo, pr, activityCache, failedFetchCach
       pr.html_url,
       pr.title
     ),
-    fetchDraftState(owner, repo, pr, failedFetchCache),
+    fetchPrDetail(owner, repo, pr, failedFetchCache),
   ]);
-  activity.isDraft = isDraft;
+  activity.isDraft = prDetail.isDraft;
+  activity.requestedReviewers = prDetail.requestedReviewers;
+  activity.mergeableState = prDetail.mergeableState;
+  activity.baseRef = prDetail.baseRef;
+  activity.milestone = prDetail.milestone;
 
   if (activityCache) {
-    activityCache.set(cacheKey, { updatedAt: pr.updated_at, activity });
+    activityCache.set(cacheKey, { updatedAt: pr.updated_at, activity, schemaVersion: 2 });
   }
   return activity;
 }
@@ -252,7 +276,7 @@ const formatTask = async (pr, status, activityCache, failedFetchCache) => {
     updatedAt: pr.updated_at,
     number: pr.number,
     user: pr.user,
-    // Authoritative draft from the PR detail endpoint (see fetchDraftState),
+    // Authoritative draft from the PR detail endpoint (see fetchPrDetail),
     // falling back to the search/issues item's own `draft` only if a cached
     // activity object predates this field.
     isDraft: typeof activity.isDraft === 'boolean' ? activity.isDraft : pr.draft === true,
@@ -386,7 +410,7 @@ async function fetchOngoingAuthoredPrs(activityCache, failedFetchCache) {
 
   return mapWithConcurrency(candidates, PR_CONCURRENCY, async (item) => {
     // formatTask now sources the authoritative draft flag from the PR detail
-    // endpoint (via fetchDraftState), so no `/issues`-shaped override is needed.
+    // endpoint (via fetchPrDetail), so no `/issues`-shaped override is needed.
     const formatted = await formatTask(item, 'Authored', activityCache, failedFetchCache);
     formatted.author = GITHUB_USERNAME;
     formatted.body = item.body;

--- a/scripts/api/fetch-ongoing-workbench.js
+++ b/scripts/api/fetch-ongoing-workbench.js
@@ -1,7 +1,11 @@
 require('dotenv').config();
 const axios = require('axios');
 const { GITHUB_USERNAME, BASE_URL } = require('../config/config');
-const { getLinkedIssueNumbers, getPrActivityMeta } = require('../utils/github-helpers');
+const {
+  getLinkedIssueNumbers,
+  getPrActivityMeta,
+  extractLinkedCodePr,
+} = require('../utils/github-helpers');
 const {
   attachRateLimitLogger,
   withRateLimitRetry,
@@ -32,9 +36,11 @@ const axiosInstance = attachRateLimitLogger(
 // unlimited Promise.all) so we don't fire hundreds of simultaneous requests
 // at GitHub's secondary rate limiter when a user has thousands of open PRs
 // to track. Each PR's activity fetch fans out to 4 parallel calls, plus one
-// authoritative draft-state call (see fetchPrDetail) = 5, so the real peak is
-// PR_CONCURRENCY * 5 sockets — kept at 3 (=> ~15 in flight, further capped by
-// the agent's maxSockets) to stay under GitHub's abuse-detection threshold.
+// authoritative draft-state call (see fetchPrDetail), plus one linked-code-PR
+// state call on the rows that reference one (see fetchLinkedCodePrState) = up
+// to 6, so the real peak is PR_CONCURRENCY * 6 sockets — kept at 3 (=> ~18 in
+// flight, further capped by the agent's maxSockets) to stay under GitHub's
+// abuse-detection threshold.
 // Going higher reliably tripped secondary rate limits and ECONNRESET storms
 // that cost far more in backoff than the extra parallelism saved. The draft
 // call rides the same updated_at-gated cache, so it only fires when a PR
@@ -212,6 +218,31 @@ async function fetchPrDetail(owner, repo, pr, failedFetchCache) {
 }
 
 /**
+ * SHARED HELPER: fetchLinkedCodePrState
+ * Some docs PRs reference a code PR in another repo (extractLinkedCodePr).
+ * Knowing whether that code PR merged, closed unmerged, or is still open is
+ * what turns a vague "Watching" into a real next step. Only called for
+ * records that actually carry a linked code PR reference — everything else
+ * pays nothing. A failed or 403 fetch resolves to null (unknown), never
+ * 'open', so callers don't mistake "couldn't check" for "still open".
+ */
+async function fetchLinkedCodePrState(ref) {
+  const [repoPart, numberPart] = ref.split('#');
+  const [owner, repo] = repoPart.split('/');
+  const number = Number(numberPart);
+  try {
+    const resp = await withRateLimitRetry(
+      () => axiosInstance.get(`/repos/${owner}/${repo}/pulls/${number}`),
+      { label: `linked-code-pr#${number}` }
+    );
+    if (resp.data.merged) return 'merged';
+    return resp.data.state === 'closed' ? 'closed' : 'open';
+  } catch (err) {
+    return null;
+  }
+}
+
+/**
  * SHARED HELPER: getCachedActivity
  * Wraps getPrActivityMeta (and the authoritative draft read) with a persistent,
  * updatedAt-gated cache so a PR that hasn't changed since the last run costs
@@ -231,7 +262,11 @@ async function getCachedActivity(owner, repo, pr, activityCache, failedFetchCach
 
   // The 4-call activity fetch and the PR detail read are independent, so run
   // them in parallel; the detail fields are folded onto the activity object.
-  const [activity, prDetail] = await Promise.all([
+  // The linked-code-PR state check rides along the same Promise.all, but only
+  // fires for a PR whose body actually references one — everything else pays
+  // nothing extra.
+  const linkedCodePr = extractLinkedCodePr(pr.body, `${owner}/${repo}`);
+  const [activity, prDetail, linkedCodePrState] = await Promise.all([
     getPrActivityMeta(
       owner,
       repo,
@@ -244,12 +279,14 @@ async function getCachedActivity(owner, repo, pr, activityCache, failedFetchCach
       pr.title
     ),
     fetchPrDetail(owner, repo, pr, failedFetchCache),
+    linkedCodePr ? fetchLinkedCodePrState(linkedCodePr) : Promise.resolve(null),
   ]);
   activity.isDraft = prDetail.isDraft;
   activity.requestedReviewers = prDetail.requestedReviewers;
   activity.mergeableState = prDetail.mergeableState;
   activity.baseRef = prDetail.baseRef;
   activity.milestone = prDetail.milestone;
+  activity.linkedCodePrState = linkedCodePrState;
 
   if (activityCache) {
     activityCache.set(cacheKey, { updatedAt: pr.updated_at, activity, schemaVersion: 2 });
@@ -304,6 +341,7 @@ const formatTask = async (pr, status, activityCache, failedFetchCache) => {
     mergeableState: activity.mergeableState ?? null,
     baseRef: activity.baseRef ?? null,
     milestone: activity.milestone ?? null,
+    linkedCodePrState: activity.linkedCodePrState ?? null,
   };
 };
 

--- a/scripts/generators/html/workbench-html-generator.js
+++ b/scripts/generators/html/workbench-html-generator.js
@@ -204,6 +204,11 @@ const WORKBENCH_CSS = `
   .wbx-step{font-family:ui-monospace,monospace;font-size:.75rem;letter-spacing:.05em;text-transform:uppercase;padding:1px 8px;border-radius:5px}
   .wbx-step--do{color:var(--t-caution);background:var(--t-caution-wash)}
   .wbx-step--ship{color:var(--t-positive);background:var(--t-positive-wash)}
+  /* Triage, not the row's instruction — brand blue keeps it a visibly
+     different class of thing from the amber "do this" step, the way the
+     upstream docs-PR tracker separates its teal setup chip from its blue
+     act chip. */
+  .wbx-step--setup{color:var(--t-brand);background:var(--t-brand-wash);border:1px solid var(--t-brand-line)}
   .wbx-empty{text-align:center;padding:44px 20px;color:var(--t-ink-2)}
   .wbx-empty .g{font-size:2rem;color:var(--t-positive);font-weight:800}
   .wbx-chip-draft{display:inline-flex;align-items:center;font-family:ui-monospace,monospace;font-size:.75rem;letter-spacing:.03em;color:var(--t-neutral);background:var(--t-neutral-wash);border:1px solid var(--t-neutral-line);border-radius:999px;padding:1px 9px}
@@ -269,11 +274,23 @@ function statusSignatureFor(record) {
     record.botPing && record.botPing.of,
     record.linkedCodePr && record.linkedCodePr.ref,
     record.isDraft,
+    // Setting the milestone or the label is a real change of situation, so a
+    // row checked off while one was missing must not stay checked once it is.
+    record.milestoneMissing,
+    record.pendingLabelMissing,
   ]);
 }
 
 function searchBlobFor(record, repoLabel) {
-  return [repoLabel, record.title, record.relationship, record.ball, record.nextStep]
+  return [
+    repoLabel,
+    record.title,
+    record.relationship,
+    record.ball,
+    record.nextStep,
+    record.milestoneMissing ? 'add milestone' : null,
+    record.pendingLabelMissing ? `add ${record.pendingLabelMissing} label` : null,
+  ]
     .filter(Boolean)
     .join(' ')
     .toLowerCase();
@@ -287,7 +304,25 @@ function renderRow(record) {
       : '';
   const repoLabel = record.key ? spaceBeforeNumber(record.key) : record.repo || '';
   const title = escapeHtml(record.title || repoLabel);
+
+  // Actions first, context after. The row used to lead with "approved by X ·
+  // Y reviewed this · 🔗 code PR" and put the one thing you actually had to DO
+  // at the very end of the line. Triage leads the actions, mirroring the
+  // upstream tracker, which pushes its "Add milestone" chip ahead of the
+  // review chip because the milestone is the cheaper, more blocking fix.
   const nextBits = [];
+  if (record.pendingLabelMissing) {
+    nextBits.push(
+      `<span class="wbx-step wbx-step--setup">Add ${escapeHtml(record.pendingLabelMissing)} label</span>`
+    );
+  }
+  if (record.milestoneMissing) {
+    nextBits.push('<span class="wbx-step wbx-step--setup">Add milestone</span>');
+  }
+  if (record.nextStep) {
+    const stepClass = record.lane === 'ready' ? 'wbx-step--ship' : 'wbx-step--do';
+    nextBits.push(`<span class="wbx-step ${stepClass}">${escapeHtml(record.nextStep)}</span>`);
+  }
   if (record.approval && record.approval.by) {
     // An approval dismissed after a push is still worth surfacing — it just
     // needs a fresh look, not a re-review from scratch.
@@ -309,10 +344,6 @@ function renderRow(record) {
       ? `<a href="https://github.com/${escapeHtml(refMatch[1])}/pull/${refMatch[2]}" target="_blank" rel="noopener noreferrer">${escapeHtml(ref)}</a>`
       : escapeHtml(ref);
     nextBits.push(`<span style="font-family:ui-monospace,monospace;font-size:.75rem">🔗 code PR <b>${refHtml}</b></span>`);
-  }
-  if (record.nextStep) {
-    const stepClass = record.lane === 'ready' ? 'wbx-step--ship' : 'wbx-step--do';
-    nextBits.push(`<span class="wbx-step ${stepClass}">${escapeHtml(record.nextStep)}</span>`);
   }
   const nextHtml = nextBits.length ? `<div class="wbx-next">${nextBits.join(' · ')}</div>` : '';
   const key = record.key || record.url || '';

--- a/scripts/generators/html/workbench-html-generator.js
+++ b/scripts/generators/html/workbench-html-generator.js
@@ -201,7 +201,7 @@ const WORKBENCH_CSS = `
   .wbx-task a{color:var(--t-ink);font-weight:600}
   .wbx-task a:hover{color:var(--t-brand)}
   .wbx-next{display:flex;align-items:center;gap:6px;flex-wrap:wrap;margin-top:10px;font-size:.78rem;color:var(--t-ink-2)}
-  .wbx-step{font-family:ui-monospace,monospace;font-size:.75rem;letter-spacing:.05em;text-transform:uppercase;padding:1px 8px;border-radius:5px}
+  .wbx-step{font-family:ui-monospace,monospace;font-size:.75rem;letter-spacing:.05em;text-transform:uppercase;padding:1px 8px;border-radius:5px;word-break:break-word;overflow-wrap:break-word}
   .wbx-step--do{color:var(--t-caution);background:var(--t-caution-wash)}
   .wbx-step--ship{color:var(--t-positive);background:var(--t-positive-wash)}
   /* Triage, not the row's instruction — brand blue keeps it a visibly

--- a/scripts/generators/markdown/community-markdown-generator.js
+++ b/scripts/generators/markdown/community-markdown-generator.js
@@ -217,9 +217,14 @@ function repoCell(record) {
   return bits.join('<br>');
 }
 
-/** Mirrors renderRow's nextBits: approval note, reviewed note, bot ping, linked code PR, next step. */
+/** Mirrors renderRow's nextBits, in the same order: actions first (add
+ * milestone, then the next step), then the context notes. */
 function nextCell(record) {
   const bits = [];
+  if (record.pendingLabelMissing)
+    bits.push(`**Add ${mdEscapeCell(record.pendingLabelMissing)} label**`);
+  if (record.milestoneMissing) bits.push('**Add milestone**');
+  if (record.nextStep) bits.push(mdEscapeCell(record.nextStep));
   if (record.approval && record.approval.by) {
     const dismissedNote = record.approval.dismissed ? ' — dismissed after update' : '';
     bits.push(`approved by **${mdEscapeCell(record.approval.by)}**${dismissedNote}`);
@@ -238,7 +243,6 @@ function nextCell(record) {
       : mdEscapeCell(ref);
     bits.push(`🔗 code PR ${refMd}`);
   }
-  if (record.nextStep) bits.push(mdEscapeCell(record.nextStep));
   return bits.length ? bits.map((bit) => `• ${bit}`).join('<br>') : '—';
 }
 

--- a/scripts/services/workbench-merge.js
+++ b/scripts/services/workbench-merge.js
@@ -13,7 +13,11 @@
  *                 it does not end one
  *   - nextStep    plain-language remaining action (required for action/ready)
  *   - linkedCodePr / upstream signals from the tracker cache
- *   - idleDays    drives remind (7d) → follow up (10d) → escalate (14d)
+ *   - idleDays    how long a row has sat untouched; shown on the pill and
+ *                 drives the 30d stalled fold. "Escalate" is reserved for the
+ *                 upstream tracker's own timeline (code PR merged, author
+ *                 reminded, still silent 14d) — this repo doesn't track who
+ *                 reminded whom yet, so that word never appears here.
  *
  * Every rule here is repo-agnostic. The tracker feed only ever covered the
  * Mautic docs repos, so reading its `raw*` arrays directly used to be what
@@ -44,8 +48,6 @@ const TRACKER_CACHE_FILE = path.join('data', 'tracker-cache.json');
 
 const STALLED_AFTER_DAYS = 30;
 const REMIND_AFTER_DAYS = 7;
-const FOLLOW_UP_AFTER_DAYS = 10;
-const ESCALATE_AFTER_DAYS = 14;
 
 /**
  * Per-project docs housekeeping — see contents/docs-workflow-repos.js. Loaded
@@ -668,38 +670,17 @@ function deriveBotPing(activity, local, me) {
 // Lane + next-step derivation (the tracker's model, generalized)
 // ---------------------------------------------------------------------------
 
-function idleHint(idleDays) {
-  if (idleDays >= ESCALATE_AFTER_DAYS) return `idle ${Math.floor(idleDays)}d, escalate`;
-  if (idleDays >= FOLLOW_UP_AFTER_DAYS) return `idle ${Math.floor(idleDays)}d, follow up`;
-  if (idleDays >= REMIND_AFTER_DAYS) return `idle ${Math.floor(idleDays)}d, send a reminder`;
-  return null;
-}
-
-/**
- * Appends the escalation to a step instead of replacing it: "reason · idle 14d,
- * escalate". The old `idleHint(idleDays) || reason` form discarded the reason
- * on exactly the rows that most needed it — the oldest ones, where the board
- * went from telling you what to do to telling you only how late you were.
- *
- * Steps that already state their own age ("You reviewed 12d ago…") skip this:
- * the escalation is what age ADDS to a step, and a step carrying "12d ago ·
- * idle 12d" says the same thing twice.
- */
-function withIdle(step, idleDays) {
-  const hint = idleHint(idleDays);
-  if (!hint) return step || null;
-  return step ? `${step} · ${hint}` : hint;
-}
-
 /**
  * Assigns lane, ball label, and nextStep for one merged record.
  *
  * Precedence, first match wins:
- *   1 bot lane          2 assigned issue     3 approval states
- *   4 direct ping at me 5 changes requested  6 conflicts
- *   7 turn-based fallback                    8 stalled fold
+ *   1 bot lane          2 assigned issue        3 approval states
+ *   3a linked code PR   4 direct ping at me      5 changes requested
+ *   6 conflicts         7 turn-based fallback    8 stalled fold
  *
- * 1–3 and 8 live here; 4–7 live in deriveTurn. Rules 4–6 only ever choose the
+ * 1–3, 3a, and 8 live here; 4–7 live in deriveTurn. Rule 3a only fires for a
+ * merged or closed-unmerged linked code PR — an open or unknown (null) state
+ * falls straight through to the turn-based reading unchanged. Rules 4–6 only ever choose the
  * WORDING — the lane and ball a row lands in are decided by the turn logic and
  * by the staleness fold exactly as before.
  *
@@ -717,8 +698,8 @@ function withIdle(step, idleDays) {
  * were carved out of that rule first (an issue you haven't started has nobody
  * touching it, so it always ages past the threshold); this generalizes the
  * carve-out to every path where the ball is yours. Age still shows: the row
- * carries idleDays, the reviewing steps escalate through idleHint, and the
- * action lane sorts oldest-first.
+ * carries idleDays (rendered on the pill), and the action lane sorts
+ * oldest-first.
  */
 function deriveLane(record, me, botPingSignal = null, signals = emptySignals()) {
   const result = laneFor(record, me, botPingSignal, signals);
@@ -791,6 +772,21 @@ function laneFor(record, me, botPingSignal, signals) {
     return { lane: 'ready', ball: 'Approved', nextStep };
   }
 
+  // Rule 3a — the linked code PR's fate is decisive: merged means the docs are
+  // now actionable, closed-unmerged means this docs PR has nothing left to
+  // track. An 'open' or unknown (null) state carries no verdict, so it falls
+  // straight through to the turn-based reading below, unchanged.
+  if (record.linkedCodePrState === 'merged') {
+    return { lane: 'action', ball: 'Take Action', nextStep: 'Code PR merged — review the docs now' };
+  }
+  if (record.linkedCodePrState === 'closed') {
+    return {
+      lane: 'action',
+      ball: 'Take Action',
+      nextStep: 'Code PR closed unmerged — close this docs PR',
+    };
+  }
+
   // Whose turn is it? Resolved BEFORE staleness (see the note above), so a row
   // where the ball is yours keeps its action lane no matter how old it is.
   const turn = deriveTurn(record, me, botPingSignal, signals);
@@ -834,7 +830,7 @@ function directPingStep(record, signals) {
     record.relationship === 'reviewing' &&
     (record.status === 'Request review' || Boolean(record.reviewRequest))
   ) {
-    return withIdle('Review requested — review it', record.idleDays);
+    return 'Review requested — review it';
   }
   return null;
 }
@@ -850,7 +846,7 @@ function changesRequestedStep(record, signals) {
   if (record.relationship !== 'authored' && record.relationship !== 'co-authoring') return null;
   const cr = signals.changesRequested;
   if (!cr || !cr.by) return null;
-  return withIdle(`Changes requested by ${cr.by} — address the feedback`, record.idleDays);
+  return `Changes requested by ${cr.by} — address the feedback`;
 }
 
 /**
@@ -861,10 +857,9 @@ function changesRequestedStep(record, signals) {
 function conflictStep(record, signals) {
   if (record.relationship !== 'authored' && record.relationship !== 'co-authoring') return null;
   if (!signals.conflict) return null;
-  const step = signals.conflict.base
+  return signals.conflict.base
     ? `Conflicts with ${signals.conflict.base} — rebase needed`
     : 'Conflicts — rebase needed';
-  return withIdle(step, record.idleDays);
 }
 
 /**
@@ -973,19 +968,19 @@ function turnReading(record, me, signals) {
       return {
         lane: 'action',
         ball: 'Take Action',
-        nextStep: withIdle('Author replied — review the latest changes', record.idleDays),
+        nextStep: 'Author replied — review the latest changes',
       };
     }
     // A formal review request aimed at you is a "your turn" ping — treat it
-    // like an @-mention. It lands in the action lane and escalates with age
-    // (remind → follow up → escalate). This generalizes the local
-    // `status === 'Request review'` flag to the cached review-request events,
-    // so any repo's rows get the same signal, not just tracker-covered ones.
+    // like an @-mention. It lands in the action lane; the pill already carries
+    // how long it's been idle. This generalizes the local `status === 'Request
+    // review'` flag to the cached review-request events, so any repo's rows
+    // get the same signal, not just tracker-covered ones.
     if (record.status === 'Request review' || Boolean(record.reviewRequest)) {
       return {
         lane: 'action',
         ball: 'Take Action',
-        nextStep: withIdle('Review requested — review it', record.idleDays),
+        nextStep: 'Review requested — review it',
       };
     }
     // A third party moved last: the outstanding review belongs to someone
@@ -1017,7 +1012,7 @@ function turnReading(record, me, signals) {
       return {
         lane: 'waiting',
         ball: 'Waiting',
-        nextStep: withIdle('No reviewer assigned — request one', record.idleDays),
+        nextStep: 'No reviewer assigned — request one',
       };
     }
     return {
@@ -1147,6 +1142,7 @@ function mergeWorkbench({
       linkedCodePr: linkedCodePr
         ? { ref: linkedCodePr, hasActivity: Boolean(upstream && upstream.codeUpdatedAt) }
         : null,
+      linkedCodePrState: local.linkedCodePrState ?? null,
       upstream: upstream
         ? {
             docsUpdatedAt: upstream.docsUpdatedAt || null,

--- a/scripts/services/workbench-merge.js
+++ b/scripts/services/workbench-merge.js
@@ -15,10 +15,20 @@
  *   - linkedCodePr / upstream signals from the tracker cache
  *   - idleDays    drives remind (7d) → follow up (10d) → escalate (14d)
  *
+ * Every rule here is repo-agnostic. The tracker feed only ever covered the
+ * Mautic docs repos, so reading its `raw*` arrays directly used to be what
+ * decided whether a row got a specific next step at all — every other repo fell
+ * through to `nextStep: null`. The signals are now read from a NORMALIZED
+ * activity view (see normalizeActivity) that the local fetch layer and the
+ * tracker both feed, so an untracked repo derives the same steps from its own
+ * cached reviews/comments/review requests. Upstream stays the preferred source
+ * wherever both sides carry the same array.
+ *
  * Resilience contract: the tracker feed can be down, rate-limited, or
  * schema-drifted — the merge NEVER fails the build. Failures degrade to the
  * last cached copy (data/tracker-cache.json) and finally to local-only
- * records, with `feed.degraded` explaining what happened.
+ * records, with `feed.degraded` explaining what happened. Signal derivation is
+ * likewise fail-soft: a malformed record yields no signals, never a throw.
  */
 const fs = require('fs/promises');
 const path = require('path');
@@ -36,6 +46,50 @@ const STALLED_AFTER_DAYS = 30;
 const REMIND_AFTER_DAYS = 7;
 const FOLLOW_UP_AFTER_DAYS = 10;
 const ESCALATE_AFTER_DAYS = 14;
+
+/**
+ * Per-project docs housekeeping — see contents/docs-workflow-repos.js. Loaded
+ * the same fail-soft way as the bot allowlist: a missing or broken file
+ * switches these rules off rather than failing the build.
+ */
+function loadDocsWorkflow() {
+  try {
+    const config = require('../../contents/docs-workflow-repos');
+    const list = (key) => (config[key] || []).map((r) => String(r).toLowerCase()).filter(Boolean);
+    return {
+      milestoneRepos: list('milestoneRepos'),
+      pendingLabelRepos: list('pendingLabelRepos'),
+      pendingLabel: String(config.pendingLabel || '').trim(),
+    };
+  } catch (e) {
+    return { milestoneRepos: [], pendingLabelRepos: [], pendingLabel: '' };
+  }
+}
+
+const DOCS_WORKFLOW = loadDocsWorkflow();
+
+function matchesRepoList(repo, list) {
+  const lower = String(repo || '').toLowerCase();
+  if (!lower || !list.length) return false;
+  return list.some((entry) => lower.includes(entry));
+}
+
+/**
+ * Whether `repo` is one of the projects that tracks milestones. The repo list
+ * is the ONLY thing that scopes the "Add milestone" chip — deliberately never
+ * inferred from whether a record happens to carry a milestone field, since a
+ * PR without one looks identical in a project that wants milestones and a
+ * project that has never used them.
+ */
+function tracksMilestones(repo) {
+  return matchesRepoList(repo, DOCS_WORKFLOW.milestoneRepos);
+}
+
+/** Whether `repo` marks docs PRs as pending their code PR with a label. */
+function usesPendingLabel(repo) {
+  if (!DOCS_WORKFLOW.pendingLabel) return false;
+  return matchesRepoList(repo, DOCS_WORKFLOW.pendingLabelRepos);
+}
 
 // ---------------------------------------------------------------------------
 // Upstream feed: fetch → validate → cache → degrade
@@ -210,12 +264,244 @@ function daysBetween(from, to) {
   return (to - new Date(from)) / (1000 * 60 * 60 * 24);
 }
 
+function sameLogin(a, b) {
+  const x = String(a || '').toLowerCase();
+  const y = String(b || '').toLowerCase();
+  return Boolean(x) && x === y;
+}
+
+/** Newest entry of a list by its `at` timestamp, or null for an empty list. */
+function newestBy(list) {
+  if (!Array.isArray(list) || list.length === 0) return null;
+  return list.reduce((a, b) => (new Date(a.at || 0) >= new Date(b.at || 0) ? a : b));
+}
+
+// ---------------------------------------------------------------------------
+// Normalized activity — one shape, two sources
+// ---------------------------------------------------------------------------
+
+/**
+ * Flattens the two feeds' activity into one shape every rule below reads:
+ *
+ *   reviews         [{ login, state, at }]
+ *   comments        [{ login, at, mentions: [login] }]
+ *   reviewRequests  [{ of, by, at }]
+ *
+ * The tracker's `raw*` arrays and the local fetch layer's cached
+ * `reviews`/`comments`/`reviewRequests` carry the same facts under different
+ * field names — normalizing them is what lets an untracked repo derive the same
+ * next steps as a tracker-covered one. Upstream wins per-array when it actually
+ * has entries: the tracker sees a repo's full history, while the local cache is
+ * capped and can miss older activity. An EMPTY upstream array is not a source
+ * of truth, so it falls through to the local array rather than blanking it.
+ *
+ * Comment bodies exist only upstream; the local cache stores the extracted
+ * mention logins instead and discards the body, so mentions are read from
+ * whichever side supplied the comment.
+ */
+function normalizeActivity(local, upstream) {
+  const prefer = (up, loc) => (Array.isArray(up) && up.length ? up : Array.isArray(loc) ? loc : []);
+
+  const rawReviews = prefer(upstream?.rawDocsReviews, local?.reviews);
+  const reviews = rawReviews.filter(Boolean).map((r) => ({
+    login: r.user?.login || r.login || null,
+    state: r.state || null,
+    at: r.submitted_at || r.submittedAt || null,
+  }));
+
+  const rawComments = prefer(upstream?.rawDocsComments, local?.comments);
+  const comments = rawComments.filter(Boolean).map((c) => ({
+    login: c.user?.login || c.login || null,
+    at: c.created_at || c.createdAt || null,
+    mentions: Array.isArray(c.mentions) ? c.mentions : extractMentions(c.body),
+  }));
+
+  const rawRequests = prefer(upstream?.rawReviewRequests, local?.reviewRequests);
+  const reviewRequests = rawRequests.filter(Boolean).map((r) => ({
+    of: r.requested_reviewer?.login || r.requestedReviewer || null,
+    by: r.actor?.login || r.actor || null,
+    at: r.created_at || r.createdAt || null,
+  }));
+
+  return { reviews, comments, reviewRequests };
+}
+
+function emptySignals() {
+  return {
+    activity: { reviews: [], comments: [], reviewRequests: [] },
+    myLastReplyDays: null,
+    mention: null,
+    changesRequested: null,
+    pendingReview: null,
+    waitingOn: null,
+    noReviewerAssigned: false,
+    conflict: null,
+    milestoneMissing: false,
+    pendingLabelMissing: null,
+  };
+}
+
+/**
+ * Everything the next-step rules need, derived once per record from the
+ * normalized activity plus the PR-detail fields the local fetch layer caches
+ * (requestedReviewers, mergeableState, baseRef, milestone).
+ *
+ *   myLastReplyDays     days since YOUR newest review or comment
+ *   mention             newest @-mention of you nobody has heard back on
+ *   changesRequested    newest CHANGES_REQUESTED you haven't answered
+ *   pendingReview       an outstanding review request aimed at someone else
+ *   waitingOn           who the ball actually sits with
+ *   noReviewerAssigned  ready, non-draft, nobody asked to look
+ *   conflict            ONLY when the merge state is definitively dirty
+ *   milestoneMissing    milestone-tracking repo, no milestone set
+ *
+ * Wrapped so a drifted or malformed record produces no signals instead of a
+ * throw — the merge must never fail the build.
+ */
+function deriveSignals(local, upstream, me, now) {
+  try {
+    return buildSignals(local, upstream, me, now || new Date());
+  } catch (e) {
+    return emptySignals();
+  }
+}
+
+function buildSignals(local, upstream, me, now) {
+  const activity = normalizeActivity(local, upstream);
+  const signals = { ...emptySignals(), activity };
+  const daysSince = (at) => (at ? Math.max(0, Math.floor(daysBetween(at, now))) : null);
+  const everything = [...activity.reviews, ...activity.comments];
+
+  // Your own newest word on the thread. Anything older than this you have, by
+  // definition, already replied to.
+  const mineAt = everything
+    .filter((x) => sameLogin(x.login, me) && x.at)
+    .map((x) => new Date(x.at).getTime())
+    .filter((t) => !Number.isNaN(t));
+  const myLatest = mineAt.length ? Math.max(...mineAt) : null;
+  const answeredByMe = (at) => Boolean(myLatest && at && myLatest > new Date(at).getTime());
+  signals.myLastReplyDays = myLatest ? daysSince(new Date(myLatest).toISOString()) : null;
+
+  // A DIRECT @-mention of you, still unanswered. Genuine bots are skipped —
+  // a CI bot naming you in a log line isn't a person waiting on a reply —
+  // but ALLOW-LISTED bots (Promptless) are kept: their pings are real work.
+  const mentionsOfMe = activity.comments.filter(
+    (c) =>
+      c.login &&
+      !sameLogin(c.login, me) &&
+      !isBotLogin(c.login) &&
+      c.mentions.some((m) => sameLogin(m, me))
+  );
+  const latestMention = newestBy(mentionsOfMe);
+  if (latestMention && !answeredByMe(latestMention.at)) {
+    signals.mention = { by: latestMention.login, days: daysSince(latestMention.at) };
+  }
+
+  // Changes requested and not yet answered. Someone else's change request only
+  // — your own is the "you reviewed, author hasn't replied" case instead.
+  const latestChanges = newestBy(
+    activity.reviews.filter(
+      (r) => r.state === 'CHANGES_REQUESTED' && r.login && !sameLogin(r.login, me)
+    )
+  );
+  if (latestChanges && !answeredByMe(latestChanges.at)) {
+    signals.changesRequested = { by: latestChanges.login, days: daysSince(latestChanges.at) };
+  }
+
+  // Who else is on the hook for a review. `requestedReviewers` is GitHub's LIVE
+  // pending list (it empties the moment someone reviews), so it's the stronger
+  // signal; the request events supply the date it was asked. A request whose
+  // reviewer has since spoken is fulfilled and drops out.
+  const pendingLogins = (
+    Array.isArray(local?.requestedReviewers) ? local.requestedReviewers : []
+  ).filter((l) => l && !sameLogin(l, me));
+  const spokeAfter = (login, at) =>
+    everything.some(
+      (x) => sameLogin(x.login, login) && x.at && at && new Date(x.at) > new Date(at)
+    );
+  const openRequests = activity.reviewRequests.filter(
+    (r) => r.of && !sameLogin(r.of, me) && !spokeAfter(r.of, r.at)
+  );
+  const stillPending = openRequests.filter((r) => pendingLogins.some((l) => sameLogin(l, r.of)));
+  const chosen = newestBy(stillPending.length ? stillPending : openRequests);
+  if (chosen) {
+    signals.pendingReview = { of: chosen.of, days: daysSince(chosen.at) };
+  } else if (pendingLogins.length) {
+    // Named on the live list but no request event survived the cache cap —
+    // we can still say WHO, just not when. The date clause gets dropped.
+    signals.pendingReview = { of: pendingLogins[0], days: null };
+  }
+
+  // Failing a pending reviewer, the ball sits with whoever last reviewed.
+  const latestOtherReviewer = newestBy(
+    activity.reviews.filter((r) => r.login && !sameLogin(r.login, me) && !isBotActor(r.login))
+  );
+  signals.waitingOn = signals.pendingReview?.of || latestOtherReviewer?.login || null;
+
+  // The PR-detail fields ride along with the widened activity cache, so their
+  // presence marks a record we can reason about. Without them, "nobody is
+  // assigned" and "no milestone" are unknowns, not facts — stay quiet.
+  const hasPrDetail =
+    Boolean(local) &&
+    (local.mergeableState !== undefined ||
+      local.requestedReviewers !== undefined ||
+      local.milestone !== undefined);
+
+  signals.noReviewerAssigned =
+    hasPrDetail &&
+    local.isDraft !== true &&
+    pendingLogins.length === 0 &&
+    activity.reviews.length === 0 &&
+    local.hasFormalReview !== true;
+
+  // ONLY a definitively dirty merge state counts. GitHub reports `unknown`
+  // (and this field reports null) while it is still computing mergeability, so
+  // anything that isn't literally "dirty" stays silent rather than guessing —
+  // and there is nothing to retry, the next build reads a fresh value anyway.
+  if (String(local?.mergeableState || '').toLowerCase() === 'dirty') {
+    signals.conflict = { base: local.baseRef || null };
+  }
+
+  signals.milestoneMissing = hasPrDetail && tracksMilestones(local?.repo) && !local.milestone;
+
+  // A DRAFT docs PR is by definition still pending something, so in projects
+  // that track that with a label it should be carrying one. Draft-gated on
+  // purpose, matching the upstream tracker: once the PR is ready for review
+  // the label is a judgement call about the linked code PR, not a lapse.
+  //
+  // Read live from the PR's own labels every build — never a stored flag — so
+  // adding the label on GitHub clears the chip on the next run with nothing to
+  // reset by hand. Unlike the milestone this needs no hasPrDetail gate: every
+  // PR record already carries its labels, so an empty list is a real answer.
+  //
+  // Carries the LABEL NAME when it's missing (null otherwise) so the chip can
+  // name it — the label is configurable per project, so hardcoding the wording
+  // in the renderers would silently lie for any repo that renames it.
+  const labelMissing =
+    Boolean(local) &&
+    local.isDraft === true &&
+    usesPendingLabel(local.repo) &&
+    !(Array.isArray(local.labels) ? local.labels : []).some(
+      (l) => String(l).toLowerCase() === DOCS_WORKFLOW.pendingLabel.toLowerCase()
+    );
+  signals.pendingLabelMissing = labelMissing ? DOCS_WORKFLOW.pendingLabel : null;
+
+  // A DRAFT docs PR is by definition still pending something, so in projects
+  // that track that with a label it should be carrying one. Draft-gated on
+  // purpose, matching the upstream tracker: once the PR is ready for review
+  // the label is a judgement call about the linked code PR, not a lapse.
+  // Unlike the milestone this reads a field every PR record already has, so
+  // there's no hasPrDetail gate — an empty label list is a real answer.
+
+  return signals;
+}
+
 /**
  * Latest approval visible from either side of the join, plus whether any
- * substantive (non-bot) docs comment landed AFTER that approval — the
- * tracker's "note since approval — take a look" signal.
+ * substantive (non-bot) comment landed AFTER that approval — the "note since
+ * approval — take a look" signal.
  */
-function deriveApproval(local, upstream) {
+function deriveApproval(local, activity) {
   let state = null;
   let by = null;
   let approvedAt = null;
@@ -227,41 +513,34 @@ function deriveApproval(local, upstream) {
     by = local.approvedBy ? String(local.approvedBy).trim() : null;
   }
 
-  // Read the latest APPROVED/DISMISSED review from the tracker. A dismissed
-  // approval no longer shows as APPROVED in GitHub's reviews list — it flips
-  // to DISMISSED while still carrying the original approver's login — so
-  // filtering to APPROVED alone silently drops it. We keep it and mark it
+  // Read the latest APPROVED/DISMISSED review from the normalized activity. A
+  // dismissed approval no longer shows as APPROVED in GitHub's reviews list —
+  // it flips to DISMISSED while still carrying the original approver's login —
+  // so filtering to APPROVED alone silently drops it. We keep it and mark it
   // `dismissed` so the lane can route it to "re-request" instead.
-  if (upstream && Array.isArray(upstream.rawDocsReviews)) {
-    const reviews = upstream.rawDocsReviews;
-    const decisive = reviews.filter((r) => r && (r.state === 'APPROVED' || r.state === 'DISMISSED'));
-    if (decisive.length > 0) {
-      const latest = decisive.reduce((a, b) =>
-        new Date(a.submitted_at || 0) >= new Date(b.submitted_at || 0) ? a : b
-      );
-      // A change request landing AFTER the last approval/dismissal supersedes
-      // it — the PR is no longer approved (the reviewed-again case, e.g. an
-      // approval dismissed on push and then changes requested). Drop the
-      // approval and let the turn-based logic take over.
-      const supersededByChanges = reviews.some(
-        (r) =>
-          r &&
-          r.state === 'CHANGES_REQUESTED' &&
-          new Date(r.submitted_at || 0) > new Date(latest.submitted_at || 0)
-      );
-      if (supersededByChanges) {
-        state = null;
-        by = null;
-        approvedAt = null;
-      } else {
-        state = 'APPROVED';
-        approvedAt = latest.submitted_at || null;
-        dismissed = latest.state === 'DISMISSED';
-        dismissedAt = dismissed ? latest.submitted_at || null : null;
-        // A dismissed review names the approver whose approval was dropped;
-        // prefer it so "re-request from <login>" points at the right person.
-        by = dismissed ? latest.user?.login || by : by || latest.user?.login || null;
-      }
+  const reviews = activity && Array.isArray(activity.reviews) ? activity.reviews : [];
+  const decisive = reviews.filter((r) => r.state === 'APPROVED' || r.state === 'DISMISSED');
+  if (decisive.length > 0) {
+    const latest = newestBy(decisive);
+    // A change request landing AFTER the last approval/dismissal supersedes
+    // it — the PR is no longer approved (the reviewed-again case, e.g. an
+    // approval dismissed on push and then changes requested). Drop the
+    // approval and let the turn-based logic take over.
+    const supersededByChanges = reviews.some(
+      (r) => r.state === 'CHANGES_REQUESTED' && new Date(r.at || 0) > new Date(latest.at || 0)
+    );
+    if (supersededByChanges) {
+      state = null;
+      by = null;
+      approvedAt = null;
+    } else {
+      state = 'APPROVED';
+      approvedAt = latest.at || null;
+      dismissed = latest.state === 'DISMISSED';
+      dismissedAt = dismissed ? latest.at || null : null;
+      // A dismissed review names the approver whose approval was dropped;
+      // prefer it so "re-request from <login>" points at the right person.
+      by = dismissed ? latest.login || by : by || latest.login || null;
     }
   }
 
@@ -270,12 +549,10 @@ function deriveApproval(local, upstream) {
   // "Note since approval" only applies to a live approval — a dismissed one
   // already routes to "re-request", which supersedes any later note.
   let noteSince = false;
-  if (!dismissed && approvedAt && upstream && Array.isArray(upstream.rawDocsComments)) {
-    noteSince = upstream.rawDocsComments.some(
-      (c) =>
-        c &&
-        new Date(c.created_at || 0) > new Date(approvedAt) &&
-        !isBotLogin(c.user?.login)
+  if (!dismissed && approvedAt) {
+    const comments = activity && Array.isArray(activity.comments) ? activity.comments : [];
+    noteSince = comments.some(
+      (c) => new Date(c.at || 0) > new Date(approvedAt) && !isBotLogin(c.login)
     );
   }
 
@@ -284,52 +561,34 @@ function deriveApproval(local, upstream) {
 
 /**
  * A LIVE formal review request aimed at YOU (the workbench owner) — the
- * tracker's rawReviewRequests, filtered to `requested_reviewer === me`. Team
- * requests and requests aimed at other reviewers are ignored: this is the
- * "you've been pinged to review" signal, the review-side equivalent of an
- * @-mention. Returns the most recent such LIVE request, or null.
+ * normalized review requests, filtered to `of === me`. Team requests and
+ * requests aimed at other reviewers are ignored: this is the "you've been
+ * pinged to review" signal, the review-side equivalent of an @-mention.
+ * Returns the most recent such LIVE request, or null.
  *
- * Liveness is the crux. rawReviewRequests are historical GitHub timeline events
+ * Liveness is the crux. Review requests are historical GitHub timeline events
  * that PERSIST after the request is fulfilled: GitHub clears the live
- * `requested_reviewers` the instant you review, but the upstream tracker caches
- * the `review_requested` issue event for good — which is exactly why we can see
- * it at all. So a request counts as live ONLY when you have not already answered
- * it: no review (rawDocsReviews) or comment (rawDocsComments) of yours is dated
+ * `requested_reviewers` the instant you review, but both the tracker cache and
+ * the local activity cache keep the `review_requested` event for good — which
+ * is exactly why we can see it at all. So a request counts as live ONLY when
+ * you have not already answered it: no review or comment of yours is dated
  * after the request was made. A later comment by someone ELSE does not revive a
  * request you already handled — only your own activity fulfills it.
  */
-function deriveReviewRequest(upstream, me) {
-  if (!upstream || !Array.isArray(upstream.rawReviewRequests)) return null;
-  const mine = upstream.rawReviewRequests.filter(
-    (r) =>
-      r && r.requested_reviewer && String(r.requested_reviewer.login || '').toLowerCase() === me
-  );
+function deriveReviewRequest(activity, me) {
+  if (!activity || !Array.isArray(activity.reviewRequests)) return null;
+  const mine = activity.reviewRequests.filter((r) => sameLogin(r.of, me));
   if (mine.length === 0) return null;
-  const latest = mine.reduce((a, b) =>
-    new Date(a.created_at || 0) >= new Date(b.created_at || 0) ? a : b
-  );
+  const latest = newestBy(mine);
 
   // Fulfilled? A review or comment of MINE dated after the request was made.
-  const requestedAt = new Date(latest.created_at || 0);
-  const answeredByMe = (arr, dateField) =>
-    (Array.isArray(arr) ? arr : []).some(
-      (x) =>
-        x &&
-        String(x.user?.login || '').toLowerCase() === me &&
-        new Date(x[dateField] || 0) > requestedAt
-    );
-  if (
-    answeredByMe(upstream.rawDocsReviews, 'submitted_at') ||
-    answeredByMe(upstream.rawDocsComments, 'created_at')
-  ) {
-    return null;
-  }
+  const requestedAt = new Date(latest.at || 0);
+  const answeredByMe = [...activity.reviews, ...activity.comments].some(
+    (x) => sameLogin(x.login, me) && new Date(x.at || 0) > requestedAt
+  );
+  if (answeredByMe) return null;
 
-  return {
-    of: latest.requested_reviewer.login || null,
-    by: latest.actor?.login || null,
-    at: latest.created_at || null,
-  };
+  return { of: latest.of || null, by: latest.by || null, at: latest.at || null };
 }
 
 /**
@@ -339,20 +598,16 @@ function deriveReviewRequest(upstream, me) {
  * lane. Suppressed when an approval (live or dismissed) is already surfaced,
  * and it skips your own reviews and bot reviews (incl. allow-listed bots).
  */
-function deriveReviewedNote(upstream, approval, me) {
+function deriveReviewedNote(activity, approval, me) {
   if (approval) return null;
-  if (!upstream || !Array.isArray(upstream.rawDocsReviews)) return null;
-  const reviews = upstream.rawDocsReviews.filter((r) => {
-    if (!r) return false;
-    const login = String(r.user?.login || '').toLowerCase();
-    if (!login || login === me || isBotActor(login)) return false;
+  if (!activity || !Array.isArray(activity.reviews)) return null;
+  const reviews = activity.reviews.filter((r) => {
+    if (!r.login || sameLogin(r.login, me) || isBotActor(r.login)) return false;
     return r.state === 'COMMENTED' || r.state === 'CHANGES_REQUESTED';
   });
   if (reviews.length === 0) return null;
-  const latest = reviews.reduce((a, b) =>
-    new Date(a.submitted_at || 0) >= new Date(b.submitted_at || 0) ? a : b
-  );
-  return latest.user?.login ? { by: latest.user.login } : null;
+  const latest = newestBy(reviews);
+  return latest.login ? { by: latest.login } : null;
 }
 
 /** Logins @-mentioned in a comment body, in their original case. Loose match
@@ -381,7 +636,7 @@ function extractMentions(body) {
  * A ping to you is your turn (the caller routes it to the action lane); a ping
  * aimed only at others is their turn, surfaced to the renderer as botPing.
  */
-function deriveBotPing(upstream, local, me) {
+function deriveBotPing(activity, local, me) {
   const author = String(local?.author || '').toLowerCase();
   const lastActor = String(
     local?.lastActor ||
@@ -390,34 +645,20 @@ function deriveBotPing(upstream, local, me) {
   ).toLowerCase();
   if (!author || !isAllowedBotLogin(author) || lastActor !== author) return null;
 
-  // The bot's most recent docs comment — where a "Thanks @you…" ping lives.
-  const botComments = (Array.isArray(upstream?.rawDocsComments) ? upstream.rawDocsComments : []).filter(
-    (c) => c && String(c.user?.login || '').toLowerCase() === author
-  );
-  const latestComment = botComments.length
-    ? botComments.reduce((a, b) =>
-        new Date(a.created_at || 0) >= new Date(b.created_at || 0) ? a : b
-      )
-    : null;
-  const mentions = latestComment ? extractMentions(latestComment.body) : [];
-  const mentionsMe = mentions.some((m) => m.toLowerCase() === me);
+  // The bot's most recent comment — where a "Thanks @you…" ping lives.
+  const comments = Array.isArray(activity?.comments) ? activity.comments : [];
+  const latestComment = newestBy(comments.filter((c) => sameLogin(c.login, author)));
+  const mentions = latestComment ? latestComment.mentions : [];
+  const mentionsMe = mentions.some((m) => sameLogin(m, me));
 
   // Who else did it ping? Prefer an @-mention of another human in the latest
   // comment; fall back to a review request aimed at someone other than you.
-  let of = mentions.find((m) => m.toLowerCase() !== me && m.toLowerCase() !== author) || null;
-  if (!of && Array.isArray(upstream?.rawReviewRequests)) {
-    const others = upstream.rawReviewRequests.filter(
-      (r) =>
-        r &&
-        r.requested_reviewer &&
-        String(r.requested_reviewer.login || '').toLowerCase() !== me
-    );
-    if (others.length) {
-      const latestReq = others.reduce((a, b) =>
-        new Date(a.created_at || 0) >= new Date(b.created_at || 0) ? a : b
-      );
-      of = latestReq.requested_reviewer.login || null;
-    }
+  let of = mentions.find((m) => !sameLogin(m, me) && !sameLogin(m, author)) || null;
+  if (!of) {
+    const requests = Array.isArray(activity?.reviewRequests) ? activity.reviewRequests : [];
+    const others = requests.filter((r) => r.of && !sameLogin(r.of, me));
+    const latestReq = newestBy(others);
+    if (latestReq) of = latestReq.of || null;
   }
 
   return { mentionsMe, of };
@@ -428,16 +669,43 @@ function deriveBotPing(upstream, local, me) {
 // ---------------------------------------------------------------------------
 
 function idleHint(idleDays) {
-  if (idleDays >= ESCALATE_AFTER_DAYS) return `idle ${Math.floor(idleDays)}d — escalate`;
-  if (idleDays >= FOLLOW_UP_AFTER_DAYS) return `idle ${Math.floor(idleDays)}d — follow up`;
-  if (idleDays >= REMIND_AFTER_DAYS) return `idle ${Math.floor(idleDays)}d — send a reminder`;
+  if (idleDays >= ESCALATE_AFTER_DAYS) return `idle ${Math.floor(idleDays)}d, escalate`;
+  if (idleDays >= FOLLOW_UP_AFTER_DAYS) return `idle ${Math.floor(idleDays)}d, follow up`;
+  if (idleDays >= REMIND_AFTER_DAYS) return `idle ${Math.floor(idleDays)}d, send a reminder`;
   return null;
 }
 
 /**
+ * Appends the escalation to a step instead of replacing it: "reason · idle 14d,
+ * escalate". The old `idleHint(idleDays) || reason` form discarded the reason
+ * on exactly the rows that most needed it — the oldest ones, where the board
+ * went from telling you what to do to telling you only how late you were.
+ *
+ * Steps that already state their own age ("You reviewed 12d ago…") skip this:
+ * the escalation is what age ADDS to a step, and a step carrying "12d ago ·
+ * idle 12d" says the same thing twice.
+ */
+function withIdle(step, idleDays) {
+  const hint = idleHint(idleDays);
+  if (!hint) return step || null;
+  return step ? `${step} · ${hint}` : hint;
+}
+
+/**
  * Assigns lane, ball label, and nextStep for one merged record.
- * Precedence: bot → assigned issue → approved (ready/action) → WHOSE TURN →
- * stalled.
+ *
+ * Precedence, first match wins:
+ *   1 bot lane          2 assigned issue     3 approval states
+ *   4 direct ping at me 5 changes requested  6 conflicts
+ *   7 turn-based fallback                    8 stalled fold
+ *
+ * 1–3 and 8 live here; 4–7 live in deriveTurn. Rules 4–6 only ever choose the
+ * WORDING — the lane and ball a row lands in are decided by the turn logic and
+ * by the staleness fold exactly as before.
+ *
+ * The missing-milestone reminder is deliberately NOT in that ladder: it appends
+ * (see withMilestone), so it can never win a place in the order and can never
+ * be crowded out of one either.
  *
  * Staleness runs LAST, and only over rows the turn logic left with someone
  * else. Age is not evidence that a row is dead — it's evidence of how overdue
@@ -452,7 +720,22 @@ function idleHint(idleDays) {
  * carries idleDays, the reviewing steps escalate through idleHint, and the
  * action lane sorts oldest-first.
  */
-function deriveLane(record, me, botPingSignal = null) {
+function deriveLane(record, me, botPingSignal = null, signals = emptySignals()) {
+  const result = laneFor(record, me, botPingSignal, signals);
+  // Surfaced as their own fields, never spliced into nextStep, so renderers
+  // can draw them as separate chips — the way the upstream docs-PR tracker
+  // renders "Add milestone" and "Add <label> label" as chips alongside (and
+  // ahead of) the review chip rather than folding them into one sentence.
+  // The bot lane is folded away precisely so it carries no instructions.
+  const quiet = result.lane === 'bot';
+  return {
+    ...result,
+    milestoneMissing: signals.milestoneMissing && !quiet,
+    pendingLabelMissing: quiet ? null : signals.pendingLabelMissing || null,
+  };
+}
+
+function laneFor(record, me, botPingSignal, signals) {
   const { relationship, approval, idleDays, linkedCodePr, upstream } = record;
 
   if (record.isBot) {
@@ -510,7 +793,7 @@ function deriveLane(record, me, botPingSignal = null) {
 
   // Whose turn is it? Resolved BEFORE staleness (see the note above), so a row
   // where the ball is yours keeps its action lane no matter how old it is.
-  const turn = deriveTurn(record, me, botPingSignal);
+  const turn = deriveTurn(record, me, botPingSignal, signals);
   if (turn.lane === 'action') return turn;
 
   // Waiting on someone else, and untouched for a month — fold it away. The
@@ -531,32 +814,114 @@ function deriveLane(record, me, botPingSignal = null) {
 }
 
 /**
+ * Rule 4 — a DIRECT ping at you, which outranks every turn-based reading of the
+ * row. An @-mention nobody has heard back on is the sharpest signal the board
+ * has, and a formal review request aimed at you is its review-side twin.
+ * Returns null when nothing is pointed at you.
+ *
+ * The review-request half stays scoped to rows you're reviewing: "review it"
+ * is only an instruction when reviewing is the job. The mention half applies
+ * everywhere — being named is being asked, whoever's PR it is.
+ */
+function directPingStep(record, signals) {
+  if (signals.mention && signals.mention.by) {
+    const { by, days } = signals.mention;
+    return days == null
+      ? `${by} mentioned you — reply`
+      : `${by} mentioned you ${days}d ago — reply`;
+  }
+  if (
+    record.relationship === 'reviewing' &&
+    (record.status === 'Request review' || Boolean(record.reviewRequest))
+  ) {
+    return withIdle('Review requested — review it', record.idleDays);
+  }
+  return null;
+}
+
+/**
+ * Rule 5 — changes requested and still unanswered. Scoped to work you're on the
+ * hook for: on a PR you're merely reviewing, someone else's change request is
+ * the AUTHOR's to address, and telling you to "address the feedback" would hand
+ * you a job that isn't yours. Your own change request on a row you review is
+ * covered by the "you reviewed, author hasn't replied" step instead.
+ */
+function changesRequestedStep(record, signals) {
+  if (record.relationship !== 'authored' && record.relationship !== 'co-authoring') return null;
+  const cr = signals.changesRequested;
+  if (!cr || !cr.by) return null;
+  return withIdle(`Changes requested by ${cr.by} — address the feedback`, record.idleDays);
+}
+
+/**
+ * Rule 6 — a definitively conflicted branch. Same scoping as rule 5: rebasing
+ * is the author's move, not the reviewer's. The base branch name is a clause
+ * that gets dropped rather than printed empty when the fetch couldn't read it.
+ */
+function conflictStep(record, signals) {
+  if (record.relationship !== 'authored' && record.relationship !== 'co-authoring') return null;
+  if (!signals.conflict) return null;
+  const step = signals.conflict.base
+    ? `Conflicts with ${signals.conflict.base} — rebase needed`
+    : 'Conflicts — rebase needed';
+  return withIdle(step, record.idleDays);
+}
+
+/**
  * The turn-based half of deriveLane: given a row that isn't a bot, an assigned
  * issue, or approved, decides whether the ball is YOURS (action) or someone
  * else's (waiting), and what the remaining step is. Split out so deriveLane can
  * run it ahead of the staleness rule — see the precedence note there.
+ *
+ * Lane and ball come from the turn reading alone. The wording is then chosen by
+ * precedence — direct ping (4), changes requested (5), conflicts (6), the
+ * turn's own step (7), and finally milestone housekeeping — so a sharper reason
+ * can replace a vaguer one WITHOUT ever moving a row between lanes.
  */
-function deriveTurn(record, me, botPingSignal = null) {
-  const { relationship, linkedCodePr } = record;
-  const lastActor = String(record.lastActor || '').toLowerCase();
-  const prAuthor = String(record.author || '').toLowerCase();
-  const isMe = lastActor === me;
-  const isAuthor = lastActor && lastActor === prAuthor;
-  const actorIsBot = !isAllowedBotLogin(lastActor) && (record.isLastActorBot || isBotLogin(lastActor));
-  const reminder = idleHint(record.idleDays);
-  const reviewRequestedOfMe = Boolean(record.reviewRequest);
+function deriveTurn(record, me, botPingSignal = null, signals = emptySignals()) {
+  return promoteForHousekeeping(turnFor(record, me, botPingSignal, signals), signals);
+}
 
+/**
+ * Missing housekeeping — a milestone, or the pending-PR label on a draft — is
+ * YOUR move, so the row cannot sit in a lane that means the opposite. "Waiting
+ * on others" reads *your part is done — awaiting review*, and "Stalled" reads
+ * *needs a decision: nudge or close*; both are false while something is still
+ * owed, and Stalled additionally folds the row shut so the chip goes unread.
+ *
+ * Promoting here rather than in deriveLane is what makes the staleness fold
+ * skip these rows for free: that fold only ever runs over rows the turn logic
+ * left with someone ELSE, so a row promoted to action keeps its lane however
+ * old it is — the same "turn beats age" rule assigned issues and review pings
+ * already rely on.
+ *
+ * The approved lane is deliberately untouched: it already reads *bring it
+ * home — still needs a final review or a maintainer nudge before it ships*, so
+ * one more thing to do before shipping is exactly what that lane is for, and
+ * the Approved pill carries information Take Action would throw away.
+ *
+ * Drafts are NOT exempt. The upstream docs-PR tracker triages them the other
+ * way round — its `needs-label-and-milestone` category fires precisely ON
+ * drafts, and carries "act" severity rather than "triage" — because a draft is
+ * exactly when the milestone is cheapest to set, before anyone is waiting on
+ * the merge.
+ */
+function promoteForHousekeeping(turn, signals) {
+  if (!signals.milestoneMissing && !signals.pendingLabelMissing) return turn;
+  if (turn.lane !== 'waiting') return turn;
+  return { ...turn, lane: 'action', ball: 'Take Action' };
+}
+
+function turnFor(record, me, botPingSignal, signals) {
   // An allow-listed bot (Promptless) authored this AND pushed last — its
   // "reply" is automated, so route by who it pinged instead of the human
   // "author replied" step (which we must never emit for a bot). A ping aimed
   // ONLY at someone else is their turn (waiting), recorded as botPing so the
-  // board can show "Promptless pinged <who>". Otherwise it's my turn — it
-  // @-mentioned me, or requested my review, or there's simply no ping pointing
-  // elsewhere and the review is still mine to do — routed to the action lane
-  // with no next-step chip, since the lane already says it's my move.
+  // board can show "Promptless pinged <who>" — and nothing below applies,
+  // because none of it is addressed to you.
   if (botPingSignal) {
     const pingsOnlyOthers =
-      !botPingSignal.mentionsMe && !reviewRequestedOfMe && Boolean(botPingSignal.of);
+      !botPingSignal.mentionsMe && !Boolean(record.reviewRequest) && Boolean(botPingSignal.of);
     if (pingsOnlyOthers) {
       return {
         lane: 'waiting',
@@ -565,27 +930,68 @@ function deriveTurn(record, me, botPingSignal = null) {
         botPing: { by: record.author, of: botPingSignal.of },
       };
     }
-    return { lane: 'action', ball: 'Take Action', nextStep: null };
+    // Pinged AT you: your turn. The wording comes from the ping itself — who
+    // named you and when, or the review it asked you for — never from the
+    // human "author replied" step, which would credit a push to a person.
+    return { lane: 'action', ball: 'Take Action', nextStep: directPingStep(record, signals) };
   }
 
+  const turn = turnReading(record, me, signals);
+
+  const nextStep =
+    directPingStep(record, signals) ??
+    changesRequestedStep(record, signals) ??
+    conflictStep(record, signals) ??
+    turn.nextStep;
+
+  return { ...turn, nextStep: nextStep ?? null };
+}
+
+/** Rule 7 — whose turn is it, and what does that alone imply? */
+function turnReading(record, me, signals) {
+  const { relationship, linkedCodePr } = record;
+  const lastActor = String(record.lastActor || '').toLowerCase();
+  const prAuthor = String(record.author || '').toLowerCase();
+  const isMe = lastActor === me;
+  const isAuthor = lastActor && lastActor === prAuthor;
+  const actorIsBot = !isAllowedBotLogin(lastActor) && (record.isLastActorBot || isBotLogin(lastActor));
+  // How long since you last spoke. The activity trail is the precise answer;
+  // row age is the fallback when no cached activity carries your name.
+  const sinceMyReply = signals.myLastReplyDays ?? Math.floor(record.idleDays);
+
   if (relationship === 'reviewing') {
-    if (isMe) return { lane: 'waiting', ball: 'Waiting', nextStep: null };
+    // You reviewed and nobody came back. Still someone else's move, but the
+    // row can now say WHY it's sitting there instead of showing a bare pill.
+    if (isMe) {
+      return {
+        lane: 'waiting',
+        ball: 'Waiting',
+        nextStep: `You reviewed ${sinceMyReply}d ago — author hasn't replied`,
+      };
+    }
     if (isAuthor) {
       return {
         lane: 'action',
         ball: 'Take Action',
-        nextStep: reminder || 'Author replied — review the latest changes',
+        nextStep: withIdle('Author replied — review the latest changes', record.idleDays),
       };
     }
     // A formal review request aimed at you is a "your turn" ping — treat it
     // like an @-mention. It lands in the action lane and escalates with age
-    // (remind → follow up → escalate) through `reminder`. This generalizes the
-    // local `status === 'Request review'` flag to the tracker's
-    // rawReviewRequests so tracker-augmented rows get the same signal.
-    if (record.status === 'Request review' || reviewRequestedOfMe) {
-      return { lane: 'action', ball: 'Take Action', nextStep: reminder || 'Review requested — review it' };
+    // (remind → follow up → escalate). This generalizes the local
+    // `status === 'Request review'` flag to the cached review-request events,
+    // so any repo's rows get the same signal, not just tracker-covered ones.
+    if (record.status === 'Request review' || Boolean(record.reviewRequest)) {
+      return {
+        lane: 'action',
+        ball: 'Take Action',
+        nextStep: withIdle('Review requested — review it', record.idleDays),
+      };
     }
-    return { lane: 'waiting', ball: 'Watching', nextStep: null };
+    // A third party moved last: the outstanding review belongs to someone
+    // else. Name them and say how long they've had it — or stay silent, since
+    // "waiting on nobody in particular" is what the pill already says.
+    return { lane: 'waiting', ball: 'Watching', nextStep: waitingOnReviewStep(signals) };
   }
 
   // authored / co-authoring
@@ -604,10 +1010,34 @@ function deriveTurn(record, me, botPingSignal = null) {
     };
   }
   if (!lastActor || isMe) {
-    return { lane: 'waiting', ball: 'Waiting', nextStep: null };
+    // Your ball has been passed on. If it was never passed to anyone — ready,
+    // non-draft, nobody asked to look — that IS the remaining step; otherwise
+    // name who you're waiting on, dropping the clause when nobody resolves.
+    if (signals.noReviewerAssigned) {
+      return {
+        lane: 'waiting',
+        ball: 'Waiting',
+        nextStep: withIdle('No reviewer assigned — request one', record.idleDays),
+      };
+    }
+    return {
+      lane: 'waiting',
+      ball: 'Waiting',
+      nextStep: signals.waitingOn
+        ? `You replied ${sinceMyReply}d ago — waiting on ${signals.waitingOn}`
+        : `You replied ${sinceMyReply}d ago`,
+    };
   }
   if (actorIsBot) {
-    return { lane: 'waiting', ball: 'Watching', nextStep: null };
+    // An automated push on your own PR. Nothing to reply to, but the diff
+    // moved under you, so the honest step is to look at it again.
+    return {
+      lane: 'waiting',
+      ball: 'Watching',
+      nextStep: record.lastActor
+        ? `${record.lastActor} pushed ${Math.floor(record.idleDays)}d ago — re-check the changes`
+        : null,
+    };
   }
   return {
     lane: 'action',
@@ -616,6 +1046,17 @@ function deriveTurn(record, me, botPingSignal = null) {
       ? 'Address the review feedback'
       : 'Reply to the discussion, then request review',
   };
+}
+
+/** "Waiting on <login> to review — requested Nd ago", clauses dropped when a
+ * login or a date can't be resolved. No login means no step: an unattributed
+ * "waiting on someone" says nothing the Watching pill hasn't already said. */
+function waitingOnReviewStep(signals) {
+  const pending = signals.pendingReview;
+  if (!pending || !pending.of) return null;
+  return pending.days == null
+    ? `Waiting on ${pending.of} to review`
+    : `Waiting on ${pending.of} to review — requested ${pending.days}d ago`;
 }
 
 // ---------------------------------------------------------------------------
@@ -673,10 +1114,11 @@ function mergeWorkbench({
     const effectiveDate = local.lastSubstantiveDate || local.updatedAt || local.createdAt;
     const idleDays = effectiveDate ? Math.max(0, daysBetween(effectiveDate, nowDate)) : 0;
     const linkedCodePr = extractLinkedCodePr(local.body, local.repo);
-    const approval = deriveApproval(local, upstream);
-    const reviewRequest = deriveReviewRequest(upstream, me);
-    const reviewedNote = deriveReviewedNote(upstream, approval, me);
-    const botPingSignal = deriveBotPing(upstream, local, me);
+    const signals = deriveSignals(local, upstream, me, nowDate);
+    const approval = deriveApproval(local, signals.activity);
+    const reviewRequest = deriveReviewRequest(signals.activity, me);
+    const reviewedNote = deriveReviewedNote(signals.activity, approval, me);
+    const botPingSignal = deriveBotPing(signals.activity, local, me);
 
     const record = {
       key,
@@ -699,6 +1141,9 @@ function mergeWorkbench({
       // Set by deriveLane only when an allow-listed bot pinged someone other
       // than you; null otherwise. Always present so renderers can rely on it.
       botPing: null,
+      // Set by deriveLane. Always present so renderers can rely on them.
+      milestoneMissing: false,
+      pendingLabelMissing: null,
       linkedCodePr: linkedCodePr
         ? { ref: linkedCodePr, hasActivity: Boolean(upstream && upstream.codeUpdatedAt) }
         : null,
@@ -716,7 +1161,7 @@ function mergeWorkbench({
         local.relationship === 'assigned issue' && key ? issuePrLinks.get(key) || null : null,
     };
 
-    Object.assign(record, deriveLane(record, me, botPingSignal));
+    Object.assign(record, deriveLane(record, me, botPingSignal, signals));
     return record;
   });
 
@@ -729,9 +1174,10 @@ function mergeWorkbench({
     if (matchedKeys.has(key)) continue;
     const [repo, number] = key.split('#');
     const titleInfo = titles[key] || null;
-    const approval = deriveApproval(null, upstream);
-    const reviewRequest = deriveReviewRequest(upstream, me);
-    const reviewedNote = deriveReviewedNote(upstream, approval, me);
+    const signals = deriveSignals(null, upstream, me, nowDate);
+    const approval = deriveApproval(null, signals.activity);
+    const reviewRequest = deriveReviewRequest(signals.activity, me);
+    const reviewedNote = deriveReviewedNote(signals.activity, approval, me);
     const effectiveDate = upstream.docsUpdatedAt || null;
     const idleDays = effectiveDate ? Math.max(0, daysBetween(effectiveDate, nowDate)) : 0;
 
@@ -760,6 +1206,8 @@ function mergeWorkbench({
       // Tracker-only rows have no local author/last-actor, so no bot-ping can be
       // derived — kept present and null for a uniform record contract.
       botPing: null,
+      milestoneMissing: false,
+      pendingLabelMissing: null,
       linkedCodePr: titleInfo?.linkedCodePr
         ? { ref: titleInfo.linkedCodePr, hasActivity: Boolean(upstream.codeUpdatedAt) }
         : upstream.codeUpdatedAt
@@ -776,7 +1224,7 @@ function mergeWorkbench({
       linkedPr: null,
     };
 
-    Object.assign(record, deriveLane(record, me));
+    Object.assign(record, deriveLane(record, me, null, signals));
     records.push(record);
   }
 
@@ -956,6 +1404,10 @@ module.exports = {
   extractLinkedCodePr,
   extractIssueRefs,
   buildIssuePrLinks,
+  normalizeActivity,
+  deriveSignals,
+  tracksMilestones,
+  usesPendingLabel,
   deriveApproval,
   deriveReviewRequest,
   deriveReviewedNote,

--- a/scripts/services/workbench-merge.test.js
+++ b/scripts/services/workbench-merge.test.js
@@ -829,16 +829,18 @@ run(
   }
 );
 
-// SR2. Age is urgency text INSIDE a row, never demotion to a folded lane. A
-// reviewing row the author last touched 12d ago stays in the action lane and
-// carries the escalation in its nextStep.
+// SR2. Age is urgency shown via idleDays (the pill), never demotion to a
+// folded lane. A reviewing row the author last touched 12d ago stays in the
+// action lane; nextStep states the reason plainly, without an escalation
+// word the row hasn't earned (see the LCP rule 3a fixtures for the one case
+// "escalate" is reserved for).
 run(
-  'SR2 · author replied 12d ago → still action, age shown as follow-up text',
+  'SR2 · author replied 12d ago → still action, age shown via idleDays',
   { tasks: [local({ number: 4002, updatedAt: daysAgo(12), lastSubstantiveDate: daysAgo(12), lastActor: 'writer3', author: 'writer3' })] },
   ({ records }) => {
     assert.equal(records[0].lane, 'action');
-    assert.ok(/12d/.test(records[0].nextStep), records[0].nextStep);
-    assert.ok(/follow up|escalate|reminder/i.test(records[0].nextStep), records[0].nextStep);
+    assert.equal(records[0].nextStep, 'Author replied — review the latest changes');
+    assert.ok(records[0].idleDays >= 12, `idleDays was: ${records[0].idleDays}`);
   }
 );
 
@@ -923,9 +925,11 @@ run(
   ({ records }) => {
     assert.equal(records[0].lane, 'action', `lane was ${records[0].lane}`);
     assert.equal(records[0].ball, 'Take Action');
-    // Age is not lost — it escalates inside the row instead of demoting it.
-    assert.ok(/40d/.test(records[0].nextStep), records[0].nextStep);
-    assert.ok(/escalate/i.test(records[0].nextStep), records[0].nextStep);
+    assert.equal(records[0].nextStep, 'Author replied — review the latest changes');
+    // Age is not lost — it's carried on idleDays (rendered on the pill)
+    // instead of demoting the row or being misworded as "escalate" in the
+    // step text, which is reserved for the real code-author-reminder case.
+    assert.ok(records[0].idleDays >= 40, `idleDays was: ${records[0].idleDays}`);
   }
 );
 
@@ -957,7 +961,8 @@ run(
   ({ records }) => {
     assert.equal(records[0].lane, 'action', `lane was ${records[0].lane}`);
     assert.ok(records[0].reviewRequest, 'the review request must survive on the record');
-    assert.ok(/45d/.test(records[0].nextStep), records[0].nextStep);
+    assert.equal(records[0].nextStep, 'Review requested — review it');
+    assert.ok(records[0].idleDays >= 45, `idleDays was: ${records[0].idleDays}`);
   }
 );
 
@@ -1843,10 +1848,11 @@ run(
   }
 );
 
-// M9. The idle escalation still rides inside nextStep, and the milestone stays
-// out of it — two separate channels, so neither can crowd out the other.
+// M9. idleDays and the milestone flag are two separate channels on the
+// record — the missing-milestone flag never gets folded into nextStep text,
+// and nextStep stays the plain reason regardless of age.
 run(
-  'M9 · idle hint stays in the step, milestone stays a field',
+  'M9 · idleDays and milestone stay separate fields, nextStep stays plain',
   {
     tasks: [
       local({
@@ -1862,11 +1868,8 @@ run(
   },
   ({ records }) => {
     assertMilestone(records[0], true);
-    assert.equal(
-      records[0].nextStep,
-      `${AUTHOR_REPLIED} · idle 20d, escalate`,
-      records[0].nextStep
-    );
+    assert.equal(records[0].nextStep, AUTHOR_REPLIED, records[0].nextStep);
+    assert.ok(records[0].idleDays >= 20, `idleDays was: ${records[0].idleDays}`);
   }
 );
 
@@ -2069,18 +2072,18 @@ run(
 );
 
 // ===========================================================================
-// Idle suffix (§ I) — the escalation APPENDS to the reason, never replaces it.
-// Regression: `idleHint(idleDays) || reason` dropped the reason on exactly the
-// oldest rows, so the board stopped saying what to do and said only how late.
+// Idle wording (§ I) — nextStep states the reason plainly at any age. Age
+// itself lives only in idleDays (rendered as the pill's "· Nd" badge), never
+// folded into the step text as a remind/follow-up/escalate word — that ladder
+// belongs to the upstream tracker's own code-author-reminder timeline (see
+// the LCP fixtures), which this repo doesn't model for generic action rows.
+// Regression: this used to append "· idle Nd, escalate" and mislabel any
+// aged action-lane row (e.g. a plain review request) as needing escalation.
 // ===========================================================================
 
-for (const [days, tail] of [
-  [8, 'idle 8d, send a reminder'],
-  [11, 'idle 11d, follow up'],
-  [20, 'idle 20d, escalate'],
-]) {
+for (const days of [3, 8, 11, 20]) {
   run(
-    `I1 · idle ${days}d → "reason · ${tail}"`,
+    `I1 · idle ${days}d → reason stays plain, age lives in idleDays`,
     {
       tasks: [
         local({
@@ -2094,18 +2097,16 @@ for (const [days, tail] of [
       ],
     },
     ({ records }) => {
-      assert.equal(records[0].nextStep, `${AUTHOR_REPLIED} · ${tail}`, records[0].nextStep);
-      assert.ok(
-        records[0].nextStep.startsWith(AUTHOR_REPLIED),
-        'the reason survives the escalation'
-      );
+      assert.equal(records[0].nextStep, AUTHOR_REPLIED, records[0].nextStep);
+      assert.ok(records[0].idleDays >= days, `idleDays was: ${records[0].idleDays}`);
     }
   );
 }
 
-// I2. Under the 7-day threshold there is no suffix at all.
+// I2. Same bare reason at zero days too — nothing special about crossing a
+// threshold, because there's no longer a threshold-driven suffix to cross.
 run(
-  'I2 · below the remind threshold → bare reason, no suffix',
+  'I2 · fresh row → same bare reason',
   {
     tasks: [local({ repo: 'someorg/app', number: 6060, lastActor: 'writerA', author: 'writerA' })],
   },
@@ -2280,6 +2281,105 @@ run(
   ({ records }) => {
     assert.equal(records[0].lane, 'action');
     assert.equal(records[0].nextStep, 'Address the review feedback', records[0].nextStep);
+  }
+);
+
+// ===========================================================================
+// Linked code PR state (rule 3a)
+// ===========================================================================
+
+// LCP1. Linked code PR merged → action lane, "review the docs now".
+run(
+  'LCP1 · linked code PR merged → action lane',
+  {
+    prs: [
+      local({
+        repo: 'mautic/user-documentation',
+        number: 7001,
+        author: ME,
+        lastActor: ME,
+        body: 'Docs for https://github.com/mautic/mautic/pull/17001',
+        linkedCodePrState: 'merged',
+      }),
+    ],
+  },
+  ({ records }) => {
+    const r = records[0];
+    assert.equal(r.lane, 'action');
+    assert.equal(r.ball, 'Take Action');
+    assert.equal(r.nextStep, 'Code PR merged — review the docs now');
+  }
+);
+
+// LCP2. Linked code PR closed unmerged → action lane, "close this docs PR".
+run(
+  'LCP2 · linked code PR closed unmerged → action lane',
+  {
+    prs: [
+      local({
+        repo: 'mautic/user-documentation',
+        number: 7002,
+        author: ME,
+        lastActor: ME,
+        body: 'Docs for https://github.com/mautic/mautic/pull/17002',
+        linkedCodePrState: 'closed',
+      }),
+    ],
+  },
+  ({ records }) => {
+    const r = records[0];
+    assert.equal(r.lane, 'action');
+    assert.equal(r.ball, 'Take Action');
+    assert.equal(r.nextStep, 'Code PR closed unmerged — close this docs PR');
+  }
+);
+
+// LCP3. Linked code PR still open → no verdict, falls through to the
+// turn-based reading unchanged (here: the ball is still with the author,
+// waiting on their own reply).
+run(
+  'LCP3 · linked code PR open → falls through to turn logic',
+  {
+    prs: [
+      local({
+        repo: 'mautic/user-documentation',
+        number: 7003,
+        author: ME,
+        lastActor: ME,
+        body: 'Docs for https://github.com/mautic/mautic/pull/17003',
+        linkedCodePrState: 'open',
+      }),
+    ],
+  },
+  ({ records }) => {
+    const r = records[0];
+    assert.equal(r.lane, 'waiting');
+    assert.notEqual(r.nextStep, 'Code PR merged — review the docs now');
+    assert.notEqual(r.nextStep, 'Code PR closed unmerged — close this docs PR');
+  }
+);
+
+// LCP4. Unknown (null) state — a failed/403 fetch — carries no verdict
+// either, same fallthrough as 'open'.
+run(
+  'LCP4 · linked code PR state unknown (null) → falls through to turn logic',
+  {
+    prs: [
+      local({
+        repo: 'mautic/user-documentation',
+        number: 7004,
+        author: ME,
+        lastActor: ME,
+        body: 'Docs for https://github.com/mautic/mautic/pull/17004',
+        linkedCodePrState: null,
+      }),
+    ],
+  },
+  ({ records }) => {
+    const r = records[0];
+    assert.equal(r.lane, 'waiting');
+    assert.notEqual(r.nextStep, 'Code PR merged — review the docs now');
+    assert.notEqual(r.nextStep, 'Code PR closed unmerged — close this docs PR');
   }
 );
 

--- a/scripts/services/workbench-merge.test.js
+++ b/scripts/services/workbench-merge.test.js
@@ -691,10 +691,11 @@ run(
 
 const AUTHOR_REPLIED = 'Author replied — review the latest changes';
 
-// B1. Bot's latest comment @-mentions me → my turn: action, no chip, no botPing,
-// and never the forbidden "author replied" step.
+// B1. Bot's latest comment @-mentions me → my turn: action, no botPing, and
+// never the forbidden "author replied" step. The step is routed BY THE PING —
+// who named me and when — so the row says what the ping was, not who "replied".
 run(
-  'Promptless last actor @-mentions me → action (no chip)',
+  'Promptless last actor @-mentions me → action, routed by the ping',
   {
     tasks: [
       local({
@@ -723,14 +724,19 @@ run(
     assert.notEqual(r.lane, 'bot');
     assert.equal(r.lane, 'action');
     assert.equal(r.ball, 'Take Action');
-    assert.equal(r.nextStep, null, 'no chip — the lane already says it is my turn');
+    assert.equal(
+      r.nextStep,
+      'promptless-for-oss mentioned you 1d ago — reply',
+      `nextStep was: ${r.nextStep}`
+    );
     assert.ok(!r.botPing, 'no botPing when the bot pinged me');
     assert.notEqual(r.nextStep, AUTHOR_REPLIED);
   }
 );
 
 // B1b. Bot pinged me via a live review request (its latest comment names nobody)
-// → still my turn: action, no chip, no botPing. Mirrors real #592.
+// → still my turn: action, no botPing, and the step names the review it asked
+// for rather than any "author" wording. Mirrors real #592.
 run(
   'Promptless last actor with live review request aimed at me → action',
   {
@@ -760,7 +766,8 @@ run(
     const r = records.find((x) => x.key === 'mautic/developer-documentation-new#592');
     assert.equal(r.lane, 'action');
     assert.equal(r.ball, 'Take Action');
-    assert.equal(r.nextStep, null);
+    assert.equal(r.nextStep, 'Review requested — review it', `nextStep was: ${r.nextStep}`);
+    assert.notEqual(r.nextStep, AUTHOR_REPLIED);
     assert.ok(!r.botPing, 'pinged me too → my turn, not a "pinged others" row');
   }
 );
@@ -1097,6 +1104,1182 @@ run(
     assert.equal(records[0].lane, 'stalled');
     assert.ok(records[0].reviewedNote, 'reviewedNote must survive the demotion');
     assert.equal(records[0].reviewedNote.by, 'reviewer9');
+  }
+);
+
+// ===========================================================================
+// Generalized next steps (§ G) — every repo, not just the tracker-covered ones.
+//
+// These rows deliberately live in UNTRACKED repos with an EMPTY tracker feed:
+// each step below is derived purely from the widened local activity the fetch
+// layer caches (reviews, comments with mentions, reviewRequests,
+// requestedReviewers, mergeableState, baseRef, milestone). Before this, every
+// one of them fell through to `nextStep: null`.
+// ===========================================================================
+
+/** The widened PR-detail/activity block the fetch layer now writes onto each
+ * local record. Present-but-empty is meaningful: it says "we looked", which is
+ * what lets rules like "no reviewer assigned" speak at all. */
+function detail(overrides = {}) {
+  return {
+    reviews: [],
+    comments: [],
+    reviewRequests: [],
+    requestedReviewers: [],
+    mergeableState: null,
+    baseRef: null,
+    milestone: null,
+    ...overrides,
+  };
+}
+
+// G1. Reviewing, you moved last → the row can finally say why it's parked.
+run(
+  'G1 · reviewing, I reviewed last → "You reviewed Nd ago — author hasn\'t replied"',
+  {
+    tasks: [
+      local({
+        repo: 'someorg/app',
+        number: 6001,
+        lastActor: ME,
+        author: 'writerA',
+        ...detail({ reviews: [{ login: ME, state: 'COMMENTED', submittedAt: daysAgo(4) }] }),
+      }),
+    ],
+  },
+  ({ records }) => {
+    const r = records[0];
+    assert.equal(r.source, 'local', 'derived with no tracker record at all');
+    assert.equal(r.upstream, null);
+    assert.equal(r.lane, 'waiting');
+    assert.equal(r.ball, 'Waiting');
+    assert.equal(r.nextStep, "You reviewed 4d ago — author hasn't replied", r.nextStep);
+  }
+);
+
+// G2. Reviewing, a third party moved last → name the reviewer still on the hook.
+run(
+  'G2 · reviewing, third party last → "Waiting on LOGIN to review — requested Nd ago"',
+  {
+    tasks: [
+      local({
+        repo: 'someorg/app',
+        number: 6002,
+        lastActor: 'thirdparty',
+        author: 'writerA',
+        ...detail({
+          requestedReviewers: ['maintainerZ'],
+          reviewRequests: [
+            { requestedReviewer: 'maintainerZ', actor: 'writerA', createdAt: daysAgo(5) },
+          ],
+        }),
+      }),
+    ],
+  },
+  ({ records }) => {
+    const r = records[0];
+    assert.equal(r.lane, 'waiting');
+    assert.equal(r.ball, 'Watching');
+    assert.equal(r.nextStep, 'Waiting on maintainerZ to review — requested 5d ago', r.nextStep);
+  }
+);
+
+// G2b. Nobody resolvable to wait on → drop the whole clause rather than print
+// "Waiting on  to review". The Watching pill already says this much.
+run(
+  'G2b · no resolvable reviewer → no step, never an empty placeholder',
+  {
+    tasks: [
+      local({
+        repo: 'someorg/app',
+        number: 6021,
+        lastActor: 'thirdparty',
+        author: 'writerA',
+        ...detail(),
+      }),
+    ],
+  },
+  ({ records }) => {
+    assert.equal(records[0].nextStep, null, records[0].nextStep);
+  }
+);
+
+// G2c. A live pending reviewer with no surviving request event still gets
+// named — only the date clause drops.
+run(
+  'G2c · pending reviewer, no request event → date clause dropped',
+  {
+    tasks: [
+      local({
+        repo: 'someorg/app',
+        number: 6022,
+        lastActor: 'thirdparty',
+        author: 'writerA',
+        ...detail({ requestedReviewers: ['maintainerZ'] }),
+      }),
+    ],
+  },
+  ({ records }) => {
+    assert.equal(records[0].nextStep, 'Waiting on maintainerZ to review', records[0].nextStep);
+  }
+);
+
+// G3. Your own PR, you spoke last → say when, and who owes you.
+run(
+  'G3 · authored, I replied last → "You replied Nd ago — waiting on LOGIN"',
+  {
+    prs: [
+      local({
+        repo: 'someorg/app',
+        number: 6003,
+        lastActor: ME,
+        author: ME,
+        ...detail({
+          requestedReviewers: ['maintainerZ'],
+          comments: [{ login: ME, createdAt: daysAgo(3), mentions: [] }],
+        }),
+      }),
+    ],
+  },
+  ({ records }) => {
+    const r = records[0];
+    assert.equal(r.lane, 'waiting');
+    assert.equal(r.nextStep, 'You replied 3d ago — waiting on maintainerZ', r.nextStep);
+  }
+);
+
+// G4. A bot pushed to your own PR. Never "author replied" — a push is not a
+// person answering you, it's a diff that moved under you.
+run(
+  'G4 · authored, bot pushed last → "LOGIN pushed Nd ago — re-check the changes"',
+  {
+    prs: [
+      local({
+        repo: 'someorg/app',
+        number: 6004,
+        user: { login: ME },
+        author: ME,
+        lastActor: 'renovate[bot]',
+        isLastActorBot: true,
+        ...detail(),
+      }),
+    ],
+  },
+  ({ records }) => {
+    const r = records[0];
+    assert.notEqual(r.lane, 'bot', 'my PR, not bot-lane clutter');
+    assert.equal(r.ball, 'Watching');
+    assert.equal(r.nextStep, 'renovate[bot] pushed 2d ago — re-check the changes', r.nextStep);
+  }
+);
+
+// G5. Changes requested and unanswered → say who, on any repo.
+run(
+  'G5 · changes requested → "Changes requested by LOGIN — address the feedback"',
+  {
+    prs: [
+      local({
+        repo: 'someorg/app',
+        number: 6005,
+        lastActor: 'reviewerQ',
+        author: ME,
+        hasFormalReview: true,
+        ...detail({
+          reviews: [{ login: 'reviewerQ', state: 'CHANGES_REQUESTED', submittedAt: daysAgo(2) }],
+        }),
+      }),
+    ],
+  },
+  ({ records }) => {
+    const r = records[0];
+    assert.equal(r.lane, 'action', 'the wording sharpens; the lane is untouched');
+    assert.equal(r.ball, 'Take Action');
+    assert.equal(r.nextStep, 'Changes requested by reviewerQ — address the feedback', r.nextStep);
+  }
+);
+
+// G5b. Once you reply, it stops nagging and the generic step returns.
+run(
+  'G5b · changes requested, answered by a later reply of mine → back to generic',
+  {
+    prs: [
+      local({
+        repo: 'someorg/app',
+        number: 6023,
+        lastActor: 'reviewerQ',
+        author: ME,
+        hasFormalReview: true,
+        ...detail({
+          reviews: [{ login: 'reviewerQ', state: 'CHANGES_REQUESTED', submittedAt: daysAgo(4) }],
+          comments: [{ login: ME, createdAt: daysAgo(2), mentions: [] }],
+        }),
+      }),
+    ],
+  },
+  ({ records }) => {
+    assert.equal(records[0].nextStep, 'Address the review feedback', records[0].nextStep);
+  }
+);
+
+// G6. A direct @-mention outranks the turn reading — being named is being asked.
+run(
+  'G6 · @-mention of me → "LOGIN mentioned you Nd ago — reply"',
+  {
+    tasks: [
+      local({
+        repo: 'someorg/app',
+        number: 6006,
+        lastActor: 'writerA',
+        author: 'writerA',
+        ...detail({
+          comments: [{ login: 'writerA', createdAt: daysAgo(2), mentions: ['adiati98'] }],
+        }),
+      }),
+    ],
+  },
+  ({ records }) => {
+    const r = records[0];
+    assert.equal(r.lane, 'action', 'lane still comes from the turn reading');
+    assert.equal(r.nextStep, 'writerA mentioned you 2d ago — reply', r.nextStep);
+  }
+);
+
+// G6b. A mention you already answered is spent — no later comment of mine, no
+// step. (Here I commented after it, so the row falls back to its turn step.)
+run(
+  'G6b · mention already answered → no ping step',
+  {
+    tasks: [
+      local({
+        repo: 'someorg/app',
+        number: 6024,
+        lastActor: 'writerA',
+        author: 'writerA',
+        ...detail({
+          comments: [
+            { login: 'writerA', createdAt: daysAgo(5), mentions: ['adiati98'] },
+            { login: ME, createdAt: daysAgo(3), mentions: [] },
+          ],
+        }),
+      }),
+    ],
+  },
+  ({ records }) => {
+    assert.ok(!/mentioned you/.test(records[0].nextStep || ''), records[0].nextStep);
+  }
+);
+
+// G7. Ready, non-draft, nobody asked to look → that IS the remaining step.
+run(
+  'G7 · ready with no reviewer and no review → "No reviewer assigned — request one"',
+  {
+    prs: [local({ repo: 'someorg/app', number: 6007, lastActor: ME, author: ME, ...detail() })],
+  },
+  ({ records }) => {
+    assert.equal(records[0].nextStep, 'No reviewer assigned — request one', records[0].nextStep);
+  }
+);
+
+// G7b. A draft is not "ready", so it keeps the draft step instead.
+run(
+  'G7b · draft with no reviewer → still the draft step, not "request one"',
+  {
+    prs: [
+      local({
+        repo: 'someorg/app',
+        number: 6025,
+        lastActor: ME,
+        author: ME,
+        isDraft: true,
+        ...detail(),
+      }),
+    ],
+  },
+  ({ records }) => {
+    assert.equal(records[0].nextStep, 'Draft — finish and mark ready', records[0].nextStep);
+  }
+);
+
+// G7c. Without the PR-detail block there is no evidence either way, so the
+// rule stays silent rather than claiming nobody was asked.
+run(
+  'G7c · no cached PR detail → no "request one" claim',
+  {
+    prs: [local({ repo: 'someorg/app', number: 6026, lastActor: ME, author: ME })],
+  },
+  ({ records }) => {
+    assert.ok(!/reviewer assigned/.test(records[0].nextStep || ''), records[0].nextStep);
+  }
+);
+
+// G8. A definitively dirty merge state names the base branch.
+run(
+  'G8 · mergeableState dirty → "Conflicts with BRANCH — rebase needed"',
+  {
+    prs: [
+      local({
+        repo: 'someorg/app',
+        number: 6008,
+        lastActor: 'reviewerQ',
+        author: ME,
+        hasFormalReview: true,
+        ...detail({ mergeableState: 'dirty', baseRef: 'main' }),
+      }),
+    ],
+  },
+  ({ records }) => {
+    assert.equal(records[0].nextStep, 'Conflicts with main — rebase needed', records[0].nextStep);
+  }
+);
+
+// G8b. No base branch to name → drop the clause, keep the fact.
+run(
+  'G8b · dirty with no baseRef → clause dropped',
+  {
+    prs: [
+      local({
+        repo: 'someorg/app',
+        number: 6027,
+        lastActor: 'reviewerQ',
+        author: ME,
+        hasFormalReview: true,
+        ...detail({ mergeableState: 'dirty', baseRef: null }),
+      }),
+    ],
+  },
+  ({ records }) => {
+    assert.equal(records[0].nextStep, 'Conflicts — rebase needed', records[0].nextStep);
+  }
+);
+
+// G8c. null (and any non-dirty state) means UNKNOWN, not clean and not
+// conflicted. Emit nothing — there is nothing to retry, the next build reads a
+// fresh value anyway.
+for (const state of [null, 'unknown', 'blocked', 'behind', 'clean']) {
+  run(
+    `G8c · mergeableState ${JSON.stringify(state)} → no conflict step`,
+    {
+      prs: [
+        local({
+          repo: 'someorg/app',
+          number: 6028,
+          lastActor: 'reviewerQ',
+          author: ME,
+          hasFormalReview: true,
+          ...detail({ mergeableState: state, baseRef: 'main' }),
+        }),
+      ],
+    },
+    ({ records }) => {
+      assert.ok(!/rebase|onflict/.test(records[0].nextStep || ''), records[0].nextStep);
+      assert.equal(records[0].nextStep, 'Address the review feedback', records[0].nextStep);
+    }
+  );
+}
+
+// ===========================================================================
+// Precedence (§ P) — one row carrying every signal at once, peeled back a
+// layer at a time. Ping → changes requested → conflicts → turn.
+//
+// Deliberately NOT a milestone repo: the milestone reminder appends rather
+// than competes (see § M), so keeping it out here leaves the ladder legible.
+// ===========================================================================
+
+function stacked(overrides) {
+  return local({
+    repo: 'someorg/app',
+    number: 6009,
+    lastActor: ME,
+    author: ME,
+    ...detail({
+      requestedReviewers: ['escopecz'],
+      reviews: [{ login: 'reviewerQ', state: 'CHANGES_REQUESTED', submittedAt: daysAgo(2) }],
+      comments: [{ login: 'reviewerQ', createdAt: daysAgo(1), mentions: ['adiati98'] }],
+      mergeableState: 'dirty',
+      baseRef: 'main',
+      milestone: null,
+    }),
+    ...overrides,
+  });
+}
+
+run(
+  'P1 · ping outranks changes requested, conflicts and the turn',
+  { prs: [stacked({})] },
+  ({ records }) => {
+    assert.equal(
+      records[0].nextStep,
+      'reviewerQ mentioned you 1d ago — reply',
+      records[0].nextStep
+    );
+  }
+);
+
+run(
+  'P2 · no ping → changes requested outranks conflicts and the turn',
+  { prs: [stacked({ comments: [] })] },
+  ({ records }) => {
+    assert.equal(
+      records[0].nextStep,
+      'Changes requested by reviewerQ — address the feedback',
+      records[0].nextStep
+    );
+  }
+);
+
+run(
+  'P3 · no ping, no change request → conflicts outrank the turn',
+  { prs: [stacked({ comments: [], reviews: [] })] },
+  ({ records }) => {
+    assert.equal(records[0].nextStep, 'Conflicts with main — rebase needed', records[0].nextStep);
+  }
+);
+
+run(
+  'P4 · nothing pressing → the turn reading is what is left',
+  { prs: [stacked({ comments: [], reviews: [], mergeableState: null })] },
+  ({ records }) => {
+    assert.equal(
+      records[0].nextStep,
+      'You replied 2d ago — waiting on escopecz',
+      records[0].nextStep
+    );
+  }
+);
+
+// ===========================================================================
+// Milestone reminder (§ M) — scoped by a repo list, never inferred from the
+// data, and carried as its OWN record field rather than spliced into nextStep.
+//
+// This follows the upstream docs-PR tracker, which models a missing milestone
+// as a lifecycle category (needs-milestone / needs-label-and-milestone) with
+// "act" severity, and renders it as a separate "Add milestone" chip pushed
+// AHEAD of the review chip. Two consequences differ from a plain suffix:
+// nextStep stays clean, and drafts are triaged rather than exempted.
+// ===========================================================================
+
+/** Every eligible row must expose the flag; none may leak it into the prose. */
+function assertMilestone(record, expected) {
+  assert.equal(
+    record.milestoneMissing,
+    expected,
+    `milestoneMissing was ${record.milestoneMissing}`
+  );
+  assert.ok(
+    !/milestone/i.test(record.nextStep || ''),
+    `nextStep must stay clean, was: ${record.nextStep}`
+  );
+}
+
+// M1. Fires on a listed Mautic repo, as a field — the row's own step is
+// untouched, so the renderer can draw the chip separately.
+run(
+  'M1 · listed Mautic repo → flag set, nextStep left alone',
+  {
+    prs: [
+      local({
+        repo: 'mautic/developer-documentation-new',
+        number: 6031,
+        lastActor: ME,
+        author: ME,
+        ...detail({ requestedReviewers: ['escopecz'], milestone: null }),
+      }),
+    ],
+  },
+  ({ records }) => {
+    assertMilestone(records[0], true);
+    assert.equal(
+      records[0].nextStep,
+      'You replied 2d ago — waiting on escopecz',
+      records[0].nextStep
+    );
+  }
+);
+
+// M2. …and NOT on an identical row in a repo that isn't on the list. Same
+// missing milestone, same shape — only the repo differs.
+run(
+  'M2 · milestone reminder does NOT fire for a non-Mautic repo',
+  {
+    prs: [
+      local({
+        repo: 'someorg/app',
+        number: 6032,
+        lastActor: ME,
+        author: ME,
+        ...detail({ requestedReviewers: ['escopecz'], milestone: null }),
+      }),
+    ],
+  },
+  ({ records }) => {
+    assertMilestone(records[0], false);
+    assert.equal(
+      records[0].nextStep,
+      'You replied 2d ago — waiting on escopecz',
+      records[0].nextStep
+    );
+  }
+);
+
+// M3. A listed repo that DOES carry a milestone says nothing about it — and a
+// non-listed repo carrying one is equally silent. Presence of the field is
+// never what decides the scope.
+run(
+  'M3 · milestone present → silent, on listed and unlisted repos alike',
+  {
+    prs: [
+      local({
+        repo: 'mautic/user-documentation',
+        number: 6033,
+        lastActor: ME,
+        author: ME,
+        ...detail({ requestedReviewers: ['escopecz'], milestone: 'Q3 docs' }),
+      }),
+      local({
+        repo: 'someorg/app',
+        number: 6034,
+        lastActor: ME,
+        author: ME,
+        ...detail({ requestedReviewers: ['escopecz'], milestone: 'Q3 docs' }),
+      }),
+    ],
+  },
+  ({ records }) => {
+    for (const r of records) assertMilestone(r, false);
+  }
+);
+
+// M4. The action lane — where most of the real board's Mautic rows sit. The
+// instruction is untouched; the chip is an independent field beside it.
+run(
+  'M4 · action lane → instruction untouched, flag set alongside',
+  {
+    tasks: [
+      local({
+        repo: 'mautic/user-documentation',
+        number: 6029,
+        lastActor: 'writerA',
+        author: 'writerA',
+        ...detail({ milestone: null }),
+      }),
+    ],
+  },
+  ({ records }) => {
+    assert.equal(records[0].lane, 'action');
+    assertMilestone(records[0], true);
+    assert.equal(records[0].nextStep, AUTHOR_REPLIED, records[0].nextStep);
+  }
+);
+
+// M5. A missing milestone is YOUR move, so the row must not sit in a lane that
+// means the opposite. "Waiting on others" reads *your part is done*; "Stalled"
+// reads *nudge or close* AND folds the row shut so the chip goes unseen. Both
+// are false while a milestone is owed, so the row is promoted — and because
+// the promotion happens in the turn logic, the staleness fold skips it for
+// free, the same way it skips assigned issues and review pings.
+run(
+  'M5 · a stalled row is promoted to action, never folded away',
+  {
+    prs: [
+      local({
+        repo: 'mautic/user-documentation',
+        number: 6035,
+        updatedAt: daysAgo(40),
+        lastSubstantiveDate: daysAgo(40),
+        lastActor: ME,
+        author: ME,
+        ...detail({ requestedReviewers: ['escopecz'], milestone: null }),
+      }),
+    ],
+  },
+  ({ records }) => {
+    assert.equal(records[0].lane, 'action', `lane was ${records[0].lane}`);
+    assert.equal(records[0].ball, 'Take Action');
+    assert.ok(
+      records[0].idleDays >= 30,
+      'genuinely old — it just is not stale while you owe it something'
+    );
+    assert.ok(!/nudge or close/.test(records[0].nextStep), records[0].nextStep);
+    assertMilestone(records[0], true);
+  }
+);
+
+// M5b. The plain waiting case, same rule.
+run(
+  'M5b · a waiting row is promoted to action',
+  {
+    prs: [
+      local({
+        repo: 'mautic/user-documentation',
+        number: 6041,
+        lastActor: ME,
+        author: ME,
+        ...detail({ requestedReviewers: ['escopecz'], milestone: null }),
+      }),
+    ],
+  },
+  ({ records }) => {
+    assert.equal(records[0].lane, 'action', `lane was ${records[0].lane}`);
+    assert.equal(records[0].ball, 'Take Action');
+  }
+);
+
+// M5c. …but with the milestone set, the identical row stays where it was. The
+// promotion is caused by the missing milestone, not by the repo.
+run(
+  'M5c · milestone set → the same row stays in waiting',
+  {
+    prs: [
+      local({
+        repo: 'mautic/user-documentation',
+        number: 6042,
+        lastActor: ME,
+        author: ME,
+        ...detail({ requestedReviewers: ['escopecz'], milestone: 'Q3 docs' }),
+      }),
+    ],
+  },
+  ({ records }) => {
+    assert.equal(records[0].lane, 'waiting');
+    assert.equal(records[0].ball, 'Waiting');
+  }
+);
+
+// M5d. Drafts are triaged, NOT exempted. The upstream tracker's
+// needs-label-and-milestone category fires precisely on drafts and carries
+// "act" severity — a draft is when the milestone is cheapest to set, before
+// anyone is waiting on the merge. The draft instruction survives beside it.
+run(
+  'M5d · a draft is promoted too, keeping its own instruction',
+  {
+    prs: [
+      local({
+        repo: 'mautic/user-documentation',
+        number: 6043,
+        lastActor: ME,
+        author: ME,
+        isDraft: true,
+        ...detail({ milestone: null }),
+      }),
+    ],
+  },
+  ({ records }) => {
+    assert.equal(records[0].lane, 'action', `lane was ${records[0].lane}`);
+    assertMilestone(records[0], true);
+    assert.equal(records[0].nextStep, 'Draft — finish and mark ready', records[0].nextStep);
+  }
+);
+
+// M6. The approval branch returns before the turn logic runs at all, so the
+// flag has to survive that route too — an approved PR still wants a milestone.
+// The lane is deliberately NOT promoted: "Approved — bring it home" already
+// means work is left before it ships, and the Approved pill says something
+// Take Action would throw away.
+run(
+  'M6 · reaches approved rows, and leaves that lane and pill alone',
+  {
+    prs: [
+      local({
+        repo: 'mautic/user-documentation',
+        number: 6036,
+        reviewState: 'APPROVED',
+        approvedBy: 'escopecz',
+        lastActor: 'escopecz',
+        author: ME,
+        ...detail({ milestone: null }),
+      }),
+    ],
+  },
+  ({ records }) => {
+    assert.equal(records[0].lane, 'ready');
+    assert.equal(records[0].ball, 'Approved');
+    assertMilestone(records[0], true);
+    assert.equal(records[0].nextStep, 'Final review, then merge', records[0].nextStep);
+  }
+);
+
+// M7. A row with nothing else to say carries the flag alone — the chip is the
+// whole message, and nextStep stays null rather than inventing prose for it.
+run(
+  'M7 · no other step → the flag stands alone, nextStep stays null',
+  {
+    tasks: [
+      local({
+        repo: 'mautic/user-documentation',
+        number: 6037,
+        lastActor: 'thirdparty',
+        author: 'writerA',
+        ...detail({ milestone: null }),
+      }),
+    ],
+  },
+  ({ records }) => {
+    assertMilestone(records[0], true);
+    assert.equal(records[0].nextStep, null, records[0].nextStep);
+  }
+);
+
+// M8. The bot lane is folded away precisely so it carries no instructions —
+// a dependabot PR in a Mautic repo must stay silent. The upstream tracker
+// exempts Dependabot from milestone triage for the same reason.
+run(
+  'M8 · never on the bot lane',
+  {
+    tasks: [
+      local({
+        repo: 'mautic/user-documentation',
+        number: 6038,
+        user: { login: 'dependabot[bot]' },
+        author: 'dependabot[bot]',
+        title: 'Bump lodash from 4 to 5',
+        ...detail({ milestone: null }),
+      }),
+    ],
+  },
+  ({ records }) => {
+    assert.equal(records[0].lane, 'bot');
+    assertMilestone(records[0], false);
+    assert.equal(records[0].nextStep, null, records[0].nextStep);
+  }
+);
+
+// M9. The idle escalation still rides inside nextStep, and the milestone stays
+// out of it — two separate channels, so neither can crowd out the other.
+run(
+  'M9 · idle hint stays in the step, milestone stays a field',
+  {
+    tasks: [
+      local({
+        repo: 'mautic/user-documentation',
+        number: 6039,
+        updatedAt: daysAgo(20),
+        lastSubstantiveDate: daysAgo(20),
+        lastActor: 'writerA',
+        author: 'writerA',
+        ...detail({ milestone: null }),
+      }),
+    ],
+  },
+  ({ records }) => {
+    assertMilestone(records[0], true);
+    assert.equal(
+      records[0].nextStep,
+      `${AUTHOR_REPLIED} · idle 20d, escalate`,
+      records[0].nextStep
+    );
+  }
+);
+
+// M10. Every record carries the field, so renderers never have to guard for
+// undefined — the same contract botPing follows.
+run(
+  'M10 · the field is present on every record, tracker-only rows included',
+  {
+    prs: [local({ repo: 'someorg/app', number: 6044, lastActor: ME, author: ME })],
+    tracker: {
+      'mautic/user-documentation#6045': {
+        docsUpdatedAt: daysAgo(3),
+        rawDocsReviews: [],
+        rawDocsComments: [],
+      },
+    },
+  },
+  ({ records }) => {
+    for (const r of records) {
+      assert.ok('milestoneMissing' in r, `missing on ${r.key}`);
+      assert.equal(typeof r.milestoneMissing, 'boolean', `not a boolean on ${r.key}`);
+    }
+    // A tracker-only row has no local PR detail, so "no milestone" is an
+    // unknown, not a fact.
+    const trackerOnly = records.find((r) => r.source === 'tracker');
+    assert.equal(trackerOnly.milestoneMissing, false);
+  }
+);
+
+// ===========================================================================
+// Pending-PR label (§ L) — the second Mautic docs housekeeping rule, scoped by
+// its own repo list. Ported from the upstream tracker's
+// needs-label-and-milestone category, which prompts for the label on DRAFTS:
+// a draft docs PR is by definition still pending something. Once it is ready
+// for review, whether the label belongs is a judgement call about the linked
+// code PR, not a lapse — so the prompt stops.
+// ===========================================================================
+
+const PENDING_LABEL = 'pending-pr-merge';
+
+function draftRow(overrides) {
+  return local({
+    repo: 'mautic/user-documentation',
+    lastActor: ME,
+    author: ME,
+    isDraft: true,
+    ...detail({ milestone: 'Q3 docs' }),
+    ...overrides,
+  });
+}
+
+// L1. Draft in a listed repo, label absent → chip, and the row is promoted the
+// same way a missing milestone promotes it.
+run(
+  'L1 · draft without the label → flagged and promoted',
+  { prs: [draftRow({ number: 6101, labels: [] })] },
+  ({ records }) => {
+    assert.equal(records[0].pendingLabelMissing, PENDING_LABEL, records[0].pendingLabelMissing);
+    assert.equal(records[0].lane, 'action', `lane was ${records[0].lane}`);
+    assert.equal(records[0].ball, 'Take Action');
+    assert.equal(records[0].nextStep, 'Draft — finish and mark ready', records[0].nextStep);
+  }
+);
+
+// L2. THE CLEARING CASE — the prompt is a live read of the PR's own labels
+// every build, never a stored flag. Add the label on GitHub and the chip is
+// gone on the next run, with nothing to reset by hand; the row drops back out
+// of the action lane too, since nothing is owed any more. Same fixture as L1
+// apart from the label, so the label is provably the only thing doing it.
+run(
+  'L2 · adding the label clears the chip and the promotion',
+  { prs: [draftRow({ number: 6102, labels: [PENDING_LABEL] })] },
+  ({ records }) => {
+    assert.equal(records[0].pendingLabelMissing, null, records[0].pendingLabelMissing);
+    assert.equal(records[0].lane, 'waiting', 'nothing owed → back where it was');
+    assert.equal(records[0].ball, 'Waiting');
+  }
+);
+
+// L2b. Matched case-insensitively — GitHub label casing varies by who made it.
+run(
+  'L2b · label match ignores case',
+  { prs: [draftRow({ number: 6103, labels: ['Pending-PR-Merge'] })] },
+  ({ records }) => {
+    assert.equal(records[0].pendingLabelMissing, null, records[0].pendingLabelMissing);
+  }
+);
+
+// L2c. …and it is the RIGHT label that clears it, not merely having labels.
+run(
+  'L2c · unrelated labels do not clear the prompt',
+  { prs: [draftRow({ number: 6104, labels: ['needs-backport', 'content-approved'] })] },
+  ({ records }) => {
+    assert.equal(records[0].pendingLabelMissing, PENDING_LABEL, records[0].pendingLabelMissing);
+  }
+);
+
+// L3. Not a draft → no prompt, however the labels look. Once a PR is ready for
+// review the label is a judgement call, not a lapse.
+run(
+  'L3 · ready-for-review PR without the label → silent',
+  {
+    prs: [
+      local({
+        repo: 'mautic/user-documentation',
+        number: 6105,
+        lastActor: ME,
+        author: ME,
+        isDraft: false,
+        labels: [],
+        ...detail({ requestedReviewers: ['escopecz'], milestone: 'Q3 docs' }),
+      }),
+    ],
+  },
+  ({ records }) => {
+    assert.equal(records[0].pendingLabelMissing, null, records[0].pendingLabelMissing);
+  }
+);
+
+// L4. A draft in a repo that isn't on the list → silent. Same shape, only the
+// repo differs — the scope is the list, never the data.
+run(
+  'L4 · draft in a non-listed repo → silent',
+  { prs: [draftRow({ repo: 'someorg/app', number: 6106, labels: [], ...detail() })] },
+  ({ records }) => {
+    assert.equal(records[0].pendingLabelMissing, null, records[0].pendingLabelMissing);
+    assert.equal(records[0].lane, 'waiting', 'nothing owed → no promotion');
+  }
+);
+
+// L5. Both housekeeping rules at once — two independent fields, neither
+// crowding out the other nor the row's own instruction.
+run(
+  'L5 · label and milestone both missing → both fields set, step untouched',
+  {
+    prs: [
+      draftRow({
+        repo: 'mautic/developer-documentation-new',
+        number: 6107,
+        labels: ['needs-backport'],
+        ...detail({ milestone: null }),
+      }),
+    ],
+  },
+  ({ records }) => {
+    assert.equal(records[0].pendingLabelMissing, PENDING_LABEL);
+    assert.equal(records[0].milestoneMissing, true);
+    assert.equal(records[0].nextStep, 'Draft — finish and mark ready', records[0].nextStep);
+    assert.ok(!/label|milestone/i.test(records[0].nextStep), 'neither leaks into the prose');
+  }
+);
+
+// L6. Bot rows stay clean — the lane is folded away precisely so it carries no
+// instructions, and the upstream tracker exempts Dependabot for the same reason.
+run(
+  'L6 · never on the bot lane',
+  {
+    tasks: [
+      local({
+        repo: 'mautic/user-documentation',
+        number: 6108,
+        user: { login: 'dependabot[bot]' },
+        author: 'dependabot[bot]',
+        title: 'Bump lodash from 4 to 5',
+        isDraft: true,
+        labels: [],
+        ...detail({ milestone: null }),
+      }),
+    ],
+  },
+  ({ records }) => {
+    assert.equal(records[0].lane, 'bot');
+    assert.equal(records[0].pendingLabelMissing, null);
+    assert.equal(records[0].milestoneMissing, false);
+  }
+);
+
+// L7. Present on every record, so renderers never guard for undefined.
+run(
+  'L7 · the field is present on every record',
+  {
+    prs: [local({ repo: 'someorg/app', number: 6109, lastActor: ME, author: ME })],
+    tracker: {
+      'mautic/user-documentation#6110': {
+        docsUpdatedAt: daysAgo(3),
+        rawDocsReviews: [],
+        rawDocsComments: [],
+      },
+    },
+  },
+  ({ records }) => {
+    for (const r of records) {
+      assert.ok('pendingLabelMissing' in r, `missing on ${r.key}`);
+      assert.ok(
+        r.pendingLabelMissing === null || typeof r.pendingLabelMissing === 'string',
+        `bad type on ${r.key}: ${typeof r.pendingLabelMissing}`
+      );
+    }
+  }
+);
+
+// ===========================================================================
+// Idle suffix (§ I) — the escalation APPENDS to the reason, never replaces it.
+// Regression: `idleHint(idleDays) || reason` dropped the reason on exactly the
+// oldest rows, so the board stopped saying what to do and said only how late.
+// ===========================================================================
+
+for (const [days, tail] of [
+  [8, 'idle 8d, send a reminder'],
+  [11, 'idle 11d, follow up'],
+  [20, 'idle 20d, escalate'],
+]) {
+  run(
+    `I1 · idle ${days}d → "reason · ${tail}"`,
+    {
+      tasks: [
+        local({
+          repo: 'someorg/app',
+          number: 6040 + days,
+          updatedAt: daysAgo(days),
+          lastSubstantiveDate: daysAgo(days),
+          lastActor: 'writerA',
+          author: 'writerA',
+        }),
+      ],
+    },
+    ({ records }) => {
+      assert.equal(records[0].nextStep, `${AUTHOR_REPLIED} · ${tail}`, records[0].nextStep);
+      assert.ok(
+        records[0].nextStep.startsWith(AUTHOR_REPLIED),
+        'the reason survives the escalation'
+      );
+    }
+  );
+}
+
+// I2. Under the 7-day threshold there is no suffix at all.
+run(
+  'I2 · below the remind threshold → bare reason, no suffix',
+  {
+    tasks: [local({ repo: 'someorg/app', number: 6060, lastActor: 'writerA', author: 'writerA' })],
+  },
+  ({ records }) => {
+    assert.equal(records[0].nextStep, AUTHOR_REPLIED, records[0].nextStep);
+  }
+);
+
+// I3. Steps that already state their own age don't double up on it.
+run(
+  'I3 · a step carrying its own age gets no idle suffix',
+  {
+    tasks: [
+      local({
+        repo: 'someorg/app',
+        number: 6061,
+        updatedAt: daysAgo(20),
+        lastSubstantiveDate: daysAgo(20),
+        lastActor: ME,
+        author: 'writerA',
+        ...detail({ reviews: [{ login: ME, state: 'COMMENTED', submittedAt: daysAgo(20) }] }),
+      }),
+    ],
+  },
+  ({ records }) => {
+    assert.equal(
+      records[0].nextStep,
+      "You reviewed 20d ago — author hasn't replied",
+      records[0].nextStep
+    );
+    assert.ok(!/idle 20d/.test(records[0].nextStep), 'no "20d ago · idle 20d"');
+  }
+);
+
+// ===========================================================================
+// Degradation (§ D) — the tracker can be down, and none of this may care.
+// ===========================================================================
+
+// D1. Feed down, no cache at all: the local fields carry the whole thing.
+run(
+  'D1 · tracker feed down → local fields still derive the specific step',
+  {
+    prs: [
+      local({
+        repo: 'someorg/app',
+        number: 6070,
+        lastActor: 'reviewerQ',
+        author: ME,
+        hasFormalReview: true,
+        ...detail({
+          reviews: [{ login: 'reviewerQ', state: 'CHANGES_REQUESTED', submittedAt: daysAgo(2) }],
+        }),
+      }),
+    ],
+    feed: {
+      data: {},
+      fetchedAt: null,
+      degraded: true,
+      reason: 'live fetch failed; no cached feed',
+    },
+  },
+  ({ records, feed }) => {
+    assert.equal(feed.degraded, true);
+    assert.equal(
+      records[0].nextStep,
+      'Changes requested by reviewerQ — address the feedback',
+      records[0].nextStep
+    );
+  }
+);
+
+// D2. Where BOTH sides carry an array, upstream wins — the tracker sees a
+// repo's full history, the local cache is capped and can miss older activity.
+run(
+  'D2 · upstream reviews preferred over the local copy',
+  {
+    prs: [
+      local({
+        repo: 'mautic/user-documentation',
+        number: 6071,
+        lastActor: 'reviewerQ',
+        author: ME,
+        hasFormalReview: true,
+        ...detail({
+          // A milestone is set so this fixture stays about the merge
+          // preference and not the § M trailing clause.
+          milestone: 'Q3 docs',
+          reviews: [{ login: 'localGuy', state: 'CHANGES_REQUESTED', submittedAt: daysAgo(2) }],
+        }),
+      }),
+    ],
+    tracker: {
+      'mautic/user-documentation#6071': {
+        docsUpdatedAt: daysAgo(1),
+        rawDocsReviews: [
+          { user: { login: 'upstreamGuy' }, state: 'CHANGES_REQUESTED', submitted_at: daysAgo(2) },
+        ],
+        rawDocsComments: [],
+      },
+    },
+  },
+  ({ records }) => {
+    assert.equal(
+      records[0].nextStep,
+      'Changes requested by upstreamGuy — address the feedback',
+      records[0].nextStep
+    );
+  }
+);
+
+// D3. An EMPTY upstream array is not a source of truth — it falls through to
+// the local copy instead of blanking a row that has real local activity.
+run(
+  'D3 · empty upstream array falls through to local activity',
+  {
+    prs: [
+      local({
+        repo: 'mautic/user-documentation',
+        number: 6072,
+        lastActor: 'reviewerQ',
+        author: ME,
+        hasFormalReview: true,
+        ...detail({
+          // A milestone is set so this fixture stays about the merge
+          // preference and not the § M trailing clause.
+          milestone: 'Q3 docs',
+          reviews: [{ login: 'localGuy', state: 'CHANGES_REQUESTED', submittedAt: daysAgo(2) }],
+        }),
+      }),
+    ],
+    tracker: {
+      'mautic/user-documentation#6072': {
+        docsUpdatedAt: daysAgo(1),
+        rawDocsReviews: [],
+        rawDocsComments: [],
+      },
+    },
+  },
+  ({ records }) => {
+    assert.equal(
+      records[0].nextStep,
+      'Changes requested by localGuy — address the feedback',
+      records[0].nextStep
+    );
+  }
+);
+
+// D4. A record whose activity blows up mid-read yields NO signals rather than
+// a thrown build. The row still lands in a lane.
+run(
+  'D4 · malformed activity degrades to no signals, never a throw',
+  {
+    prs: [
+      local({
+        repo: 'someorg/app',
+        number: 6073,
+        lastActor: 'reviewerQ',
+        author: ME,
+        hasFormalReview: true,
+        ...detail({
+          comments: [
+            {
+              get login() {
+                throw new Error('drifted record');
+              },
+            },
+          ],
+        }),
+      }),
+    ],
+  },
+  ({ records }) => {
+    assert.equal(records[0].lane, 'action');
+    assert.equal(records[0].nextStep, 'Address the review feedback', records[0].nextStep);
   }
 );
 

--- a/scripts/utils/github-helpers.js
+++ b/scripts/utils/github-helpers.js
@@ -25,6 +25,13 @@ function extractLinkedCodePr(body, ownRepo) {
   return null;
 }
 
+/** Extracts @-mention logins from a comment body. The body itself is never persisted. */
+function extractMentions(body) {
+  if (!body) return [];
+  const matches = body.match(/@([a-zA-Z0-9](?:[a-zA-Z0-9-]{0,37}[a-zA-Z0-9])?)/g) || [];
+  return [...new Set(matches.map((m) => m.slice(1)))];
+}
+
 /**
  * HELPER: Fetches specific activity metadata for a PR to determine "Who has the ball".
  * Merges timeline processing with explicit fallback comment checking to guarantee review replies are caught,
@@ -55,6 +62,9 @@ async function getPrActivityMeta(
     approvedBy: null,
     lastSubstantiveDate: prMainUpdatedAt,
     hasHumanEngagement: false,
+    reviews: [],
+    comments: [],
+    reviewRequests: [],
   };
 
   // Already confirmed permanently 403 (e.g. an org we don't have SSO
@@ -142,6 +152,36 @@ async function getPrActivityMeta(
         commentsResp.data.some((c) => c.user?.type === 'User' && c.user.login !== authorLogin)
       : false;
 
+    // Full review history, newest last, capped so the cache doesn't grow
+    // unbounded on PRs with a long back-and-forth review trail.
+    const reviewsList = reviews
+      .filter((r) => r.user)
+      .sort((a, b) => new Date(a.submitted_at) - new Date(b.submitted_at))
+      .map((r) => ({ login: r.user.login, state: r.state, submittedAt: r.submitted_at }))
+      .slice(-30);
+
+    // Merged from both comment endpoints (issue comments + review comments).
+    // Only the mention logins are kept — the body itself is never persisted.
+    const comments = [...commentsResp.data, ...reviewCommentsResp.data]
+      .filter((c) => c.user)
+      .map((c) => ({
+        login: c.user.login,
+        createdAt: c.created_at,
+        isBot: isBotLogin(c.user.login, c.user.type),
+        mentions: extractMentions(c.body),
+      }))
+      .sort((a, b) => new Date(a.createdAt) - new Date(b.createdAt))
+      .slice(-30);
+
+    const reviewRequests = timeline
+      .filter((e) => e.event === 'review_requested')
+      .map((e) => ({
+        requestedReviewer: e.requested_reviewer?.login || e.requested_team?.name || null,
+        actor: e.actor?.login || e.review_requester?.login || null,
+        createdAt: e.created_at,
+      }))
+      .slice(-30);
+
     const baseActivity = {
       lastActor,
       isLastActorBot,
@@ -150,6 +190,9 @@ async function getPrActivityMeta(
       approvedBy,
       lastSubstantiveDate,
       hasHumanEngagement,
+      reviews: reviewsList,
+      comments,
+      reviewRequests,
     };
 
     // Explicit Substantive Activity Augmentation (the fix for review replies)


### PR DESCRIPTION
## Summary
- Widens the cached PR activity shape (reviews, comments with @-mentions, review requests, live requested reviewers, mergeable state, base ref, milestone) with zero additional API calls, gated behind a `schemaVersion` bump so the cache invalidates cleanly.
- Generalizes the merge engine's next-step derivations so every repo gets a specific reason (not just the tracker-covered Mautic docs repos): direct pings, changes-requested, no-reviewer-assigned, and merge conflicts.
- Adds linked-code-PR resolution (merged / closed / open) as a decisive next step, one extra request only for rows that carry a linked code PR.
- Adds a `pending-pr-merge` label reminder chip and milestone reminder, both scoped by an explicit repo list rather than inferred from field presence.
- Hardens both renderers (HTML grid + Markdown table) so longer next-step strings wrap cleanly without horizontal overflow or truncation.

## Test plan
- [x] `node --test scripts/services/workbench-merge.test.js` — full suite passing, including precedence order, milestone/label scoping, linked-PR states, and malformed-input degradation
- [x] Fresh `npm run build` against live data — workbench HTML and Markdown regenerate correctly, new detailed next-step wording appears on non-Mautic rows (e.g. `Virtual-Coffee/VC-Community-Docs`), no layout overflow

Generated data/output files are intentionally left out of this branch's commits.