### PR TITLE
fix: unify content-page headers and widen glossary layout

### DIFF
--- a/contributions/html-generated/glossary.html
+++ b/contributions/html-generated/glossary.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en" class="h-full">
   <head>
     <meta charset="UTF-8" />
@@ -12,22 +12,22 @@
     <script>
       (function () {
         try {
-          var mq = window.matchMedia('(prefers-color-scheme: dark)');
+          var mq = window.matchMedia("(prefers-color-scheme: dark)");
 
           function isDark() {
-            var stored = localStorage.getItem('theme'); // 'light' | 'dark' | null ('system')
-            if (stored === 'dark') return true;
-            if (stored === 'light') return false;
+            var stored = localStorage.getItem("theme"); // 'light' | 'dark' | null ('system')
+            if (stored === "dark") return true;
+            if (stored === "light") return false;
             return mq.matches;
           }
 
-          document.documentElement.classList.toggle('dark', isDark());
+          document.documentElement.classList.toggle("dark", isDark());
 
           // Re-reads localStorage on every change instead of caching it, so a
           // theme choice made via the navbar toggle (after this script ran)
           // is respected rather than overridden by a stale snapshot.
-          mq.addEventListener('change', function () {
-            document.documentElement.classList.toggle('dark', isDark());
+          mq.addEventListener("change", function () {
+            document.documentElement.classList.toggle("dark", isDark());
           });
         } catch (e) {}
       })();
@@ -37,7 +37,7 @@
       @custom-variant dark (&:where(.dark, .dark *));
     </style>
     <style>
-      @import url('https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap');
+      @import url("https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap");
       :root {
         --c-primary-hex: #232963;
         --c-primary-rgb: rgb(35, 41, 99);
@@ -297,8 +297,11 @@
         --t-neutral-wash: #e8e9eb;
         --t-neutral-line: #cbccd2;
         --t-neutral-strong: #424450;
-        --t-shadow: 0 1px 2px rgba(20, 20, 30, 0.05), 0 4px 16px rgba(20, 20, 30, 0.05);
-        --t-shadow-lg: 0 2px 4px rgba(20, 20, 30, 0.04), 0 22px 60px -24px rgba(35, 41, 99, 0.22);
+        --t-shadow:
+          0 1px 2px rgba(20, 20, 30, 0.05), 0 4px 16px rgba(20, 20, 30, 0.05);
+        --t-shadow-lg:
+          0 2px 4px rgba(20, 20, 30, 0.04),
+          0 22px 60px -24px rgba(35, 41, 99, 0.22);
       }
       html.dark {
         --t-surface: #11121d;
@@ -339,8 +342,10 @@
         --t-neutral-wash: #1f2131;
         --t-neutral-line: #3d3f4d;
         --t-neutral-strong: #85899c;
-        --t-shadow: 0 1px 2px rgba(0, 0, 0, 0.35), 0 4px 18px rgba(0, 0, 0, 0.3);
-        --t-shadow-lg: 0 2px 4px rgba(0, 0, 0, 0.4), 0 22px 60px -22px rgba(0, 0, 0, 0.6);
+        --t-shadow:
+          0 1px 2px rgba(0, 0, 0, 0.35), 0 4px 18px rgba(0, 0, 0, 0.3);
+        --t-shadow-lg:
+          0 2px 4px rgba(0, 0, 0, 0.4), 0 22px 60px -22px rgba(0, 0, 0, 0.6);
       }
       html,
       body {
@@ -357,7 +362,7 @@
          button on every page built from this base CSS. */
         overflow-x: hidden;
         position: relative;
-        font-family: 'Inter', sans-serif;
+        font-family: "Inter", sans-serif;
         min-height: 10vh;
         display: flex;
         flex-direction: column;
@@ -430,7 +435,8 @@
       /* The Block Code Look */
       .glossary-code-block {
         display: block;
-        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+        font-family:
+          ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
         background-color: var(--t-card-2);
         border: 1px solid var(--t-line);
       }
@@ -448,13 +454,13 @@
         padding: 0;
       }
 
-      /* Highlight the section when navigating via URL hash (#) */
+      /* Highlight the section when navigating via URL hash (#). Uses a
+       box-shadow halo rather than negative margin so the highlight can't
+       eat into a following section's spacing (e.g. on a last:mb-0 item). */
       :target {
         background-color: var(--t-brand-wash);
-        border-radius: 1rem;
         transition: background-color 0.5s ease;
-        padding: 1rem;
-        margin: -1rem;
+        box-shadow: 0 0 0 1rem var(--t-brand-wash);
         scroll-margin-top: 100px;
       }
 
@@ -513,13 +519,13 @@
      needs no separate "is accent configured" branch. .no-underline opts a
      link back out — for a card/tile where the whole multi-line block is the
      link, underlining it would draw a line under every line inside. */
-      a[target='_blank']:not(.no-underline) {
+      a[target="_blank"]:not(.no-underline) {
         text-decoration: underline;
         text-decoration-color: var(--t-accent-line);
         text-decoration-thickness: 2px;
         text-underline-offset: 3px;
       }
-      a[target='_blank']:not(.no-underline):hover {
+      a[target="_blank"]:not(.no-underline):hover {
         text-decoration-color: var(--t-accent);
       }
       .back-to-top {
@@ -566,7 +572,9 @@
       style="background-color: var(--c-primary-rgb); color: var(--t-on-nav)"
       class="fixed top-0 left-0 right-0 z-50 shadow-lg"
     >
-      <div class="mx-auto max-w-7xl h-16 flex items-center justify-between px-4 sm:px-6 lg:px-8">
+      <div
+        class="mx-auto max-w-7xl h-16 flex items-center justify-between px-4 sm:px-6 lg:px-8"
+      >
         <div class="flex items-center space-x-4">
           <a
             href="./index.html"
@@ -640,7 +648,10 @@
                 aria-expanded="false"
                 aria-label="Change theme"
               >
-                <span data-theme-icon-for="light" class="theme-dropdown-trigger-icon hidden">
+                <span
+                  data-theme-icon-for="light"
+                  class="theme-dropdown-trigger-icon hidden"
+                >
                   <svg
                     fill="none"
                     stroke="currentColor"
@@ -656,7 +667,10 @@
                       d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"
                     />
                   </svg> </span
-                ><span data-theme-icon-for="dark" class="theme-dropdown-trigger-icon hidden">
+                ><span
+                  data-theme-icon-for="dark"
+                  class="theme-dropdown-trigger-icon hidden"
+                >
                   <svg
                     fill="none"
                     stroke="currentColor"
@@ -669,7 +683,10 @@
                   >
                     <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
                   </svg> </span
-                ><span data-theme-icon-for="system" class="theme-dropdown-trigger-icon hidden">
+                ><span
+                  data-theme-icon-for="system"
+                  class="theme-dropdown-trigger-icon hidden"
+                >
                   <svg
                     fill="none"
                     stroke="currentColor"
@@ -711,7 +728,9 @@
                     </svg>
                   </span>
                   <span>Light</span>
-                  <span class="theme-dropdown-check" aria-hidden="true">✓</span></button
+                  <span class="theme-dropdown-check" aria-hidden="true"
+                    >✓</span
+                  ></button
                 ><button
                   type="button"
                   role="menuitemradio"
@@ -730,11 +749,15 @@
                       xmlns="http://www.w3.org/2000/svg"
                       aria-hidden="true"
                     >
-                      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+                      <path
+                        d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"
+                      />
                     </svg>
                   </span>
                   <span>Dark</span>
-                  <span class="theme-dropdown-check" aria-hidden="true">✓</span></button
+                  <span class="theme-dropdown-check" aria-hidden="true"
+                    >✓</span
+                  ></button
                 ><button
                   type="button"
                   role="menuitemradio"
@@ -867,7 +890,10 @@
               aria-expanded="false"
               aria-label="Change theme"
             >
-              <span data-theme-icon-for="light" class="theme-dropdown-trigger-icon hidden">
+              <span
+                data-theme-icon-for="light"
+                class="theme-dropdown-trigger-icon hidden"
+              >
                 <svg
                   fill="none"
                   stroke="currentColor"
@@ -883,7 +909,10 @@
                     d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"
                   />
                 </svg> </span
-              ><span data-theme-icon-for="dark" class="theme-dropdown-trigger-icon hidden">
+              ><span
+                data-theme-icon-for="dark"
+                class="theme-dropdown-trigger-icon hidden"
+              >
                 <svg
                   fill="none"
                   stroke="currentColor"
@@ -896,7 +925,10 @@
                 >
                   <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
                 </svg> </span
-              ><span data-theme-icon-for="system" class="theme-dropdown-trigger-icon hidden">
+              ><span
+                data-theme-icon-for="system"
+                class="theme-dropdown-trigger-icon hidden"
+              >
                 <svg
                   fill="none"
                   stroke="currentColor"
@@ -938,7 +970,9 @@
                   </svg>
                 </span>
                 <span>Light</span>
-                <span class="theme-dropdown-check" aria-hidden="true">✓</span></button
+                <span class="theme-dropdown-check" aria-hidden="true"
+                  >✓</span
+                ></button
               ><button
                 type="button"
                 role="menuitemradio"
@@ -961,7 +995,9 @@
                   </svg>
                 </span>
                 <span>Dark</span>
-                <span class="theme-dropdown-check" aria-hidden="true">✓</span></button
+                <span class="theme-dropdown-check" aria-hidden="true"
+                  >✓</span
+                ></button
               ><button
                 type="button"
                 role="menuitemradio"
@@ -993,79 +1029,95 @@
       </div>
 
       <script>
-        document.addEventListener('DOMContentLoaded', () => {
-          const button = document.getElementById('menu-button');
-          const menu = document.getElementById('mobile-menu');
-          const openIcon = document.getElementById('menu-open-icon');
-          const closeIcon = document.getElementById('menu-close-icon');
+        document.addEventListener("DOMContentLoaded", () => {
+          const button = document.getElementById("menu-button");
+          const menu = document.getElementById("mobile-menu");
+          const openIcon = document.getElementById("menu-open-icon");
+          const closeIcon = document.getElementById("menu-close-icon");
 
           if (button && menu) {
-            button.addEventListener('click', () => {
-              const isExpanded = button.getAttribute('aria-expanded') === 'true';
-              button.setAttribute('aria-expanded', String(!isExpanded));
-              menu.classList.toggle('hidden');
-              openIcon.classList.toggle('hidden', !isExpanded);
-              closeIcon.classList.toggle('hidden', isExpanded);
+            button.addEventListener("click", () => {
+              const isExpanded =
+                button.getAttribute("aria-expanded") === "true";
+              button.setAttribute("aria-expanded", String(!isExpanded));
+              menu.classList.toggle("hidden");
+              openIcon.classList.toggle("hidden", !isExpanded);
+              closeIcon.classList.toggle("hidden", isExpanded);
             });
           }
 
-          const dropdowns = document.querySelectorAll('[data-theme-dropdown]');
+          const dropdowns = document.querySelectorAll("[data-theme-dropdown]");
 
           function closeAllDropdowns(opts) {
             const returnFocus = Boolean(opts && opts.returnFocus);
             dropdowns.forEach((dropdown) => {
-              const trigger = dropdown.querySelector('.theme-dropdown-trigger');
-              const menu = dropdown.querySelector('.theme-dropdown-menu');
-              const wasOpen = !menu.classList.contains('hidden');
-              menu.classList.add('hidden');
-              trigger.setAttribute('aria-expanded', 'false');
+              const trigger = dropdown.querySelector(".theme-dropdown-trigger");
+              const menu = dropdown.querySelector(".theme-dropdown-menu");
+              const wasOpen = !menu.classList.contains("hidden");
+              menu.classList.add("hidden");
+              trigger.setAttribute("aria-expanded", "false");
               if (wasOpen && returnFocus) trigger.focus();
             });
           }
 
           function openDropdown(dropdown) {
-            const trigger = dropdown.querySelector('.theme-dropdown-trigger');
-            const menu = dropdown.querySelector('.theme-dropdown-menu');
+            const trigger = dropdown.querySelector(".theme-dropdown-trigger");
+            const menu = dropdown.querySelector(".theme-dropdown-menu");
             closeAllDropdowns();
-            menu.classList.remove('hidden');
-            trigger.setAttribute('aria-expanded', 'true');
-            const items = Array.from(dropdown.querySelectorAll('[data-theme-choice]'));
-            const checked = items.find((item) => item.getAttribute('aria-checked') === 'true');
+            menu.classList.remove("hidden");
+            trigger.setAttribute("aria-expanded", "true");
+            const items = Array.from(
+              dropdown.querySelectorAll("[data-theme-choice]"),
+            );
+            const checked = items.find(
+              (item) => item.getAttribute("aria-checked") === "true",
+            );
             (checked || items[0]).focus();
           }
 
           function setTheme(choice) {
-            if (choice === 'system') {
-              localStorage.removeItem('theme');
+            if (choice === "system") {
+              localStorage.removeItem("theme");
             } else {
-              localStorage.setItem('theme', choice);
+              localStorage.setItem("theme", choice);
             }
             const isDark =
-              choice === 'dark' ||
-              (choice === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches);
-            document.documentElement.classList.toggle('dark', isDark);
+              choice === "dark" ||
+              (choice === "system" &&
+                window.matchMedia("(prefers-color-scheme: dark)").matches);
+            document.documentElement.classList.toggle("dark", isDark);
             reflectActiveChoice();
           }
 
           function reflectActiveChoice() {
-            const current = localStorage.getItem('theme') || 'system';
+            const current = localStorage.getItem("theme") || "system";
             dropdowns.forEach((dropdown) => {
-              dropdown.querySelectorAll('[data-theme-icon-for]').forEach((icon) => {
-                icon.classList.toggle('hidden', icon.dataset.themeIconFor !== current);
-              });
-              dropdown.querySelectorAll('[data-theme-choice]').forEach((item) => {
-                item.setAttribute('aria-checked', String(item.dataset.themeChoice === current));
-              });
+              dropdown
+                .querySelectorAll("[data-theme-icon-for]")
+                .forEach((icon) => {
+                  icon.classList.toggle(
+                    "hidden",
+                    icon.dataset.themeIconFor !== current,
+                  );
+                });
+              dropdown
+                .querySelectorAll("[data-theme-choice]")
+                .forEach((item) => {
+                  item.setAttribute(
+                    "aria-checked",
+                    String(item.dataset.themeChoice === current),
+                  );
+                });
             });
           }
 
           dropdowns.forEach((dropdown) => {
-            const trigger = dropdown.querySelector('.theme-dropdown-trigger');
-            const menu = dropdown.querySelector('.theme-dropdown-menu');
+            const trigger = dropdown.querySelector(".theme-dropdown-trigger");
+            const menu = dropdown.querySelector(".theme-dropdown-menu");
 
-            trigger.addEventListener('click', (e) => {
+            trigger.addEventListener("click", (e) => {
               e.stopPropagation();
-              const isOpen = !menu.classList.contains('hidden');
+              const isOpen = !menu.classList.contains("hidden");
               if (isOpen) {
                 closeAllDropdowns();
               } else {
@@ -1073,44 +1125,46 @@
               }
             });
 
-            trigger.addEventListener('keydown', (e) => {
-              if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+            trigger.addEventListener("keydown", (e) => {
+              if (e.key === "ArrowDown" || e.key === "ArrowUp") {
                 e.preventDefault();
                 openDropdown(dropdown);
               }
             });
 
-            menu.addEventListener('keydown', (e) => {
-              const items = Array.from(dropdown.querySelectorAll('[data-theme-choice]'));
+            menu.addEventListener("keydown", (e) => {
+              const items = Array.from(
+                dropdown.querySelectorAll("[data-theme-choice]"),
+              );
               const currentIndex = items.indexOf(document.activeElement);
-              if (e.key === 'ArrowDown') {
+              if (e.key === "ArrowDown") {
                 e.preventDefault();
                 items[(currentIndex + 1) % items.length].focus();
-              } else if (e.key === 'ArrowUp') {
+              } else if (e.key === "ArrowUp") {
                 e.preventDefault();
                 items[(currentIndex - 1 + items.length) % items.length].focus();
-              } else if (e.key === 'Home') {
+              } else if (e.key === "Home") {
                 e.preventDefault();
                 items[0].focus();
-              } else if (e.key === 'End') {
+              } else if (e.key === "End") {
                 e.preventDefault();
                 items[items.length - 1].focus();
-              } else if (e.key === 'Tab') {
+              } else if (e.key === "Tab") {
                 closeAllDropdowns();
               }
             });
 
-            dropdown.querySelectorAll('[data-theme-choice]').forEach((item) => {
-              item.addEventListener('click', () => {
+            dropdown.querySelectorAll("[data-theme-choice]").forEach((item) => {
+              item.addEventListener("click", () => {
                 setTheme(item.dataset.themeChoice);
                 closeAllDropdowns({ returnFocus: true });
               });
             });
           });
 
-          document.addEventListener('click', () => closeAllDropdowns());
-          document.addEventListener('keydown', (e) => {
-            if (e.key === 'Escape') closeAllDropdowns({ returnFocus: true });
+          document.addEventListener("click", () => closeAllDropdowns());
+          document.addEventListener("keydown", (e) => {
+            if (e.key === "Escape") closeAllDropdowns({ returnFocus: true });
           });
 
           reflectActiveChoice();
@@ -1173,7 +1227,7 @@
           opacity 0.15s ease-in-out;
       }
       .theme-dropdown-trigger:hover,
-      .theme-dropdown-trigger[aria-expanded='true'] {
+      .theme-dropdown-trigger[aria-expanded="true"] {
         opacity: 1;
       }
       .theme-dropdown-trigger-icon svg {
@@ -1232,7 +1286,7 @@
         color: var(--c-primary-text);
         font-weight: 700;
       }
-      .theme-dropdown-item[aria-checked='true'] .theme-dropdown-check {
+      .theme-dropdown-item[aria-checked="true"] .theme-dropdown-check {
         opacity: 1;
       }
 
@@ -1247,35 +1301,303 @@
     <main id="main" class="grow w-full">
       <div class="px-6 sm:px-12 lg:px-16 xl:px-32 py-10">
         <div class="max-w-7xl mx-auto">
-          <header
-            style="border-bottom-color: var(--t-brand-line)"
-            class="text-center mt-16 mb-16 pb-12 border-b-2"
-          >
-            <h1 style="color: var(--t-brand)" class="text-4xl sm:text-6xl font-black mb-6 pt-8">
+          <header class="mt-16 mb-14">
+            <p
+              style="
+                font-family: ui-monospace, monospace;
+                font-size: 0.75rem;
+                letter-spacing: 0.14em;
+                text-transform: uppercase;
+                color: var(--t-ink-3);
+              "
+            >
+              glossary
+            </p>
+            <h1
+              class="text-4xl sm:text-5xl font-extrabold mt-2 mb-4"
+              style="color: var(--t-brand); letter-spacing: -0.01em"
+            >
               Glossary
             </h1>
-            <p class="text-xl max-w-3xl mx-auto leading-relaxed glossary-body">
-              Plain-English explanations of the terms used across this portfolio — what each one
-              means, and how it's worked out from the underlying GitHub activity.
+            <p class="text-lg max-w-3xl leading-relaxed glossary-body">
+              The terms used across this portfolio and how it's worked out from
+              the underlying GitHub activity.
             </p>
           </header>
-          <div class="max-w-[90ch] mx-auto">
+          <div class="lg:grid lg:grid-cols-[220px_1fr] lg:gap-12">
+            <nav
+              aria-label="Glossary sections"
+              class="glossary-toc mb-10 lg:mb-0 lg:sticky lg:top-8 lg:self-start lg:max-h-[calc(100vh-4rem)] lg:overflow-y-auto lg:pr-4"
+            >
+              <p
+                class="text-xs font-bold uppercase tracking-widest glossary-caption mb-3"
+              >
+                On this page
+              </p>
+              <ul class="space-y-4 text-sm">
+                <li>
+                  <a
+                    href="#portfolioWide"
+                    class="font-semibold"
+                    style="color: var(--t-brand)"
+                    >Portfolio-wide Metrics</a
+                  >
+                  <ul
+                    class="mt-2 space-y-1.5 pl-3 border-l"
+                    style="border-color: var(--t-line)"
+                  >
+                    <li>
+                      <a
+                        href="#totalImpact"
+                        class="block glossary-body hover:underline"
+                        >Total Impact</a
+                      >
+                    </li>
+                    <li>
+                      <a
+                        href="#shippedChanges"
+                        class="block glossary-body hover:underline"
+                        >Shipped Changes</a
+                      >
+                    </li>
+                    <li>
+                      <a
+                        href="#activeSince"
+                        class="block glossary-body hover:underline"
+                        >Active Since</a
+                      >
+                    </li>
+                    <li>
+                      <a
+                        href="#totalImpactedRepos"
+                        class="block glossary-body hover:underline"
+                        >Impacted Repos</a
+                      >
+                    </li>
+                    <li>
+                      <a
+                        href="#helpedShip"
+                        class="block glossary-body hover:underline"
+                        >Helped Ship</a
+                      >
+                    </li>
+                    <li>
+                      <a
+                        href="#primaryFocusProjects"
+                        class="block glossary-body hover:underline"
+                        >Primary Focus Projects</a
+                      >
+                    </li>
+                    <li>
+                      <a
+                        href="#persona"
+                        class="block glossary-body hover:underline"
+                        >Collaboration Profile</a
+                      >
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <a
+                    href="#journey"
+                    class="font-semibold"
+                    style="color: var(--t-brand)"
+                    >Journey</a
+                  >
+                  <ul
+                    class="mt-2 space-y-1.5 pl-3 border-l"
+                    style="border-color: var(--t-line)"
+                  >
+                    <li>
+                      <a
+                        href="#milestonesAwards"
+                        class="block glossary-body hover:underline"
+                        >Selected Work, Awards & Talks</a
+                      >
+                    </li>
+                    <li>
+                      <a
+                        href="#expertise"
+                        class="block glossary-body hover:underline"
+                        >Expertise, Tools & Skills</a
+                      >
+                    </li>
+                    <li>
+                      <a
+                        href="#advocacyRoles"
+                        class="block glossary-body hover:underline"
+                        >Experience & Roles</a
+                      >
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <a
+                    href="#workbench"
+                    class="font-semibold"
+                    style="color: var(--t-brand)"
+                    >Active Workbench</a
+                  >
+                  <ul
+                    class="mt-2 space-y-1.5 pl-3 border-l"
+                    style="border-color: var(--t-line)"
+                  >
+                    <li>
+                      <a
+                        href="#activeWorkbench"
+                        class="block glossary-body hover:underline"
+                        >Board & Lanes</a
+                      >
+                    </li>
+                    <li>
+                      <a
+                        href="#workbenchStatus"
+                        class="block glossary-body hover:underline"
+                        >Workbench Status & Ball Tracking</a
+                      >
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <a
+                    href="#writing"
+                    class="font-semibold"
+                    style="color: var(--t-brand)"
+                    >Writing</a
+                  >
+                  <ul
+                    class="mt-2 space-y-1.5 pl-3 border-l"
+                    style="border-color: var(--t-line)"
+                  >
+                    <li>
+                      <a
+                        href="#recognitions"
+                        class="block glossary-body hover:underline"
+                        >Recognitions</a
+                      >
+                    </li>
+                    <li>
+                      <a
+                        href="#articles"
+                        class="block glossary-body hover:underline"
+                        >Articles Written</a
+                      >
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <a
+                    href="#quarterlyReports"
+                    class="font-semibold"
+                    style="color: var(--t-brand)"
+                    >Quarterly Reports</a
+                  >
+                  <ul
+                    class="mt-2 space-y-1.5 pl-3 border-l"
+                    style="border-color: var(--t-line)"
+                  >
+                    <li>
+                      <a
+                        href="#reportsIndex"
+                        class="block glossary-body hover:underline"
+                        >Reports Index</a
+                      >
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <a
+                    href="#quarterlyMetrics"
+                    class="font-semibold"
+                    style="color: var(--t-brand)"
+                    >Quarterly Report Metrics</a
+                  >
+                  <ul
+                    class="mt-2 space-y-1.5 pl-3 border-l"
+                    style="border-color: var(--t-line)"
+                  >
+                    <li>
+                      <a
+                        href="#quarterInBrief"
+                        class="block glossary-body hover:underline"
+                        >Quarter in brief</a
+                      >
+                    </li>
+                    <li>
+                      <a
+                        href="#stats"
+                        class="block glossary-body hover:underline"
+                        >Quarterly Statistics</a
+                      >
+                    </li>
+                    <li>
+                      <a
+                        href="#focusProjects"
+                        class="block glossary-body hover:underline"
+                        >Top 3 Repositories</a
+                      >
+                    </li>
+                    <li>
+                      <a
+                        href="#merged"
+                        class="block glossary-body hover:underline"
+                        >Merged PRs</a
+                      >
+                    </li>
+                    <li>
+                      <a
+                        href="#issues"
+                        class="block glossary-body hover:underline"
+                        >Issues</a
+                      >
+                    </li>
+                    <li>
+                      <a
+                        href="#reviewed"
+                        class="block glossary-body hover:underline"
+                        >Reviewed PRs</a
+                      >
+                    </li>
+                    <li>
+                      <a
+                        href="#coAuthored"
+                        class="block glossary-body hover:underline"
+                        >Co-authored PRs</a
+                      >
+                    </li>
+                    <li>
+                      <a
+                        href="#collaborations"
+                        class="block glossary-body hover:underline"
+                        >Collaborations</a
+                      >
+                    </li>
+                  </ul>
+                </li>
+              </ul>
+            </nav>
             <article class="glossary-content">
               <div class="metrics-container">
                 <section id="portfolioWide" class="mb-24 last:mb-0">
                   <div class="mb-10">
-                    <h2 style="color: var(--t-brand)" class="text-3xl sm:text-4xl font-black mb-2">
+                    <h2
+                      style="color: var(--t-brand)"
+                      class="text-3xl sm:text-4xl font-black mb-2"
+                    >
                       Portfolio-wide Metrics
                     </h2>
                     <p class="glossary-caption text-lg font-medium italic">
-                      Terms for the numbers that sum up all the open source work shown here, from
-                      the very first contribution to now.
+                      Terms for the numbers that sum up all the open source work
+                      shown here, from the very first contribution to now.
                     </p>
                   </div>
                   <div class="space-y-2">
                     <div id="totalImpact" class="mb-16 last:mb-0">
                       <h3
-                        style="color: var(--t-brand); border-bottom: 2px solid var(--t-brand-line)"
+                        style="
+                          color: var(--t-brand);
+                          border-bottom: 2px solid var(--t-brand-line);
+                        "
                         class="text-xl font-extrabold mb-6 pb-2 inline-block"
                       >
                         Total Impact
@@ -1283,26 +1605,32 @@
 
                       <div class="space-y-6">
                         <p class="text-lg glossary-body leading-relaxed">
-                          Every contribution counted together, going back to the very first one on
-                          GitHub.
+                          Every contribution counted together, going back to the
+                          very first one on GitHub.
                         </p>
 
-                        <div class="glossary-code-block p-6 overflow-x-auto rounded-2xl">
+                        <div
+                          class="glossary-code-block p-6 overflow-x-auto rounded-2xl"
+                        >
                           <span
                             class="block text-xs uppercase tracking-widest glossary-caption mb-3 font-black font-mono"
                           >
                             How it’s worked out
                           </span>
                           <div class="text-sm glossary-accent leading-relaxed">
-                            Adds up merged pull requests, issues, reviewed pull requests,
-                            co-authored pull requests, and collaborations.
+                            Adds up merged pull requests, issues, reviewed pull
+                            requests, co-authored pull requests, and
+                            collaborations.
                           </div>
                         </div>
                       </div>
                     </div>
                     <div id="shippedChanges" class="mb-16 last:mb-0">
                       <h3
-                        style="color: var(--t-brand); border-bottom: 2px solid var(--t-brand-line)"
+                        style="
+                          color: var(--t-brand);
+                          border-bottom: 2px solid var(--t-brand-line);
+                        "
                         class="text-xl font-extrabold mb-6 pb-2 inline-block"
                       >
                         Shipped Changes
@@ -1310,19 +1638,22 @@
 
                       <div class="space-y-6">
                         <p class="text-lg glossary-body leading-relaxed">
-                          How many of those contributions were actually finished and accepted — not
-                          just opened.
+                          How many of those contributions were actually finished
+                          and accepted — not just opened.
                         </p>
 
-                        <div class="glossary-code-block p-6 overflow-x-auto rounded-2xl">
+                        <div
+                          class="glossary-code-block p-6 overflow-x-auto rounded-2xl"
+                        >
                           <span
                             class="block text-xs uppercase tracking-widest glossary-caption mb-3 font-black font-mono"
                           >
                             How it’s worked out
                           </span>
                           <div class="text-sm glossary-accent leading-relaxed">
-                            Counts only the contributions GitHub marked as merged. Total Impact also
-                            includes work that's still open, so this number is smaller — it's what's
+                            Counts only the contributions GitHub marked as
+                            merged. Total Impact also includes work that's still
+                            open, so this number is smaller — it's what's
                             actually done.
                           </div>
                         </div>
@@ -1330,7 +1661,10 @@
                     </div>
                     <div id="activeSince" class="mb-16 last:mb-0">
                       <h3
-                        style="color: var(--t-brand); border-bottom: 2px solid var(--t-brand-line)"
+                        style="
+                          color: var(--t-brand);
+                          border-bottom: 2px solid var(--t-brand-line);
+                        "
                         class="text-xl font-extrabold mb-6 pb-2 inline-block"
                       >
                         Active Since
@@ -1338,25 +1672,31 @@
 
                       <div class="space-y-6">
                         <p class="text-lg glossary-body leading-relaxed">
-                          The year of the very first recorded contribution on GitHub.
+                          The year of the very first recorded contribution on
+                          GitHub.
                         </p>
 
-                        <div class="glossary-code-block p-6 overflow-x-auto rounded-2xl">
+                        <div
+                          class="glossary-code-block p-6 overflow-x-auto rounded-2xl"
+                        >
                           <span
                             class="block text-xs uppercase tracking-widest glossary-caption mb-3 font-black font-mono"
                           >
                             How it’s worked out
                           </span>
                           <div class="text-sm glossary-accent leading-relaxed">
-                            Finds the earliest contribution in the data and uses its year as the
-                            starting point.
+                            Finds the earliest contribution in the data and uses
+                            its year as the starting point.
                           </div>
                         </div>
                       </div>
                     </div>
                     <div id="totalImpactedRepos" class="mb-16 last:mb-0">
                       <h3
-                        style="color: var(--t-brand); border-bottom: 2px solid var(--t-brand-line)"
+                        style="
+                          color: var(--t-brand);
+                          border-bottom: 2px solid var(--t-brand-line);
+                        "
                         class="text-xl font-extrabold mb-6 pb-2 inline-block"
                       >
                         Impacted Repos
@@ -1364,27 +1704,33 @@
 
                       <div class="space-y-6">
                         <p class="text-lg glossary-body leading-relaxed">
-                          How many different projects are represented here, and how many
-                          organizations those projects belong to.
+                          How many different projects are represented here, and
+                          how many organizations those projects belong to.
                         </p>
 
-                        <div class="glossary-code-block p-6 overflow-x-auto rounded-2xl">
+                        <div
+                          class="glossary-code-block p-6 overflow-x-auto rounded-2xl"
+                        >
                           <span
                             class="block text-xs uppercase tracking-widest glossary-caption mb-3 font-black font-mono"
                           >
                             How it’s worked out
                           </span>
                           <div class="text-sm glossary-accent leading-relaxed">
-                            Counts every different external repo with at least one recorded
-                            contribution. A project's organization is whoever owns the repo — the
-                            "octocat" in octocat/Hello-World, for example.
+                            Counts every different external repo with at least
+                            one recorded contribution. A project's organization
+                            is whoever owns the repo — the "octocat" in
+                            octocat/Hello-World, for example.
                           </div>
                         </div>
                       </div>
                     </div>
                     <div id="helpedShip" class="mb-16 last:mb-0">
                       <h3
-                        style="color: var(--t-brand); border-bottom: 2px solid var(--t-brand-line)"
+                        style="
+                          color: var(--t-brand);
+                          border-bottom: 2px solid var(--t-brand-line);
+                        "
                         class="text-xl font-extrabold mb-6 pb-2 inline-block"
                       >
                         Helped Ship
@@ -1392,27 +1738,34 @@
 
                       <div class="space-y-6">
                         <p class="text-lg glossary-body leading-relaxed">
-                          How many reviewed or co-authored pull requests actually got merged — work
-                          that helped someone else's contribution land, not solo PRs.
+                          How many reviewed or co-authored pull requests
+                          actually got merged — work that helped someone else's
+                          contribution land, not solo PRs.
                         </p>
 
-                        <div class="glossary-code-block p-6 overflow-x-auto rounded-2xl">
+                        <div
+                          class="glossary-code-block p-6 overflow-x-auto rounded-2xl"
+                        >
                           <span
                             class="block text-xs uppercase tracking-widest glossary-caption mb-3 font-black font-mono"
                           >
                             How it’s worked out
                           </span>
                           <div class="text-sm glossary-accent leading-relaxed">
-                            Counts every reviewed or co-authored pull request that got merged,
-                            across the full contribution history. One that's still open, or was
-                            closed without merging, doesn't count yet.
+                            Counts every reviewed or co-authored pull request
+                            that got merged, across the full contribution
+                            history. One that's still open, or was closed
+                            without merging, doesn't count yet.
                           </div>
                         </div>
                       </div>
                     </div>
                     <div id="primaryFocusProjects" class="mb-16 last:mb-0">
                       <h3
-                        style="color: var(--t-brand); border-bottom: 2px solid var(--t-brand-line)"
+                        style="
+                          color: var(--t-brand);
+                          border-bottom: 2px solid var(--t-brand-line);
+                        "
                         class="text-xl font-extrabold mb-6 pb-2 inline-block"
                       >
                         Primary Focus Projects
@@ -1420,25 +1773,31 @@
 
                       <div class="space-y-6">
                         <p class="text-lg glossary-body leading-relaxed">
-                          The three projects with the most contributions, over the full history.
+                          The three projects with the most contributions, over
+                          the full history.
                         </p>
 
-                        <div class="glossary-code-block p-6 overflow-x-auto rounded-2xl">
+                        <div
+                          class="glossary-code-block p-6 overflow-x-auto rounded-2xl"
+                        >
                           <span
                             class="block text-xs uppercase tracking-widest glossary-caption mb-3 font-black font-mono"
                           >
                             How it’s worked out
                           </span>
                           <div class="text-sm glossary-accent leading-relaxed">
-                            Sorts every tracked repo by how many contributions it has, and picks the
-                            top three.
+                            Sorts every tracked repo by how many contributions
+                            it has, and picks the top three.
                           </div>
                         </div>
                       </div>
                     </div>
                     <div id="persona" class="mb-16 last:mb-0">
                       <h3
-                        style="color: var(--t-brand); border-bottom: 2px solid var(--t-brand-line)"
+                        style="
+                          color: var(--t-brand);
+                          border-bottom: 2px solid var(--t-brand-line);
+                        "
                         class="text-xl font-extrabold mb-6 pb-2 inline-block"
                       >
                         Collaboration Profile
@@ -1446,19 +1805,23 @@
 
                       <div class="space-y-6">
                         <p class="text-lg glossary-body leading-relaxed">
-                          A label for the primary way of contributing to the community.
+                          A label for the primary way of contributing to the
+                          community.
                         </p>
 
-                        <div class="glossary-code-block p-6 overflow-x-auto rounded-2xl">
+                        <div
+                          class="glossary-code-block p-6 overflow-x-auto rounded-2xl"
+                        >
                           <span
                             class="block text-xs uppercase tracking-widest glossary-caption mb-3 font-black font-mono"
                           >
                             How it’s worked out
                           </span>
                           <div class="text-sm glossary-accent leading-relaxed">
-                            Looks at contribution frequency across every category, then picks the
-                            label that fits best — for example, "Community Mentor" for a high volume
-                            of reviews.
+                            Looks at contribution frequency across every
+                            category, then picks the label that fits best — for
+                            example, "Community Mentor" for a high volume of
+                            reviews.
                           </div>
                         </div>
                       </div>
@@ -1467,18 +1830,24 @@
                 </section>
                 <section id="journey" class="mb-24 last:mb-0">
                   <div class="mb-10">
-                    <h2 style="color: var(--t-brand)" class="text-3xl sm:text-4xl font-black mb-2">
+                    <h2
+                      style="color: var(--t-brand)"
+                      class="text-3xl sm:text-4xl font-black mb-2"
+                    >
                       Journey
                     </h2>
                     <p class="glossary-caption text-lg font-medium italic">
-                      Terms used on the Journey page — selected work, talks, expertise, and the
-                      roles behind them.
+                      Terms used on the Journey page — selected work, talks,
+                      expertise, and the roles behind them.
                     </p>
                   </div>
                   <div class="space-y-2">
                     <div id="milestonesAwards" class="mb-16 last:mb-0">
                       <h3
-                        style="color: var(--t-brand); border-bottom: 2px solid var(--t-brand-line)"
+                        style="
+                          color: var(--t-brand);
+                          border-bottom: 2px solid var(--t-brand-line);
+                        "
                         class="text-xl font-extrabold mb-6 pb-2 inline-block"
                       >
                         Selected Work, Awards & Talks
@@ -1486,27 +1855,33 @@
 
                       <div class="space-y-6">
                         <p class="text-lg glossary-body leading-relaxed">
-                          A showcase of notable work and recognition within the open source
-                          community, on one continuous timeline.
+                          A showcase of notable work and recognition within the
+                          open source community, on one continuous timeline.
                         </p>
 
-                        <div class="glossary-code-block p-6 overflow-x-auto rounded-2xl">
+                        <div
+                          class="glossary-code-block p-6 overflow-x-auto rounded-2xl"
+                        >
                           <span
                             class="block text-xs uppercase tracking-widest glossary-caption mb-3 font-black font-mono"
                           >
                             How it’s added
                           </span>
                           <div class="text-sm glossary-accent leading-relaxed">
-                            Each one is added manually. What can be found here: awards, courses and
-                            certifications, projects, documentation work, talks, and videos — each
-                            one tagged for quick identification.
+                            Each one is added manually. What can be found here:
+                            awards, courses and certifications, projects,
+                            documentation work, talks, and videos — each one
+                            tagged for quick identification.
                           </div>
                         </div>
                       </div>
                     </div>
                     <div id="expertise" class="mb-16 last:mb-0">
                       <h3
-                        style="color: var(--t-brand); border-bottom: 2px solid var(--t-brand-line)"
+                        style="
+                          color: var(--t-brand);
+                          border-bottom: 2px solid var(--t-brand-line);
+                        "
                         class="text-xl font-extrabold mb-6 pb-2 inline-block"
                       >
                         Expertise, Tools & Skills
@@ -1514,29 +1889,37 @@
 
                       <div class="space-y-6">
                         <p class="text-lg glossary-body leading-relaxed">
-                          The skill areas behind the work, plus the tools and languages used to do
-                          it. No self-rated skill bars — the rest of the portfolio is the proof.
+                          The skill areas behind the work, plus the tools and
+                          languages used to do it. No self-rated skill bars —
+                          the rest of the portfolio is the proof.
                         </p>
 
-                        <div class="glossary-code-block p-6 overflow-x-auto rounded-2xl">
+                        <div
+                          class="glossary-code-block p-6 overflow-x-auto rounded-2xl"
+                        >
                           <span
                             class="block text-xs uppercase tracking-widest glossary-caption mb-3 font-black font-mono"
                           >
                             How it’s added
                           </span>
                           <div class="text-sm glossary-accent leading-relaxed">
-                            Expertise areas are entered manually in a contents file, each with a
-                            title and a short blurb. Tools and skills each show as their own list,
-                            but only if there's something in it — an empty list just doesn't show,
-                            heading and all. A few entries can be marked to stand out (bold, in the
-                            accent color) to call out the two or three that matter most.
+                            Expertise areas are entered manually in a contents
+                            file, each with a title and a short blurb. Tools and
+                            skills each show as their own list, but only if
+                            there's something in it — an empty list just doesn't
+                            show, heading and all. A few entries can be marked
+                            to stand out (bold, in the accent color) to call out
+                            the two or three that matter most.
                           </div>
                         </div>
                       </div>
                     </div>
                     <div id="advocacyRoles" class="mb-16 last:mb-0">
                       <h3
-                        style="color: var(--t-brand); border-bottom: 2px solid var(--t-brand-line)"
+                        style="
+                          color: var(--t-brand);
+                          border-bottom: 2px solid var(--t-brand-line);
+                        "
                         class="text-xl font-extrabold mb-6 pb-2 inline-block"
                       >
                         Experience & Roles
@@ -1544,20 +1927,23 @@
 
                       <div class="space-y-6">
                         <p class="text-lg glossary-body leading-relaxed">
-                          A record of official roles held within open source organizations.
+                          A record of official roles held within open source
+                          organizations.
                         </p>
 
-                        <div class="glossary-code-block p-6 overflow-x-auto rounded-2xl">
+                        <div
+                          class="glossary-code-block p-6 overflow-x-auto rounded-2xl"
+                        >
                           <span
                             class="block text-xs uppercase tracking-widest glossary-caption mb-3 font-black font-mono"
                           >
                             How it’s added
                           </span>
                           <div class="text-sm glossary-accent leading-relaxed">
-                            Each role is added by hand in a contents file, along with its dates.
-                            Whether it shows as
-                            <strong>Active</strong> or <strong>Past</strong> is worked out
-                            automatically from those dates.
+                            Each role is added by hand in a contents file, along
+                            with its dates. Whether it shows as
+                            <strong>Active</strong> or <strong>Past</strong> is
+                            worked out automatically from those dates.
                           </div>
                         </div>
                       </div>
@@ -1566,18 +1952,24 @@
                 </section>
                 <section id="workbench" class="mb-24 last:mb-0">
                   <div class="mb-10">
-                    <h2 style="color: var(--t-brand)" class="text-3xl sm:text-4xl font-black mb-2">
+                    <h2
+                      style="color: var(--t-brand)"
+                      class="text-3xl sm:text-4xl font-black mb-2"
+                    >
                       Active Workbench
                     </h2>
                     <p class="glossary-caption text-lg font-medium italic">
-                      Terms used on the Active Workbench page — the live board of maintainer and
-                      contribution work in progress.
+                      Terms used on the Active Workbench page — the live board
+                      of maintainer and contribution work in progress.
                     </p>
                   </div>
                   <div class="space-y-2">
                     <div id="activeWorkbench" class="mb-16 last:mb-0">
                       <h3
-                        style="color: var(--t-brand); border-bottom: 2px solid var(--t-brand-line)"
+                        style="
+                          color: var(--t-brand);
+                          border-bottom: 2px solid var(--t-brand-line);
+                        "
                         class="text-xl font-extrabold mb-6 pb-2 inline-block"
                       >
                         Board & Lanes
@@ -1585,57 +1977,78 @@
 
                       <div class="space-y-6">
                         <p class="text-lg glossary-body leading-relaxed">
-                          A live board of work in progress, organized by what happens next.
+                          A live board of work in progress, organized by what
+                          happens next.
                         </p>
 
-                        <div class="glossary-code-block p-6 overflow-x-auto rounded-2xl">
+                        <div
+                          class="glossary-code-block p-6 overflow-x-auto rounded-2xl"
+                        >
                           <span
                             class="block text-xs uppercase tracking-widest glossary-caption mb-3 font-black font-mono"
                           >
                             How it’s added
                           </span>
                           <div class="text-sm glossary-accent leading-relaxed">
-                            Open pull requests, assigned issues, and review requests are pulled
-                            together with live status updates into one board, then sorted into five
-                            lanes, ordered by what happens next:
+                            Open pull requests, assigned issues, and review
+                            requests are pulled together with live status
+                            updates into one board, then sorted into five lanes,
+                            ordered by what happens next:
                             <ul class="my-3 space-y-1 glossary-accent">
-                              <li class="ml-4 list-disc list-inside glossary-accent">
-                                <strong>Needs your action:</strong> Feedback to address, a review
-                                still pending, or a note left after approval.
+                              <li
+                                class="ml-4 list-disc list-inside glossary-accent"
+                              >
+                                <strong>Needs your action:</strong> Feedback to
+                                address, a review still pending, or a note left
+                                after approval.
                               </li>
                             </ul>
                             <ul class="my-3 space-y-1 glossary-accent">
-                              <li class="ml-4 list-disc list-inside glossary-accent">
+                              <li
+                                class="ml-4 list-disc list-inside glossary-accent"
+                              >
                                 <strong>Approved — bring it home:</strong>
-                                Reviewed and approved, but not shipped yet — something still needs
-                                to happen first, like a final check or a reminder to a maintainer.
+                                Reviewed and approved, but not shipped yet —
+                                something still needs to happen first, like a
+                                final check or a reminder to a maintainer.
                               </li>
                             </ul>
                             <ul class="my-3 space-y-1 glossary-accent">
-                              <li class="ml-4 list-disc list-inside glossary-accent">
-                                <strong>Waiting on others:</strong> That side of the work is done —
-                                awaiting review, or blocked on a linked code PR.
+                              <li
+                                class="ml-4 list-disc list-inside glossary-accent"
+                              >
+                                <strong>Waiting on others:</strong> That side of
+                                the work is done — awaiting review, or blocked
+                                on a linked code PR.
                               </li>
                             </ul>
                             <ul class="my-3 space-y-1 glossary-accent">
-                              <li class="ml-4 list-disc list-inside glossary-accent">
-                                <strong>Stalled · 30+ days:</strong> No movement in a month — each
-                                needs a decision: nudge or close.
+                              <li
+                                class="ml-4 list-disc list-inside glossary-accent"
+                              >
+                                <strong>Stalled · 30+ days:</strong> No movement
+                                in a month — each needs a decision: nudge or
+                                close.
                               </li>
                             </ul>
                             <ul class="my-3 space-y-1 glossary-accent">
-                              <li class="ml-4 list-disc list-inside glossary-accent">
-                                <strong>Automated:</strong> Automatic updates from bots, like
-                                routine dependency or security updates — grouped together and kept
-                                out of the way.
+                              <li
+                                class="ml-4 list-disc list-inside glossary-accent"
+                              >
+                                <strong>Automated:</strong> Automatic updates
+                                from bots, like routine dependency or security
+                                updates — grouped together and kept out of the
+                                way.
                               </li>
                             </ul>
-                            Only open items are shown; they're removed once they're merged or
-                            closed. An empty board reads "Your court is clear" — a good sign, not an
-                            error.<br /><br />A freshness badge in the header reads "Updated Xh ago"
-                            (or "Updated just now" / "Updated yesterday") when the board's data
-                            loaded live, and "cached · Nd old" when that data isn't available right
-                            now and the board is showing the last good saved copy — a banner
+                            Only open items are shown; they're removed once
+                            they're merged or closed. An empty board reads "Your
+                            court is clear" — a good sign, not an error.<br /><br />A
+                            freshness badge in the header reads "Updated Xh ago"
+                            (or "Updated just now" / "Updated yesterday") when
+                            the board's data loaded live, and "cached · Nd old"
+                            when that data isn't available right now and the
+                            board is showing the last good saved copy — a banner
                             explains why whenever that happens.
                           </div>
                         </div>
@@ -1643,7 +2056,10 @@
                     </div>
                     <div id="workbenchStatus" class="mb-16 last:mb-0">
                       <h3
-                        style="color: var(--t-brand); border-bottom: 2px solid var(--t-brand-line)"
+                        style="
+                          color: var(--t-brand);
+                          border-bottom: 2px solid var(--t-brand-line);
+                        "
                         class="text-xl font-extrabold mb-6 pb-2 inline-block"
                       >
                         Workbench Status & Ball Tracking
@@ -1651,72 +2067,98 @@
 
                       <div class="space-y-6">
                         <p class="text-lg glossary-body leading-relaxed">
-                          A badge on each row showing whose turn it is, whether it's a draft, and
-                          how long it's been waiting.
+                          A badge on each row showing whose turn it is, whether
+                          it's a draft, and how long it's been waiting.
                         </p>
 
-                        <div class="glossary-code-block p-6 overflow-x-auto rounded-2xl">
+                        <div
+                          class="glossary-code-block p-6 overflow-x-auto rounded-2xl"
+                        >
                           <span
                             class="block text-xs uppercase tracking-widest glossary-caption mb-3 font-black font-mono"
                           >
                             How it’s added
                           </span>
                           <div class="text-sm glossary-accent leading-relaxed">
-                            Each task carries a "ball" badge showing whose move it is:
+                            Each task carries a "ball" badge showing whose move
+                            it is:
                             <ul class="my-3 space-y-1 glossary-accent">
-                              <li class="ml-4 list-disc list-inside glossary-accent">
-                                <strong>Take Action:</strong> New feedback to address, a requested
-                                review, or a reply that needs an answer.
+                              <li
+                                class="ml-4 list-disc list-inside glossary-accent"
+                              >
+                                <strong>Take Action:</strong> New feedback to
+                                address, a requested review, or a reply that
+                                needs an answer.
                               </li>
                             </ul>
                             <ul class="my-3 space-y-1 glossary-accent">
-                              <li class="ml-4 list-disc list-inside glossary-accent">
-                                <strong>To Write:</strong> An issue that's assigned, with no pull
-                                request opened yet.
+                              <li
+                                class="ml-4 list-disc list-inside glossary-accent"
+                              >
+                                <strong>To Write:</strong> An issue that's
+                                assigned, with no pull request opened yet.
                               </li>
                             </ul>
                             <ul class="my-3 space-y-1 glossary-accent">
-                              <li class="ml-4 list-disc list-inside glossary-accent">
-                                <strong>Approved:</strong> The PR has a formal approval and is
-                                heading toward merge. An approval dismissed after a later push still
-                                counts — its note names the approver and adds "dismissed after
-                                update", asking for a fresh look rather than a from-scratch
-                                re-review.
+                              <li
+                                class="ml-4 list-disc list-inside glossary-accent"
+                              >
+                                <strong>Approved:</strong> The PR has a formal
+                                approval and is heading toward merge. An
+                                approval dismissed after a later push still
+                                counts — its note names the approver and adds
+                                "dismissed after update", asking for a fresh
+                                look rather than a from-scratch re-review.
                               </li>
                             </ul>
                             <ul class="my-3 space-y-1 glossary-accent">
-                              <li class="ml-4 list-disc list-inside glossary-accent">
-                                <strong>Watching:</strong> The ball is with another maintainer or
-                                contributor; participation continues in the background.
+                              <li
+                                class="ml-4 list-disc list-inside glossary-accent"
+                              >
+                                <strong>Watching:</strong> The ball is with
+                                another maintainer or contributor; participation
+                                continues in the background.
                               </li>
                             </ul>
                             <ul class="my-3 space-y-1 glossary-accent">
-                              <li class="ml-4 list-disc list-inside glossary-accent">
-                                <strong>Waiting:</strong> That side of the work is done, and the row
-                                is idle by design — a draft not yet marked ready, or work blocked on
+                              <li
+                                class="ml-4 list-disc list-inside glossary-accent"
+                              >
+                                <strong>Waiting:</strong> That side of the work
+                                is done, and the row is idle by design — a draft
+                                not yet marked ready, or work blocked on someone
+                                else.
+                              </li>
+                            </ul>
+                            <ul class="my-3 space-y-1 glossary-accent">
+                              <li
+                                class="ml-4 list-disc list-inside glossary-accent"
+                              >
+                                <strong>Stale:</strong> No real activity for 30+
+                                days on a row where the next move belongs to
                                 someone else.
                               </li>
                             </ul>
                             <ul class="my-3 space-y-1 glossary-accent">
-                              <li class="ml-4 list-disc list-inside glossary-accent">
-                                <strong>Stale:</strong> No real activity for 30+ days on a row where
-                                the next move belongs to someone else.
+                              <li
+                                class="ml-4 list-disc list-inside glossary-accent"
+                              >
+                                <strong>Bot:</strong> An automatic update to a
+                                dependency or security patch, submitted by a
+                                bot, kept in its own lane.
                               </li>
                             </ul>
-                            <ul class="my-3 space-y-1 glossary-accent">
-                              <li class="ml-4 list-disc list-inside glossary-accent">
-                                <strong>Bot:</strong> An automatic update to a dependency or
-                                security patch, submitted by a bot, kept in its own lane.
-                              </li>
-                            </ul>
-                            A <strong>Draft</strong> chip marks a pull request still in draft state.
-                            <strong>The day count</strong> shown next to a Stalled (or otherwise
-                            long-idle) badge is the time since the last real update.<br /><br /><strong
+                            A <strong>Draft</strong> chip marks a pull request
+                            still in draft state.
+                            <strong>The day count</strong> shown next to a
+                            Stalled (or otherwise long-idle) badge is the time
+                            since the last real update.<br /><br /><strong
                               >Note on Timers:</strong
                             >
-                            "Idle" ignores noise such as labels, reviewer pings, or base-branch
-                            merges. The clock only resets on a new commit, a code review (human or
-                            bot), or a discussion comment.
+                            "Idle" ignores noise such as labels, reviewer pings,
+                            or base-branch merges. The clock only resets on a
+                            new commit, a code review (human or bot), or a
+                            discussion comment.
                           </div>
                         </div>
                       </div>
@@ -1725,18 +2167,24 @@
                 </section>
                 <section id="writing" class="mb-24 last:mb-0">
                   <div class="mb-10">
-                    <h2 style="color: var(--t-brand)" class="text-3xl sm:text-4xl font-black mb-2">
+                    <h2
+                      style="color: var(--t-brand)"
+                      class="text-3xl sm:text-4xl font-black mb-2"
+                    >
                       Writing
                     </h2>
                     <p class="glossary-caption text-lg font-medium italic">
-                      Terms used on the Writing page, covering recognitions and published articles
-                      and how they are grouped.
+                      Terms used on the Writing page, covering recognitions and
+                      published articles and how they are grouped.
                     </p>
                   </div>
                   <div class="space-y-2">
                     <div id="recognitions" class="mb-16 last:mb-0">
                       <h3
-                        style="color: var(--t-brand); border-bottom: 2px solid var(--t-brand-line)"
+                        style="
+                          color: var(--t-brand);
+                          border-bottom: 2px solid var(--t-brand-line);
+                        "
                         class="text-xl font-extrabold mb-6 pb-2 inline-block"
                       >
                         Recognitions
@@ -1744,28 +2192,34 @@
 
                       <div class="space-y-6">
                         <p class="text-lg glossary-body leading-relaxed">
-                          External recognition for individual pieces of writing — top-of-the-week
-                          picks, challenge wins, and similar mentions. Shown at the top of the page,
-                          above the article lists, and only when at least one exists.
+                          External recognition for individual pieces of writing
+                          — top-of-the-week picks, challenge wins, and similar
+                          mentions. Shown at the top of the page, above the
+                          article lists, and only when at least one exists.
                         </p>
 
-                        <div class="glossary-code-block p-6 overflow-x-auto rounded-2xl">
+                        <div
+                          class="glossary-code-block p-6 overflow-x-auto rounded-2xl"
+                        >
                           <span
                             class="block text-xs uppercase tracking-widest glossary-caption mb-3 font-black font-mono"
                           >
                             How it’s added
                           </span>
                           <div class="text-sm glossary-accent leading-relaxed">
-                            Each one is added manually in a contents file, with a title, the
-                            platform that gave it, and a link. A standout entry can be marked with a
-                            star.
+                            Each one is added manually in a contents file, with
+                            a title, the platform that gave it, and a link. A
+                            standout entry can be marked with a star.
                           </div>
                         </div>
                       </div>
                     </div>
                     <div id="articles" class="mb-16 last:mb-0">
                       <h3
-                        style="color: var(--t-brand); border-bottom: 2px solid var(--t-brand-line)"
+                        style="
+                          color: var(--t-brand);
+                          border-bottom: 2px solid var(--t-brand-line);
+                        "
                         class="text-xl font-extrabold mb-6 pb-2 inline-block"
                       >
                         Articles Written
@@ -1773,25 +2227,30 @@
 
                       <div class="space-y-6">
                         <p class="text-lg glossary-body leading-relaxed">
-                          Blog posts and articles about open source, written to support and promote
-                          the community. Grouped into
-                          <strong>Written for organizations</strong>, for pieces written for a
-                          specific org, and <strong>Personal writing</strong>, for everything else.
+                          Blog posts and articles about open source, written to
+                          support and promote the community. Grouped into
+                          <strong>Written for organizations</strong>, for pieces
+                          written for a specific org, and
+                          <strong>Personal writing</strong>, for everything
+                          else.
                         </p>
 
-                        <div class="glossary-code-block p-6 overflow-x-auto rounded-2xl">
+                        <div
+                          class="glossary-code-block p-6 overflow-x-auto rounded-2xl"
+                        >
                           <span
                             class="block text-xs uppercase tracking-widest glossary-caption mb-3 font-black font-mono"
                           >
                             How it’s added
                           </span>
                           <div class="text-sm glossary-accent leading-relaxed">
-                            Articles are pulled in automatically from Dev.to, plus added directly
-                            for other platforms (like freeCodeCamp) in the contents folder. Pieces
-                            written for a specific organization are grouped under
-                            <strong>Written for organizations</strong>, newest organization first;
-                            everything else is listed under <strong>Personal writing</strong>,
-                            newest first.
+                            Articles are pulled in automatically from Dev.to,
+                            plus added directly for other platforms (like
+                            freeCodeCamp) in the contents folder. Pieces written
+                            for a specific organization are grouped under
+                            <strong>Written for organizations</strong>, newest
+                            organization first; everything else is listed under
+                            <strong>Personal writing</strong>, newest first.
                           </div>
                         </div>
                       </div>
@@ -1800,18 +2259,24 @@
                 </section>
                 <section id="quarterlyReports" class="mb-24 last:mb-0">
                   <div class="mb-10">
-                    <h2 style="color: var(--t-brand)" class="text-3xl sm:text-4xl font-black mb-2">
+                    <h2
+                      style="color: var(--t-brand)"
+                      class="text-3xl sm:text-4xl font-black mb-2"
+                    >
                       Quarterly Reports
                     </h2>
                     <p class="glossary-caption text-lg font-medium italic">
-                      How contributions are grouped into three-month periods, making them easier to
-                      find and read.
+                      How contributions are grouped into three-month periods,
+                      making them easier to find and read.
                     </p>
                   </div>
                   <div class="space-y-2">
                     <div id="reportsIndex" class="mb-16 last:mb-0">
                       <h3
-                        style="color: var(--t-brand); border-bottom: 2px solid var(--t-brand-line)"
+                        style="
+                          color: var(--t-brand);
+                          border-bottom: 2px solid var(--t-brand-line);
+                        "
                         class="text-xl font-extrabold mb-6 pb-2 inline-block"
                       >
                         Reports Index
@@ -1819,19 +2284,23 @@
 
                       <div class="space-y-6">
                         <p class="text-lg glossary-body leading-relaxed">
-                          The main list of the portfolio. It organizes all work into separate pages
-                          grouped by year and three-month periods (quarters).
+                          The main list of the portfolio. It organizes all work
+                          into separate pages grouped by year and three-month
+                          periods (quarters).
                         </p>
 
-                        <div class="glossary-code-block p-6 overflow-x-auto rounded-2xl">
+                        <div
+                          class="glossary-code-block p-6 overflow-x-auto rounded-2xl"
+                        >
                           <span
                             class="block text-xs uppercase tracking-widest glossary-caption mb-3 font-black font-mono"
                           >
                             Where it comes from
                           </span>
                           <div class="text-sm glossary-accent leading-relaxed">
-                            The <strong>Quarterly Reports</strong> page works like a folder, showing
-                            every year and, inside each year, its three-month periods.
+                            The <strong>Quarterly Reports</strong> page works
+                            like a folder, showing every year and, inside each
+                            year, its three-month periods.
                           </div>
                         </div>
                       </div>
@@ -1840,18 +2309,24 @@
                 </section>
                 <section id="quarterlyMetrics" class="mb-24 last:mb-0">
                   <div class="mb-10">
-                    <h2 style="color: var(--t-brand)" class="text-3xl sm:text-4xl font-black mb-2">
+                    <h2
+                      style="color: var(--t-brand)"
+                      class="text-3xl sm:text-4xl font-black mb-2"
+                    >
                       Quarterly Report Metrics
                     </h2>
                     <p class="glossary-caption text-lg font-medium italic">
-                      Terms used inside a single report, covering the work done in that three-month
-                      period.
+                      Terms used inside a single report, covering the work done
+                      in that three-month period.
                     </p>
                   </div>
                   <div class="space-y-2">
                     <div id="quarterInBrief" class="mb-16 last:mb-0">
                       <h3
-                        style="color: var(--t-brand); border-bottom: 2px solid var(--t-brand-line)"
+                        style="
+                          color: var(--t-brand);
+                          border-bottom: 2px solid var(--t-brand-line);
+                        "
                         class="text-xl font-extrabold mb-6 pb-2 inline-block"
                       >
                         Quarter in brief
@@ -1859,32 +2334,39 @@
 
                       <div class="space-y-6">
                         <p class="text-lg glossary-body leading-relaxed">
-                          A plain-language summary at the top of each quarterly report: a sentence
-                          or two on what happened, which organizations were worked with, and a few
-                          highlighted contributions.
+                          A plain-language summary at the top of each quarterly
+                          report: a sentence or two on what happened, which
+                          organizations were worked with, and a few highlighted
+                          contributions.
                         </p>
 
-                        <div class="glossary-code-block p-6 overflow-x-auto rounded-2xl">
+                        <div
+                          class="glossary-code-block p-6 overflow-x-auto rounded-2xl"
+                        >
                           <span
                             class="block text-xs uppercase tracking-widest glossary-caption mb-3 font-black font-mono"
                           >
                             How it’s worked out
                           </span>
                           <div class="text-sm glossary-accent leading-relaxed">
-                            Built from the same counts as the tables below — merged, reviewed, and
-                            co-authored pull requests, and issues — turned into a few sentences, a
-                            list of organizations worked with, and up to three highlighted
-                            contributions. The Markdown version of the report shows the same numbers
-                            as a
-                            <strong>Quarterly Statistics</strong> table instead, since Markdown
-                            can't do the same layout.
+                            Built from the same counts as the tables below —
+                            merged, reviewed, and co-authored pull requests, and
+                            issues — turned into a few sentences, a list of
+                            organizations worked with, and up to three
+                            highlighted contributions. The Markdown version of
+                            the report shows the same numbers as a
+                            <strong>Quarterly Statistics</strong> table instead,
+                            since Markdown can't do the same layout.
                           </div>
                         </div>
                       </div>
                     </div>
                     <div id="stats" class="mb-16 last:mb-0">
                       <h3
-                        style="color: var(--t-brand); border-bottom: 2px solid var(--t-brand-line)"
+                        style="
+                          color: var(--t-brand);
+                          border-bottom: 2px solid var(--t-brand-line);
+                        "
                         class="text-xl font-extrabold mb-6 pb-2 inline-block"
                       >
                         Quarterly Statistics
@@ -1892,26 +2374,32 @@
 
                       <div class="space-y-6">
                         <p class="text-lg glossary-body leading-relaxed">
-                          A summary that shows the total work and the projects involved during a
-                          specific three-month period.
+                          A summary that shows the total work and the projects
+                          involved during a specific three-month period.
                         </p>
 
-                        <div class="glossary-code-block p-6 overflow-x-auto rounded-2xl">
+                        <div
+                          class="glossary-code-block p-6 overflow-x-auto rounded-2xl"
+                        >
                           <span
                             class="block text-xs uppercase tracking-widest glossary-caption mb-3 font-black font-mono"
                           >
                             How it’s worked out
                           </span>
                           <div class="text-sm glossary-accent leading-relaxed">
-                            Adds up every type of contribution and every different repo touched
-                            during that three-month period.
+                            Adds up every type of contribution and every
+                            different repo touched during that three-month
+                            period.
                           </div>
                         </div>
                       </div>
                     </div>
                     <div id="focusProjects" class="mb-16 last:mb-0">
                       <h3
-                        style="color: var(--t-brand); border-bottom: 2px solid var(--t-brand-line)"
+                        style="
+                          color: var(--t-brand);
+                          border-bottom: 2px solid var(--t-brand-line);
+                        "
                         class="text-xl font-extrabold mb-6 pb-2 inline-block"
                       >
                         Top 3 Repositories
@@ -1919,25 +2407,31 @@
 
                       <div class="space-y-6">
                         <p class="text-lg glossary-body leading-relaxed">
-                          The projects that received the most work and attention within each
-                          quarter.
+                          The projects that received the most work and attention
+                          within each quarter.
                         </p>
 
-                        <div class="glossary-code-block p-6 overflow-x-auto rounded-2xl">
+                        <div
+                          class="glossary-code-block p-6 overflow-x-auto rounded-2xl"
+                        >
                           <span
                             class="block text-xs uppercase tracking-widest glossary-caption mb-3 font-black font-mono"
                           >
                             How it’s worked out
                           </span>
                           <div class="text-sm glossary-accent leading-relaxed">
-                            Sorts repos by how many contributions happened in them that quarter.
+                            Sorts repos by how many contributions happened in
+                            them that quarter.
                           </div>
                         </div>
                       </div>
                     </div>
                     <div id="merged" class="mb-16 last:mb-0">
                       <h3
-                        style="color: var(--t-brand); border-bottom: 2px solid var(--t-brand-line)"
+                        style="
+                          color: var(--t-brand);
+                          border-bottom: 2px solid var(--t-brand-line);
+                        "
                         class="text-xl font-extrabold mb-6 pb-2 inline-block"
                       >
                         Merged PRs
@@ -1945,27 +2439,32 @@
 
                       <div class="space-y-6">
                         <p class="text-lg glossary-body leading-relaxed">
-                          A record of pull requests that got accepted and merged into other people's
-                          repos.
+                          A record of pull requests that got accepted and merged
+                          into other people's repos.
                         </p>
 
-                        <div class="glossary-code-block p-6 overflow-x-auto rounded-2xl">
+                        <div
+                          class="glossary-code-block p-6 overflow-x-auto rounded-2xl"
+                        >
                           <span
                             class="block text-xs uppercase tracking-widest glossary-caption mb-3 font-black font-mono"
                           >
                             How it’s worked out
                           </span>
                           <div class="text-sm glossary-accent leading-relaxed">
-                            Finds every pull request marked as merged, and works out the
-                            <strong>Review Period</strong> — the time from opening it to it being
-                            accepted.
+                            Finds every pull request marked as merged, and works
+                            out the <strong>Review Period</strong> — the time
+                            from opening it to it being accepted.
                           </div>
                         </div>
                       </div>
                     </div>
                     <div id="issues" class="mb-16 last:mb-0">
                       <h3
-                        style="color: var(--t-brand); border-bottom: 2px solid var(--t-brand-line)"
+                        style="
+                          color: var(--t-brand);
+                          border-bottom: 2px solid var(--t-brand-line);
+                        "
                         class="text-xl font-extrabold mb-6 pb-2 inline-block"
                       >
                         Issues
@@ -1973,26 +2472,33 @@
 
                       <div class="space-y-6">
                         <p class="text-lg glossary-body leading-relaxed">
-                          A record of bugs, ideas, and problems reported on other people's repos.
+                          A record of bugs, ideas, and problems reported on
+                          other people's repos.
                         </p>
 
-                        <div class="glossary-code-block p-6 overflow-x-auto rounded-2xl">
+                        <div
+                          class="glossary-code-block p-6 overflow-x-auto rounded-2xl"
+                        >
                           <span
                             class="block text-xs uppercase tracking-widest glossary-caption mb-3 font-black font-mono"
                           >
                             How it’s worked out
                           </span>
                           <div class="text-sm glossary-accent leading-relaxed">
-                            Collects every issue opened, whether or not it was assigned. Works out
-                            the
-                            <strong>Closing Period</strong> — the time from opening to closing.
+                            Collects every issue opened, whether or not it was
+                            assigned. Works out the
+                            <strong>Closing Period</strong> — the time from
+                            opening to closing.
                           </div>
                         </div>
                       </div>
                     </div>
                     <div id="reviewed" class="mb-16 last:mb-0">
                       <h3
-                        style="color: var(--t-brand); border-bottom: 2px solid var(--t-brand-line)"
+                        style="
+                          color: var(--t-brand);
+                          border-bottom: 2px solid var(--t-brand-line);
+                        "
                         class="text-xl font-extrabold mb-6 pb-2 inline-block"
                       >
                         Reviewed PRs
@@ -2000,26 +2506,34 @@
 
                       <div class="space-y-6">
                         <p class="text-lg glossary-body leading-relaxed">
-                          A record of formal reviews left on other people's pull requests.
+                          A record of formal reviews left on other people's pull
+                          requests.
                         </p>
 
-                        <div class="glossary-code-block p-6 overflow-x-auto rounded-2xl">
+                        <div
+                          class="glossary-code-block p-6 overflow-x-auto rounded-2xl"
+                        >
                           <span
                             class="block text-xs uppercase tracking-widest glossary-caption mb-3 font-black font-mono"
                           >
                             How it’s worked out
                           </span>
                           <div class="text-sm glossary-accent leading-relaxed">
-                            Works out the <strong>Review Period</strong> — from the pull request
-                            opening to the formal review being submitted — and tracks its current
-                            <strong>Status</strong> and <strong>Last Update</strong>.
+                            Works out the <strong>Review Period</strong> — from
+                            the pull request opening to the formal review being
+                            submitted — and tracks its current
+                            <strong>Status</strong> and
+                            <strong>Last Update</strong>.
                           </div>
                         </div>
                       </div>
                     </div>
                     <div id="coAuthored" class="mb-16 last:mb-0">
                       <h3
-                        style="color: var(--t-brand); border-bottom: 2px solid var(--t-brand-line)"
+                        style="
+                          color: var(--t-brand);
+                          border-bottom: 2px solid var(--t-brand-line);
+                        "
                         class="text-xl font-extrabold mb-6 pb-2 inline-block"
                       >
                         Co-authored PRs
@@ -2027,11 +2541,13 @@
 
                       <div class="space-y-6">
                         <p class="text-lg glossary-body leading-relaxed">
-                          A record of pull requests where code was contributed alongside other
-                          developers.
+                          A record of pull requests where code was contributed
+                          alongside other developers.
                         </p>
 
-                        <div class="glossary-code-block p-6 overflow-x-auto rounded-2xl">
+                        <div
+                          class="glossary-code-block p-6 overflow-x-auto rounded-2xl"
+                        >
                           <span
                             class="block text-xs uppercase tracking-widest glossary-caption mb-3 font-black font-mono"
                           >
@@ -2039,17 +2555,22 @@
                           </span>
                           <div class="text-sm glossary-accent leading-relaxed">
                             Finds commits credited to a co-author. The
-                            <strong>Commit Period</strong> is the time from the pull request opening
-                            to the first commit on it — showing when the collaboration started.
-                            <strong>Status</strong> and <strong>Last Update</strong> track where it
-                            stands now.
+                            <strong>Commit Period</strong> is the time from the
+                            pull request opening to the first commit on it —
+                            showing when the collaboration started.
+                            <strong>Status</strong> and
+                            <strong>Last Update</strong> track where it stands
+                            now.
                           </div>
                         </div>
                       </div>
                     </div>
                     <div id="collaborations" class="mb-16 last:mb-0">
                       <h3
-                        style="color: var(--t-brand); border-bottom: 2px solid var(--t-brand-line)"
+                        style="
+                          color: var(--t-brand);
+                          border-bottom: 2px solid var(--t-brand-line);
+                        "
                         class="text-xl font-extrabold mb-6 pb-2 inline-block"
                       >
                         Collaborations
@@ -2057,19 +2578,21 @@
 
                       <div class="space-y-6">
                         <p class="text-lg glossary-body leading-relaxed">
-                          A record of comments left on issues or pull requests opened by other
-                          people.
+                          A record of comments left on issues or pull requests
+                          opened by other people.
                         </p>
 
-                        <div class="glossary-code-block p-6 overflow-x-auto rounded-2xl">
+                        <div
+                          class="glossary-code-block p-6 overflow-x-auto rounded-2xl"
+                        >
                           <span
                             class="block text-xs uppercase tracking-widest glossary-caption mb-3 font-black font-mono"
                           >
                             How it’s worked out
                           </span>
                           <div class="text-sm glossary-accent leading-relaxed">
-                            Tracks comments on pull requests and issues, up until one gets a formal
-                            review.
+                            Tracks comments on pull requests and issues, up
+                            until one gets a formal review.
                           </div>
                         </div>
                       </div>
@@ -2083,7 +2606,10 @@
       </div>
     </main>
     <footer
-      style="border-top-color: var(--c-neutral-10); color: var(--c-text-secondary-rgb)"
+      style="
+        border-top-color: var(--c-neutral-10);
+        color: var(--c-text-secondary-rgb);
+      "
       class="mt-16 py-8 border-t text-center text-sm"
     >
       <div class="mb-1">
@@ -2123,23 +2649,31 @@
         </a>
       </div>
     </footer>
-    <button type="button" id="back-to-top" class="back-to-top" aria-label="Back to top" hidden>
+    <button
+      type="button"
+      id="back-to-top"
+      class="back-to-top"
+      aria-label="Back to top"
+      hidden
+    >
       <span aria-hidden="true">↑</span>
     </button>
     <script>
       (function () {
-        var btn = document.getElementById('back-to-top');
+        var btn = document.getElementById("back-to-top");
         if (!btn) return;
         function onScroll() {
           btn.hidden = window.scrollY < window.innerHeight * 1.5;
         }
-        window.addEventListener('scroll', onScroll, { passive: true });
+        window.addEventListener("scroll", onScroll, { passive: true });
         onScroll();
-        btn.addEventListener('click', function () {
-          var reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+        btn.addEventListener("click", function () {
+          var reduceMotion = window.matchMedia(
+            "(prefers-reduced-motion: reduce)",
+          ).matches;
           window.scrollTo({
             top: 0,
-            behavior: reduceMotion ? 'auto' : 'smooth',
+            behavior: reduceMotion ? "auto" : "smooth",
           });
         });
       })();

--- a/scripts/generators/css/style-generator.js
+++ b/scripts/generators/css/style-generator.js
@@ -454,13 +454,13 @@ function getGlossaryStyleCss() {
       padding: 0;
     }
 
-    /* Highlight the section when navigating via URL hash (#) */
+    /* Highlight the section when navigating via URL hash (#). Uses a
+       box-shadow halo rather than negative margin so the highlight can't
+       eat into a following section's spacing (e.g. on a last:mb-0 item). */
     :target {
       background-color: var(--t-brand-wash);
-      border-radius: 1rem;
       transition: background-color 0.5s ease;
-      padding: 1rem;
-      margin: -1rem;
+      box-shadow: 0 0 0 1rem var(--t-brand-wash);
       scroll-margin-top: 100px;
     }
 

--- a/scripts/generators/html/blog-html-generator.js
+++ b/scripts/generators/html/blog-html-generator.js
@@ -294,7 +294,7 @@ async function createBlogHtml(articles, recognitions) {
       ${navHtml}
       <main id="main" class="grow w-full">
         <div class="px-6 sm:px-12 lg:px-16 xl:px-32 py-10">
-          <div class="max-w-6xl mx-auto">
+          <div class="max-w-7xl mx-auto">
             <header class="mt-16 mb-14">
               <p class="wr-eyebrow">writing</p>
               <h1 class="wr-h1 text-4xl sm:text-5xl mt-2 mb-4">Articles on open source and GitHub</h1>

--- a/scripts/generators/html/contributions-report-html-generator.js
+++ b/scripts/generators/html/contributions-report-html-generator.js
@@ -154,12 +154,13 @@ ${createSkipToContentHtml('main')}
 ${navHtml}
   <main id="main" class="grow w-full">
     <div class="px-4 sm:px-8 lg:px-12 xl:px-16 2xl:px-24 py-6 sm:py-10">
-      <div class="max-w-[120ch] mx-auto">
-        <header style="border-bottom-color: var(--t-brand-line);" class="text-center mt-16 mb-16 pb-12 border-b-2">
-          <h1 style="color: var(--t-brand);" class="text-4xl sm:text-6xl font-black mb-6 pt-8">
+      <div class="max-w-7xl mx-auto">
+        <header class="mt-16 mb-14">
+          <p style="font-family: ui-monospace, monospace; font-size: 0.75rem; letter-spacing: 0.14em; text-transform: uppercase; color: var(--t-ink-3);">reports</p>
+          <h1 class="text-4xl sm:text-5xl font-extrabold mt-2 mb-4" style="color: var(--t-brand); letter-spacing: -0.01em;">
             Quarterly Reports
           </h1>
-          <p style="color: var(--t-ink-2);" class="text-xl max-w-3xl mx-auto leading-relaxed">
+          <p style="color: var(--t-ink-2);" class="text-lg max-w-3xl leading-relaxed">
             Organized by calendar quarter, these reports track external open source involvement,
             aggregating key community activities across all tracked repositories.
           </p>

--- a/scripts/generators/html/glossary-html-generator.js
+++ b/scripts/generators/html/glossary-html-generator.js
@@ -142,11 +142,12 @@ async function createGlossaryHtml() {
       <main id="main" class="grow w-full">
         <div class="px-6 sm:px-12 lg:px-16 xl:px-32 py-10">
           <div class="max-w-7xl mx-auto">
-            <header style="border-bottom-color: var(--t-brand-line);" class="text-center mt-16 mb-16 pb-12 border-b-2">
-              <h1 style="color: var(--t-brand);" class="text-4xl sm:text-6xl font-black mb-6 pt-8">
+            <header class="mt-16 mb-14">
+              <p style="font-family: ui-monospace, monospace; font-size: 0.75rem; letter-spacing: 0.14em; text-transform: uppercase; color: var(--t-ink-3);">glossary</p>
+              <h1 class="text-4xl sm:text-5xl font-extrabold mt-2 mb-4" style="color: var(--t-brand); letter-spacing: -0.01em;">
                 ${GLOSSARY_CONTENT.title}
               </h1>
-              <p class="text-xl max-w-3xl mx-auto leading-relaxed glossary-body">
+              <p class="text-lg max-w-3xl leading-relaxed glossary-body">
                 ${processText(GLOSSARY_CONTENT.subtitle)}
               </p>
             </header>

--- a/scripts/generators/html/glossary-html-generator.js
+++ b/scripts/generators/html/glossary-html-generator.js
@@ -151,7 +151,32 @@ async function createGlossaryHtml() {
                 ${processText(GLOSSARY_CONTENT.subtitle)}
               </p>
             </header>
-            <div class="max-w-[90ch] mx-auto">
+            <div class="lg:grid lg:grid-cols-[220px_1fr] lg:gap-12">
+              <nav
+                aria-label="Glossary sections"
+                class="glossary-toc mb-10 lg:mb-0 lg:sticky lg:top-8 lg:self-start lg:max-h-[calc(100vh-4rem)] lg:overflow-y-auto lg:pr-4"
+              >
+                <p class="text-xs font-bold uppercase tracking-widest glossary-caption mb-3">On this page</p>
+                <ul class="space-y-4 text-sm">
+                  ${sections
+                    .map(
+                      (group) => dedent`
+                        <li>
+                          <a href="#${group.id}" class="font-semibold" style="color: var(--t-brand);">${group.title}</a>
+                          <ul class="mt-2 space-y-1.5 pl-3 border-l" style="border-color: var(--t-line);">
+                            ${group.items
+                              .map(
+                                (item) =>
+                                  `<li><a href="#${item.id}" class="block glossary-body hover:underline">${item.title}</a></li>`
+                              )
+                              .join('')}
+                          </ul>
+                        </li>
+                      `
+                    )
+                    .join('')}
+                </ul>
+              </nav>
               <article class="glossary-content">
                 <div class="metrics-container">
                   ${metricBlocksHtml}

--- a/scripts/generators/html/journey-html-generator.js
+++ b/scripts/generators/html/journey-html-generator.js
@@ -334,7 +334,7 @@ async function createJourneyHtml(rolesData, skills, content = {}) {
       ${navHtml}
       <main id="main" class="grow w-full">
         <div class="px-6 sm:px-12 lg:px-16 xl:px-32 py-10">
-          <div class="max-w-6xl mx-auto">
+          <div class="max-w-7xl mx-auto">
             <header class="mt-16 mb-14">
               <p class="jy-eyebrow">journey</p>
               <h1 class="jy-h2 text-4xl sm:text-5xl mt-2 mb-4">Roles, expertise, and the work behind them</h1>

--- a/scripts/generators/html/workbench-html-generator.js
+++ b/scripts/generators/html/workbench-html-generator.js
@@ -518,7 +518,7 @@ async function createWorkbenchHtml({ records, impact, feed }) {
       ${navHtml}
       <main id="main" class="grow w-full">
         <div class="px-6 sm:px-12 lg:px-16 xl:px-32 py-10">
-          <div class="max-w-6xl mx-auto">
+          <div class="max-w-7xl mx-auto">
             <header class="mt-16 mb-10">
               <p style="font-family:ui-monospace,monospace;font-size:.75rem;letter-spacing:.14em;text-transform:uppercase;color:var(--t-ink-3)">active workbench</p>
               <h1 class="text-4xl sm:text-5xl font-extrabold mt-2 mb-4" style="color:var(--t-brand);letter-spacing:-.01em">Organized by what happens next</h1>

--- a/scripts/metadata/glossary.js
+++ b/scripts/metadata/glossary.js
@@ -3,7 +3,7 @@
  */
 const GLOSSARY_CONTENT = {
   title: 'Glossary',
-  subtitle: `Plain-English explanations of the terms used across this portfolio — what each one means, and how it's worked out from the underlying GitHub activity.`,
+  subtitle: `The terms used across this portfolio and how it's worked out from the underlying GitHub activity.`,
 
   sections: [
     {
@@ -15,7 +15,8 @@ const GLOSSARY_CONTENT = {
         {
           id: 'totalImpact',
           title: 'Total Impact',
-          description: 'Every contribution counted together, going back to the very first one on GitHub.',
+          description:
+            'Every contribution counted together, going back to the very first one on GitHub.',
           howItIsCalculated:
             'Adds up merged pull requests, issues, reviewed pull requests, co-authored pull requests, and collaborations.',
         },
@@ -25,7 +26,7 @@ const GLOSSARY_CONTENT = {
           description:
             'How many of those contributions were actually finished and accepted — not just opened.',
           howItIsCalculated:
-            'Counts only the contributions GitHub marked as merged. Total Impact also includes work that\'s still open, so this number is smaller — it\'s what\'s actually done.',
+            "Counts only the contributions GitHub marked as merged. Total Impact also includes work that's still open, so this number is smaller — it's what's actually done.",
         },
         {
           id: 'activeSince',
@@ -69,7 +70,8 @@ const GLOSSARY_CONTENT = {
     {
       id: 'journey',
       title: 'Journey',
-      description: 'Terms used on the Journey page — selected work, talks, expertise, and the roles behind them.',
+      description:
+        'Terms used on the Journey page — selected work, talks, expertise, and the roles behind them.',
       items: [
         {
           id: 'milestonesAwards',
@@ -85,7 +87,7 @@ const GLOSSARY_CONTENT = {
           description:
             'The skill areas behind the work, plus the tools and languages used to do it. No self-rated skill bars — the rest of the portfolio is the proof.',
           entryMethod:
-            'Expertise areas are entered manually in a contents file, each with a title and a short blurb. Tools and skills each show as their own list, but only if there\'s something in it — an empty list just doesn\'t show, heading and all. A few entries can be marked to stand out (bold, in the accent color) to call out the two or three that matter most.',
+            "Expertise areas are entered manually in a contents file, each with a title and a short blurb. Tools and skills each show as their own list, but only if there's something in it — an empty list just doesn't show, heading and all. A few entries can be marked to stand out (bold, in the accent color) to call out the two or three that matter most.",
         },
         {
           id: 'advocacyRoles',
@@ -99,7 +101,8 @@ const GLOSSARY_CONTENT = {
     {
       id: 'workbench',
       title: 'Active Workbench',
-      description: 'Terms used on the Active Workbench page — the live board of maintainer and contribution work in progress.',
+      description:
+        'Terms used on the Active Workbench page — the live board of maintainer and contribution work in progress.',
       items: [
         {
           id: 'activeWorkbench',
@@ -120,7 +123,8 @@ A freshness badge in the header reads "Updated Xh ago" (or "Updated just now" / 
         {
           id: 'workbenchStatus',
           title: 'Workbench Status & Ball Tracking',
-          description: "A badge on each row showing whose turn it is, whether it's a draft, and how long it's been waiting.",
+          description:
+            "A badge on each row showing whose turn it is, whether it's a draft, and how long it's been waiting.",
           entryMethod: `Each task carries a "ball" badge showing whose move it is:
 * **Take Action:** New feedback to address, a requested review, or a reply that needs an answer.
 * **To Write:** An issue that's assigned, with no pull request opened yet.
@@ -139,7 +143,8 @@ A **Draft** chip marks a pull request still in draft state. **The day count** sh
     {
       id: 'writing',
       title: 'Writing',
-      description: 'Terms used on the Writing page, covering recognitions and published articles and how they are grouped.',
+      description:
+        'Terms used on the Writing page, covering recognitions and published articles and how they are grouped.',
       items: [
         {
           id: 'recognitions',
@@ -162,7 +167,8 @@ A **Draft** chip marks a pull request still in draft state. **The day count** sh
     {
       id: 'quarterlyReports',
       title: 'Quarterly Reports',
-      description: 'How contributions are grouped into three-month periods, making them easier to find and read.',
+      description:
+        'How contributions are grouped into three-month periods, making them easier to find and read.',
       items: [
         {
           id: 'reportsIndex',
@@ -177,7 +183,8 @@ A **Draft** chip marks a pull request still in draft state. **The day count** sh
     {
       id: 'quarterlyMetrics',
       title: 'Quarterly Report Metrics',
-      description: 'Terms used inside a single report, covering the work done in that three-month period.',
+      description:
+        'Terms used inside a single report, covering the work done in that three-month period.',
       items: [
         {
           id: 'quarterInBrief',
@@ -185,53 +192,58 @@ A **Draft** chip marks a pull request still in draft state. **The day count** sh
           description:
             'A plain-language summary at the top of each quarterly report: a sentence or two on what happened, which organizations were worked with, and a few highlighted contributions.',
           howItIsCalculated:
-            'Built from the same counts as the tables below — merged, reviewed, and co-authored pull requests, and issues — turned into a few sentences, a list of organizations worked with, and up to three highlighted contributions. The Markdown version of the report shows the same numbers as a **Quarterly Statistics** table instead, since Markdown can\'t do the same layout.',
+            "Built from the same counts as the tables below — merged, reviewed, and co-authored pull requests, and issues — turned into a few sentences, a list of organizations worked with, and up to three highlighted contributions. The Markdown version of the report shows the same numbers as a **Quarterly Statistics** table instead, since Markdown can't do the same layout.",
         },
         {
           id: 'stats',
           title: 'Quarterly Statistics',
-          description: 'A summary that shows the total work and the projects involved during a specific three-month period.',
+          description:
+            'A summary that shows the total work and the projects involved during a specific three-month period.',
           howItIsCalculated:
             'Adds up every type of contribution and every different repo touched during that three-month period.',
         },
         {
           id: 'focusProjects',
           title: 'Top 3 Repositories',
-          description: 'The projects that received the most work and attention within each quarter.',
+          description:
+            'The projects that received the most work and attention within each quarter.',
           howItIsCalculated: 'Sorts repos by how many contributions happened in them that quarter.',
         },
         {
           id: 'merged',
           title: 'Merged PRs',
-          description: 'A record of pull requests that got accepted and merged into other people\'s repos.',
+          description:
+            "A record of pull requests that got accepted and merged into other people's repos.",
           howItIsCalculated:
             'Finds every pull request marked as merged, and works out the **Review Period** — the time from opening it to it being accepted.',
         },
         {
           id: 'issues',
           title: 'Issues',
-          description: 'A record of bugs, ideas, and problems reported on other people\'s repos.',
+          description: "A record of bugs, ideas, and problems reported on other people's repos.",
           howItIsCalculated:
             'Collects every issue opened, whether or not it was assigned. Works out the **Closing Period** — the time from opening to closing.',
         },
         {
           id: 'reviewed',
           title: 'Reviewed PRs',
-          description: 'A record of formal reviews left on other people\'s pull requests.',
+          description: "A record of formal reviews left on other people's pull requests.",
           howItIsCalculated:
             'Works out the **Review Period** — from the pull request opening to the formal review being submitted — and tracks its current **Status** and **Last Update**.',
         },
         {
           id: 'coAuthored',
           title: 'Co-authored PRs',
-          description: 'A record of pull requests where code was contributed alongside other developers.',
+          description:
+            'A record of pull requests where code was contributed alongside other developers.',
           howItIsCalculated:
             'Finds commits credited to a co-author. The **Commit Period** is the time from the pull request opening to the first commit on it — showing when the collaboration started. **Status** and **Last Update** track where it stands now.',
         },
         {
           id: 'collaborations',
           title: 'Collaborations',
-          description: 'A record of comments left on issues or pull requests opened by other people.',
+          description:
+            'A record of comments left on issues or pull requests opened by other people.',
           howItIsCalculated:
             'Tracks comments on pull requests and issues, up until one gets a formal review.',
         },


### PR DESCRIPTION
## Summary
- Quarterly Reports and Glossary used a centered, bordered header while Journey, Writing, and Workbench used a left-aligned eyebrow-label header. Unified all five on the eyebrow-label pattern and a shared max-w-7xl container width.
- Glossary was the only page constraining its content to a narrower max-w-[90ch] column inside that container. Removed that constraint and added a two-column layout with a sticky, independently-scrollable section/term table of contents on large screens (stacked and non-sticky on small screens).
- Fixed the existing `:target` highlight (triggered by TOC links jumping to a term) overflowing into the next section — it used a negative margin to expand the highlight box, which collapsed a last item's bottom margin and let the highlight spill past its own boundary. Replaced with a box-shadow halo that doesn't affect layout.

## Test plan
- [x] Regenerated `glossary.html` from the updated generator and confirmed the new header, widened layout, TOC markup, and box-shadow highlight rule are present in the output.
- [ ] Visual check in an actual browser (no working headless browser was available in this environment — missing system library, no sudo access) — confirm TOC sticky/scroll behavior on desktop and stacked/non-sticky behavior on mobile.
- [ ] Confirm Reports/Journey/Writing/Workbench pages pick up the new header format next time their generated HTML is rebuilt (their generator sources changed but the generated output depends on live contribution data not regenerated here).