### PR TITLE
fix: improve workbench's waiting-on accuracy for reviewers

### DIFF
--- a/scripts/generators/html/workbench-html-generator.js
+++ b/scripts/generators/html/workbench-html-generator.js
@@ -244,9 +244,9 @@ const WORKBENCH_CSS = `
 function relLabel(record) {
   const map = {
     authored: '✍ authored',
-    'co-authoring': '🤝 co-authoring',
-    reviewing: '👀 reviewing',
-    'assigned issue': '📝 assigned issue',
+    'co-authoring': '🤝 co-authored',
+    reviewing: '👀 PR review',
+    'assigned issue': '📝 assigned',
   };
   return map[record.relationship] || escapeHtml(record.relationship) || '';
 }

--- a/scripts/generators/markdown/community-markdown-generator.js
+++ b/scripts/generators/markdown/community-markdown-generator.js
@@ -185,9 +185,9 @@ const BALL_COLOR = {
 
 const REL_LABEL = {
   authored: '✍ authored',
-  'co-authoring': '🤝 co-authoring',
-  reviewing: '👀 reviewing',
-  'assigned issue': '📝 assigned issue',
+  'co-authoring': '🤝 co-authored',
+  reviewing: '👀 PR review',
+  'assigned issue': '📝 assigned',
 };
 
 /** Mirrors the wbx-pill: ball label as a badge, plus the same idle-day suffix rule as renderRow. */

--- a/scripts/services/workbench-merge.js
+++ b/scripts/services/workbench-merge.js
@@ -426,8 +426,26 @@ function buildSignals(local, upstream, me, now) {
   );
   const stillPending = openRequests.filter((r) => pendingLogins.some((l) => sameLogin(l, r.of)));
   const chosen = newestBy(stillPending.length ? stillPending : openRequests);
-  if (chosen) {
-    signals.pendingReview = { of: chosen.of, days: daysSince(chosen.at) };
+
+  // A newer informal ping — an @-mention asking a specific person to weigh
+  // in, still unanswered by them — can supersede a stale formal review
+  // request nobody ever withdrew. Without this, a months-old "Request
+  // review" click that the reviewer never fulfilled permanently outranks
+  // someone being asked again and again through plain comments instead,
+  // even once the real ask has clearly moved on to a different person.
+  const openPings = activity.comments
+    .filter((c) => c.login && !isBotLogin(c.login))
+    .flatMap((c) =>
+      c.mentions
+        .filter((m) => m && !sameLogin(m, me) && !sameLogin(m, c.login))
+        .map((m) => ({ of: m, at: c.at }))
+    )
+    .filter((p) => !spokeAfter(p.of, p.at));
+  const latestPing = newestBy(openPings);
+
+  const timedAsk = newestBy([chosen, latestPing].filter(Boolean));
+  if (timedAsk) {
+    signals.pendingReview = { of: timedAsk.of, days: daysSince(timedAsk.at) };
   } else if (pendingLogins.length) {
     // Named on the live list but no request event survived the cache cap —
     // we can still say WHO, just not when. The date clause gets dropped.

--- a/scripts/services/workbench-merge.js
+++ b/scripts/services/workbench-merge.js
@@ -334,6 +334,7 @@ function emptySignals() {
     myLastReplyDays: null,
     mention: null,
     changesRequested: null,
+    othersChangesRequested: null,
     pendingReview: null,
     waitingOn: null,
     noReviewerAssigned: false,
@@ -457,6 +458,28 @@ function buildSignals(local, upstream, me, now) {
     activity.reviews.filter((r) => r.login && !sameLogin(r.login, me) && !isBotActor(r.login))
   );
   signals.waitingOn = signals.pendingReview?.of || latestOtherReviewer?.login || null;
+
+  // A fellow reviewer already asked for changes and the PR's OWN AUTHOR
+  // hasn't addressed it — distinct from `changesRequested` above, which
+  // tracks whether YOU (as the PR's author) have replied. This is for PRs
+  // you're only reviewing: your own still-pending review request isn't the
+  // real blocker while someone else's change request sits unanswered by the
+  // author, so it shouldn't read as urgently as a first, untouched request.
+  const latestChangesForAuthor = newestBy(
+    activity.reviews.filter(
+      (r) =>
+        r.state === 'CHANGES_REQUESTED' &&
+        r.login &&
+        !sameLogin(r.login, me) &&
+        !sameLogin(r.login, local?.author)
+    )
+  );
+  if (latestChangesForAuthor && !spokeAfter(local?.author, latestChangesForAuthor.at)) {
+    signals.othersChangesRequested = {
+      by: latestChangesForAuthor.login,
+      days: daysSince(latestChangesForAuthor.at),
+    };
+  }
 
   // The PR-detail fields ride along with the widened activity cache, so their
   // presence marks a record we can reason about. Without them, "nobody is
@@ -848,6 +871,16 @@ function directPingStep(record, signals) {
     record.relationship === 'reviewing' &&
     (record.status === 'Request review' || Boolean(record.reviewRequest))
   ) {
+    // Someone else already asked for changes and the author hasn't moved —
+    // your pending request isn't what's actually blocking this. Stays an
+    // instruction (never silently demoted to Watching — some projects
+    // genuinely want every requested reviewer's independent pass regardless
+    // of what others already said), but describes the real state instead of
+    // issuing a flat "review it" that may not be true yet.
+    if (signals.othersChangesRequested) {
+      const { by, days } = signals.othersChangesRequested;
+      return `${by} requested changes ${days}d ago — not yet addressed`;
+    }
     return 'Review requested — review it';
   }
   return null;

--- a/scripts/services/workbench-merge.test.js
+++ b/scripts/services/workbench-merge.test.js
@@ -1229,6 +1229,69 @@ run(
   }
 );
 
+// G2d. You're still a pending reviewer, but a fellow reviewer already asked
+// for changes and the author hasn't addressed it — the request isn't stale
+// in the sense G3b covers, it just isn't the real blocker right now. Stays
+// in the action lane (never silently buried) with honest wording instead of
+// a flat "review it" that implies nothing has happened yet.
+run(
+  'G2d · fellow reviewer already requested changes, author silent → softened wording',
+  {
+    tasks: [
+      local({
+        repo: 'someorg/app',
+        number: 6023,
+        status: 'Request review',
+        lastActor: 'reviewerB',
+        author: 'writerA',
+        ...detail({
+          reviews: [{ login: 'reviewerB', state: 'CHANGES_REQUESTED', submittedAt: daysAgo(6) }],
+        }),
+      }),
+    ],
+  },
+  ({ records }) => {
+    const r = records[0];
+    assert.equal(r.lane, 'action');
+    assert.equal(r.ball, 'Take Action');
+    assert.equal(
+      r.nextStep,
+      'reviewerB requested changes 6d ago — not yet addressed',
+      r.nextStep
+    );
+  }
+);
+
+// G2e. Same setup, but the author already replied since the change request
+// (even though a third reviewer, not the author, ends up as the record's
+// last actor) — softened wording no longer applies, back to the plain
+// prompt, since there's something new for you to look at now.
+run(
+  'G2e · fellow reviewer requested changes, author already replied → plain prompt',
+  {
+    tasks: [
+      local({
+        repo: 'someorg/app',
+        number: 6024,
+        status: 'Request review',
+        lastActor: 'reviewerC',
+        author: 'writerA',
+        ...detail({
+          reviews: [{ login: 'reviewerB', state: 'CHANGES_REQUESTED', submittedAt: daysAgo(6) }],
+          comments: [
+            { login: 'writerA', createdAt: daysAgo(3), mentions: [] },
+            { login: 'reviewerC', createdAt: daysAgo(1), mentions: [] },
+          ],
+        }),
+      }),
+    ],
+  },
+  ({ records }) => {
+    const r = records[0];
+    assert.equal(r.nextStep, 'Review requested — review it', r.nextStep);
+  }
+);
+
 // G3. Your own PR, you spoke last → say when, and who owes you.
 run(
   'G3 · authored, I replied last → "You replied Nd ago — waiting on LOGIN"',

--- a/scripts/services/workbench-merge.test.js
+++ b/scripts/services/workbench-merge.test.js
@@ -1253,6 +1253,37 @@ run(
   }
 );
 
+// G3b. A stale, forgotten formal review request must not outrank a fresher
+// informal ping to someone else. Reproduces a real case: a reviewer was
+// formally requested via GitHub's "Request review" button months ago, never
+// answered, and never withdrawn — meanwhile the actual ask moved on to a
+// different person entirely, chased only through plain @-mentions.
+run(
+  'G3b · fresher ping to LOGIN outranks a stale, unwithdrawn formal request',
+  {
+    prs: [
+      local({
+        repo: 'someorg/app',
+        number: 6005,
+        lastActor: ME,
+        author: ME,
+        ...detail({
+          requestedReviewers: ['favour-chibueze'],
+          reviewRequests: [
+            { requestedReviewer: 'favour-chibueze', actor: ME, createdAt: daysAgo(190) },
+          ],
+          comments: [{ login: ME, createdAt: daysAgo(10), mentions: ['andersonjeccel'] }],
+        }),
+      }),
+    ],
+  },
+  ({ records }) => {
+    const r = records[0];
+    assert.equal(r.lane, 'waiting');
+    assert.equal(r.nextStep, 'You replied 10d ago — waiting on andersonjeccel', r.nextStep);
+  }
+);
+
 // G4. A bot pushed to your own PR. Never "author replied" — a push is not a
 // person answering you, it's a diff that moved under you.
 run(


### PR DESCRIPTION
## Description

Three related fixes to the Active Workbench, all around accurately signaling review state.

1. A formal GitHub "Request review" that was never answered and never withdrawn could permanently outrank a fresher, unanswered @-mention ping to someone else — even months later, once the real ask had clearly moved to a different person through plain comments instead. The signal now compares both by recency and prefers whichever is newer.

2. Being individually still on a PR's requested-reviewer list always read as "Review requested — review it," even when a fellow reviewer already requested changes and the PR's author hasn't addressed it yet. The row stays in the action lane (nothing gets silently buried), but now describes the actual state — who requested changes, and that it's unaddressed — instead of implying nothing has happened yet.

3. The relationship pill labels weren't consistent, and "reviewing" specifically implied you'd already reviewed the PR — not true when it's still awaiting your first review. Renamed to "PR review," and aligned "co-authoring"/"assigned issue" to "co-authored"/"assigned" to match "authored"'s tense.

Fixes 1 and 2 are covered by new regression tests in `scripts/services/workbench-merge.test.js`, reproducing the real cases that surfaced them, and verified against the merge engine's actual output for those PRs. Fix 3 is a display-only label rename, verified by inspecting the label map directly.