### PR TITLE
docs: rewrite Selected Work descriptions and simplify README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,13 @@
 # Curated Open Source Portfolio
 
-This repository serves as a portfolio of my open source contributions. You can check out the [Contribution Log](./contributions/markdown-generated/README.md) to see my work.
+At its core, this repository is a contribution tracker: it automatically logs my open source activity across GitHub — merged pull requests, issues, code reviews, and collaborations — and turns it into an organized, always-current record. Browse the [Contribution Log](./contributions/markdown-generated/README.md) to see the work itself.
 
 > [!TIP]
-> **Want to build your own?** I created this system to be reusable. If you want to generate a similar portfolio for your own GitHub activity, please use the [**Curated OSS Portfolio Template**](https://github.com/adiati98/oss-portfolio-template) for a clean, standard setup.
+> **Want to build your own?** This system is reusable. Use the [**Curated OSS Portfolio Template**](https://github.com/adiati98/oss-portfolio-template) to generate a similar tracker from your own GitHub activity.
 
-I created this log to maintain a detailed and organized record of my journey, including Pull Requests (PRs), bug reports, and general collaborations. 
+I built this because keeping that record by hand didn't scale. A scheduled job pulls fresh data from GitHub automatically, so the log stays current without me touching it.
 
-The content in this repository updates automatically via a Node.js script and a GitHub Actions workflow.
-
-If you want to learn about the motivation and development process for this project, read my full write-ups:
+Curious about the motivation and how it was built? Read the full write-ups:
 
 - [How I Built a Curated, Automated Open Source Portfolio](https://dev.to/adiatiayu/how-i-built-a-curated-automated-open-source-portfolio-18o0)
 - [The Curated, Automated Open Source Portfolio: How It’s Going](https://dev.to/adiatiayu/the-curated-automated-open-source-portfolio-how-its-going-5f98)
@@ -18,52 +16,16 @@ If you want to learn about the motivation and development process for this proje
 
 ## 💡 How It Works
 
-This project uses **GitHub Actions** as an automated engine to run a custom **Node.js** processing pipeline. This ensures the portfolio stays current without any manual intervention.
+Every day, a scheduled job checks my GitHub activity — merged pull requests, issues, code reviews, and collaborations — and adds anything new to the tracker. Once a month, it also double-checks the full history against GitHub so nothing slips through.
 
-### 🤖 The Automation: GitHub Actions
+On top of that tracked history, the site builds a few other views:
 
-The workflow file in `.github/workflows/` orchestrates the entire process. It handles environment setup, authentication, and the final commit of updated data back to the repository.
+- **Journey** — a timeline of milestones: awards, courses, projects, docs, talks, and videos, alongside the tracked contributions.
+- **Active Workbench** — open reviews and ongoing tasks, grouped by what to do next, so it's clear at a glance what's still open versus what's waiting on someone else.
+- **A persona label** — based on the pattern of my activity (reviewing, building, or planning, for example), it summarizes my role with a short title, like "Core Contributor" or "Community Mentor."
+- **My writing** — articles I publish on Dev.to sync in automatically; freeCodeCamp pieces are added by hand.
 
-| Event | Schedule | Sync Type | Automation Purpose |
-| :--- | :--- | :--- | :--- |
-| **Daily Update** | Once per day | **Incremental** | Captures activity from the last 24 hours to keep the portfolio current. |
-| **Monthly Sync** | 1st of every month | **Full Sync** | Rechecks the entire history against GitHub, while keeping existing records safe. |
-
-### 🧠 The Brain: The Node.js Script
-
-When the GitHub Action triggers the runner, the script executes a multi-stage pipeline:
-
-#### 1. Data Fetching & Processing
-
-- **GitHub API (v3):** The script communicates with the GitHub REST API to collect activity: **Merged Pull Requests (PRs), Issues, Reviewed PRs, Co-authored PRs, and Collaborations**.
-- **Active Workbench:** Tracks ongoing maintenance tasks and open reviews. It intelligently categorizes tasks into dedicated tables, separating human-centric contributions from automated bot activity (e.g., Dependabot, Snyk) to streamline workflow visibility, and shows the GitHub username of the relevant person in the "Last Interaction" column — the last actor whenever a task needs attention ("Take Action") or is awaiting someone else ("Watching"), or the reviewer who approved it ("Approved"). Additionally, it supports dynamic repository exclusions (`contents/repo-exclusions.js`) and a per-bot allowlist (`contents/allowed-bot.js`) to filter out specified organizations/projects or let trusted bots be treated as the last actor.
-- **Personal Technical Writing:**
-    - **Automated Sync:** Fetches latest articles from **Dev.to** via their API.
-    - **Curated Content:** Integrates long-form technical guides authored for freeCodeCamp, managed through manual metadata in `contents/fcc-articles.js`.
-- **Smart Syncing:** Automatically determines the fetch range (Current Year vs. Historical) based on the `last-modified` timestamp of the local data.
-- **Hierarchical Caching:** Maintains `pr-cache.json`, `commit-cache.json`, and `workbench-activity-cache.json` to optimize performance, preserve commit history, and respect GitHub API rate limits.
-
-#### 2. Output Generation
-
-The script transforms raw JSON data into a suite of high-fidelity reports:
-
-- **Quarterly & All-Time Stats:** Detailed logs and interactive dashboards built with Tailwind CSS.
-- **Authored Technical Blog:** A dedicated showcase of technical writing, documentation, and Open Source Software (OSS) articles.
-- **Journey:** Your roles and expertise, followed by your selected work on a single timeline — awards, courses, projects, documentation, talks, and videos. Your best entries are shown first, and the rest are behind a "Show more" button.
-- **Active Workbench:** Live tasks and open reviews, organized by what happens next.
-- **Markdown Ecosystem:** Generates a summary `README.md` and quarterly reports for native GitHub viewing.
-
-#### 3. Collaboration Profiles
-
-The system analyzes contribution patterns to automatically assign a persona title. This helps viewers quickly understand the primary impact style within the open source ecosystem.
-
-| Priority | Persona Title | Focus |
-| :--- | :--- | :--- |
-| 1 | **Community Mentor** | Code review and technical guidance. |
-| 2 | **Core Contributor** | Feature development and bug fixing. |
-| 3 | **Project Architect** | Problem identification and feature planning. |
-| 4 | **Collaborative Partner** | Pair programming and co-authoring code. |
-| 5 | **Ecosystem Partner** | Technical discussion and community engagement. |
+For the full technical breakdown — caching, API calls, file structure — see the write-ups above or the code itself.
 
 ---
 

--- a/contents/awards.js
+++ b/contents/awards.js
@@ -15,6 +15,6 @@ module.exports = [
     url: 'https://mautic.org/blog/learnings-from-mautic-world-conference-2025/',
     highlight: true,
     description:
-      'Awarded by a panel of experts from the Mautic community at Mautic World Conference 2025, in recognition of making a significant personal impact through exceptional support, innovative ideas, or tireless dedication to the Mautic community.',
+      "Won Mautic's 2025 Mautician of the Year award, selected by a panel from the year's active contributors for exceptional support, ideas, and dedication to the community.",
   },
 ];

--- a/contents/courses.js
+++ b/contents/courses.js
@@ -25,7 +25,7 @@ module.exports = [
     year: 2024,
     url: 'https://learn.osscommunities.com/becoming-a-maintainer/',
     description:
-      "Wrote and published a full course taking contributors from their first change through to helping run a project — sorting incoming issues, reviewing other people's work, and keeping a community healthy.",
+      'Co-created a free maintainer-onboarding course with Bekah HW and Jessica Wilkins — 13 chapters from first PR through running a project: triage, review, and community building.',
   },
   // Example of a course you took rather than authored — course and
   // certificate as two separate, both-optional links:

--- a/contents/docs.js
+++ b/contents/docs.js
@@ -20,7 +20,7 @@ module.exports = [
     url: 'https://contribute.mautic.org/en/latest/contributing/contributing_docs.html',
     highlight: true,
     description:
-      "Rewrote Mautic's contributing guidelines, then moved them onto the Community Handbook site so all three documentation projects point at one set of instructions instead of keeping their own.",
+      "Rewrote Mautic's contributing guidelines and consolidated three separate per-repo CONTRIBUTING files into one shared source on the Community Handbook.",
   },
   {
     title: 'Mautic Community Handbook reStructuredText conversion',
@@ -29,7 +29,7 @@ module.exports = [
     url: 'https://contribute.mautic.org/',
     highlight: true,
     description:
-      'Rebuilt the whole Community Handbook in reStructuredText, the format Mautic publishes its documentation from — every section, from contributing and testing through to policies and the style guide.',
+      "Converted the Community Handbook's content into reStructuredText across roughly 20 sections — one merged PR per role and policy area, from Designer and Translator guides through Governance and Financial Policy.",
   },
   {
     title: 'Mautic Tester documentation overhaul',
@@ -37,7 +37,7 @@ module.exports = [
     year: 2026,
     url: 'https://contribute.mautic.org/en/latest/contributing/tester.html',
     description:
-      'Reworked the Tester guide so it starts with setting Mautic up on your own machine rather than in the cloud, rewriting about half the page.',
+      'Rewrote the Tester guide twice: first replacing sunset Gitpod instructions with GitHub Codespaces setup written from scratch, then restructuring the page to lead with local (DDEV) setup over Codespaces.',
   },
   {
     title: 'Virtual Coffee Handbook',
@@ -47,7 +47,7 @@ module.exports = [
     url: 'https://virtualcoffee.io/resources/virtual-coffee-handbook',
     highlight: true,
     description:
-      "Created and looked after Virtual Coffee's handbook — from how to join through to finding your way around Slack — including a 2023 reorganization of every community resource on the site.",
+      "Created and still maintain Virtual Coffee's handbook — onboarding, Slack navigation, glossary — including a 2023 reorg of every community resource on the site.",
   },
   {
     title: 'Virtual Coffee Monthly Challenges documentation',
@@ -56,7 +56,7 @@ module.exports = [
     yearEnd: 2025,
     url: 'https://vc-community-docs.netlify.app/docs/monthly-challenges/',
     description:
-      'Wrote the facilitator handbook and a guide for every Monthly Challenge, so the volunteers running them had something to follow instead of working it out each time.',
+      'Wrote a facilitator handbook plus individual guides for 15+ Monthly Challenges, replacing ad hoc volunteer knowledge with a documented process.',
   },
   {
     title: 'Virtual Coffee docs migration to Docusaurus',
@@ -65,6 +65,6 @@ module.exports = [
     url: 'https://vc-community-docs.netlify.app/docs/',
     highlight: true,
     description:
-      "Moved Virtual Coffee's documentation onto Docusaurus on my own — 192 files rebuilt and delivered as a single piece of work.",
+      "Migrated Virtual Coffee's documentation to Docusaurus solo — full information architecture and content rebuilt from scratch, not a lift-and-shift.",
   },
 ];

--- a/contents/projects.js
+++ b/contents/projects.js
@@ -15,7 +15,7 @@ module.exports = [
     url: 'https://github.com/adiati98/oss-portfolio',
     highlight: true,
     description:
-      'Built an automated system that collects, organizes, and showcases open source contributions — featuring customizable themes, progress reports, and a live dashboard for active projects.',
+      'Built a self-hosted portfolio generator that pulls GitHub activity via the API and turns it into a static site — with a PR-triage engine that ranks what needs attention now, a theme system that enforces accessible contrast at build time, and auto-generated contribution reports.',
   },
   {
     title: 'Mautic Docs PRs Tracker',
@@ -25,7 +25,7 @@ module.exports = [
     url: 'https://github.com/adiati98/mautic-docs-prs-tracker',
     highlight: true,
     description:
-      'Built an automated board showing the Education Team which documentation PRs are waiting on a review, with a reminder page that nudges developers to take a look.',
+      'Built a GitHub Actions pipeline that refreshes a live Mautic docs PR dashboard roughly every 30 minutes during work hours, sorting each PR into one of four priority groups by what needs action, with a companion reminder page to prompt code PR authors to review the docs PR against their own changes.',
   },
   {
     title: 'OSS Portfolio Template',
@@ -34,6 +34,6 @@ module.exports = [
     yearEnd: 'present',
     url: 'https://github.com/adiati98/oss-portfolio-template',
     description:
-      'Turned the portfolio generator into a template anyone can copy and point at their own GitHub account.',
+      'Extracted the OSS Portfolio engine into a template repo — same GitHub API pipeline and dual Markdown/HTML output, reduced to one config value (a GitHub username) so anyone can stand up their own.',
   },
 ];

--- a/contents/talks.js
+++ b/contents/talks.js
@@ -26,7 +26,7 @@ module.exports = [
     url: 'https://www.youtube.com/watch?v=KoVX3kGMn3c',
     length: '57 min',
     blurb:
-      'Co-hosted with Bekah HW: what Open Source actually is, why it is worth contributing to, and how to make a difference once you start.',
+      "Co-hosted with Bekah HW: what open source is, why it's worth contributing to, and how to start making an impact.",
   },
   {
     title: 'Becoming an Open Source Maintainer Workshop',
@@ -44,6 +44,6 @@ module.exports = [
     url: 'https://www.youtube.com/live/pzLXQYZpOPU?t=5368',
     highlight: true,
     blurb:
-      'Why documentation is what decides whether a newcomer becomes a contributor or gives up at the README.',
+      'Gave a lightning talk explaining documentation is conversion infrastructure, not a nice-to-have. Clear docs mean faster reviews, quicker-merging PRs, and contributors who come back.',
   },
 ];

--- a/contents/videos.js
+++ b/contents/videos.js
@@ -14,7 +14,7 @@ module.exports = [
     url: 'https://www.youtube.com/watch?v=Hnzp-aJ4NWA',
     length: '11 min',
     blurb:
-      "A walkthrough of getting Mautic's documentation running on your own machine, so you can start making changes to it.",
+      "As Assistant Team Lead for Mautic's Education Team, walked contributors through setting up a local environment to contribute, test, and review documentation PRs.",
   },
   {
     title:
@@ -24,6 +24,6 @@ module.exports = [
     url: 'https://www.youtube.com/watch?v=jP-7LEyNo_k',
     length: '6 min',
     blurb:
-      'A short walkthrough of opening a pull request in the low and no code project, so your contribution gets counted.',
+      "As Assistant Team Lead for Mautic's Education Team, explained how to file a PR for low/no-code contributions so they count toward Hacktoberfest and other contribution tracking.",
   },
 ];


### PR DESCRIPTION
## Summary
- Rewrote all 14 "Selected Work" descriptions across projects, docs, awards, talks, videos, and courses — verified against source (READMEs, merged PRs, docs pages) for accuracy and rewritten for concrete scope over vague framing.
- Simplified the README so non-technical readers can follow it: leads with the contribution tracker as the core purpose, drops implementation-level detail (caching, API internals, schedule/persona tables) from "How It Works." Installation instructions are unchanged.

## Test plan
- [ ] Confirm the Selected Work descriptions read correctly on the Journey page
- [ ] Confirm README renders cleanly on GitHub