### PR TITLE
Fix what the Workbench claims, and publish the model as data

### DIFF
--- a/contents/docs-workflow-repos.js
+++ b/contents/docs-workflow-repos.js
@@ -3,15 +3,15 @@ module.exports = {
    * Docs-Workflow Repositories
    * --------------------------
    * Some projects run a documentation workflow with housekeeping steps that
-   * mean nothing anywhere else — a release milestone on every PR, a label that
-   * marks a docs PR as waiting on its code PR. Prompting for those on a repo
-   * that has never used them is pure noise, so each rule below is scoped to an
-   * explicit list of repos.
+   * mean nothing anywhere else — a release milestone on every PR, for
+   * instance. Prompting for those on a repo that has never used them is pure
+   * noise, so each repo-scoped rule below is scoped to an explicit list of
+   * repos.
    *
    * The scope is deliberately a list, never an inference: a PR that happens to
    * carry a milestone (or happens not to) says nothing about whether its
    * project expects one, so the presence of the field can't be used to decide
-   * this. Same for labels.
+   * this.
    *
    * Matching follows the same convention as excludedRepos in
    * repo-exclusions.js and allowedBot in allowed-bot.js — case-insensitive
@@ -26,16 +26,18 @@ module.exports = {
   milestoneRepos: ['mautic/user-documentation', 'mautic/developer-documentation-new'],
 
   /**
-   * Repos that mark a docs PR as waiting on its code PR with a label. Emits
-   * "Add <pendingLabel> label" on DRAFT PRs that don't carry it yet — a draft
-   * docs PR is, by definition, still pending something.
+   * NOT repo-scoped, unlike the list above it.
    *
-   * The prompt is a live read of the PR's labels every build, not a stored
-   * flag: add the label on GitHub and the chip is gone on the next run, with
-   * nothing to clear by hand.
+   * GitHub reports `mergeable_state: blocked` when a PR's branch protection
+   * requirements aren't satisfied — required reviews missing, required checks
+   * failing or still running. Nobody can merge such a PR yet, whatever repo it
+   * lives in, so there is no repo list to scope this to.
+   *
+   * The row states that reason in words. It is configured here rather than
+   * written into a renderer because the wording is a judgement about what the
+   * state means to a reader, and both generators must say the same thing.
+   *
+   * Blank it out to switch the reason (and with it the rule) off entirely.
    */
-  pendingLabelRepos: ['mautic/user-documentation', 'mautic/developer-documentation-new'],
-
-  /** The label name those repos use. */
-  pendingLabel: 'pending-pr-merge',
+  mergeBlockedReason: 'required checks or reviews not met',
 };

--- a/scripts/generators/html/workbench-html-generator.js
+++ b/scripts/generators/html/workbench-html-generator.js
@@ -209,6 +209,10 @@ const WORKBENCH_CSS = `
      upstream docs-PR tracker separates its teal setup chip from its blue
      act chip. */
   .wbx-step--setup{color:var(--t-brand);background:var(--t-brand-wash);border:1px solid var(--t-brand-line)}
+  /* Why this row is NOT in "Needs your action" — a hold, not an instruction,
+     so it reads muted rather than amber. text-transform is switched off on
+     purpose: this is a sentence about the PR's state, not a chip label. */
+  .wbx-step--hold{color:var(--t-ink-2);background:var(--t-neutral-wash);border:1px solid var(--t-neutral-line);text-transform:none;letter-spacing:0}
   .wbx-empty{text-align:center;padding:44px 20px;color:var(--t-ink-2)}
   .wbx-empty .g{font-size:2rem;color:var(--t-positive);font-weight:800}
   .wbx-chip-draft{display:inline-flex;align-items:center;font-family:ui-monospace,monospace;font-size:.75rem;letter-spacing:.03em;color:var(--t-neutral);background:var(--t-neutral-wash);border:1px solid var(--t-neutral-line);border-radius:999px;padding:1px 9px}
@@ -274,11 +278,19 @@ function statusSignatureFor(record) {
     record.botPing && record.botPing.of,
     record.linkedCodePr && record.linkedCodePr.ref,
     record.isDraft,
-    // Setting the milestone or the label is a real change of situation, so a
-    // row checked off while one was missing must not stay checked once it is.
+    // Setting the milestone is a real change of situation, so a row checked
+    // off while one was missing must not stay checked once it is.
     record.milestoneMissing,
-    record.pendingLabelMissing,
+    // A hold appearing or clearing (the merge unblocking) moves the row
+    // between lanes, so it belongs here too.
+    holdTexts(record).join('|'),
   ]);
+}
+
+/** The hold reasons as plain strings. They come from the merge engine, which
+ * reads the wording from config — see holdsFor there. */
+function holdTexts(record) {
+  return (record.waitingReasons || []).filter(Boolean);
 }
 
 function searchBlobFor(record, repoLabel) {
@@ -289,7 +301,7 @@ function searchBlobFor(record, repoLabel) {
     record.ball,
     record.nextStep,
     record.milestoneMissing ? 'add milestone' : null,
-    record.pendingLabelMissing ? `add ${record.pendingLabelMissing} label` : null,
+    ...holdTexts(record),
   ]
     .filter(Boolean)
     .join(' ')
@@ -311,13 +323,15 @@ function renderRow(record) {
   // upstream tracker, which pushes its "Add milestone" chip ahead of the
   // review chip because the milestone is the cheaper, more blocking fix.
   const nextBits = [];
-  if (record.pendingLabelMissing) {
-    nextBits.push(
-      `<span class="wbx-step wbx-step--setup">Add ${escapeHtml(record.pendingLabelMissing)} label</span>`
-    );
-  }
   if (record.milestoneMissing) {
     nextBits.push('<span class="wbx-step wbx-step--setup">Add milestone</span>');
+  }
+  // Why the row is parked, ahead of whatever step is left. On a held row this
+  // is the ONLY thing in the "next" line, because there is no action owed —
+  // and that is the point: the lane alone doesn't say why the row moved, so
+  // the reason travels with the row where a reader can check it.
+  for (const reason of holdTexts(record)) {
+    nextBits.push(`<span class="wbx-step wbx-step--hold">${escapeHtml(reason)}</span>`);
   }
   if (record.nextStep) {
     const stepClass = record.lane === 'ready' ? 'wbx-step--ship' : 'wbx-step--do';

--- a/scripts/generators/html/workbench-html-generator.js
+++ b/scripts/generators/html/workbench-html-generator.js
@@ -4,7 +4,7 @@
  *
  * Layer 1: plain-language impact header (any recruiter can read it).
  * Layer 2: five lanes ordered by what happens next —
- *   Needs your action (open by default)
+ *   Action needed (open by default)
  *   Approved — bring it home / Waiting on others / Stalled 30+ days /
  *   Automated (folded)
  *
@@ -33,8 +33,8 @@ const { escapeHtml } = require('../../utils/escape-html');
 const LANES = [
   {
     id: 'action',
-    title: 'Needs your action',
-    explain: 'Your move — feedback to address, a review waiting on you, or a note left after approval.',
+    title: 'Action needed',
+    explain: 'Feedback to address, a review waiting on a response, or a note left after approval.',
     open: true,
     stripe: 'var(--t-caution)',
   },
@@ -49,7 +49,7 @@ const LANES = [
   {
     id: 'waiting',
     title: 'Waiting on others',
-    explain: 'Your part is done — awaiting review, or blocked on a linked code PR.',
+    explain: 'Nothing left to do here — awaiting review, or blocked on a linked code PR.',
     open: false,
     stripe: 'var(--t-brand)',
   },
@@ -209,7 +209,7 @@ const WORKBENCH_CSS = `
      upstream docs-PR tracker separates its teal setup chip from its blue
      act chip. */
   .wbx-step--setup{color:var(--t-brand);background:var(--t-brand-wash);border:1px solid var(--t-brand-line)}
-  /* Why this row is NOT in "Needs your action" — a hold, not an instruction,
+  /* Why this row is NOT in "Action needed" — a hold, not an instruction,
      so it reads muted rather than amber. text-transform is switched off on
      purpose: this is a sentence about the PR's state, not a chip label. */
   .wbx-step--hold{color:var(--t-ink-2);background:var(--t-neutral-wash);border:1px solid var(--t-neutral-line);text-transform:none;letter-spacing:0}
@@ -382,21 +382,30 @@ function renderRow(record) {
   `;
 }
 
+/** Newest activity first — lower idleDays means the row moved more
+ * recently. Both generators render rows in this order by default (a
+ * fresh copy so the caller's array/order is untouched). */
+function sortNewestFirst(records) {
+  return [...records].sort((a, b) => (a.idleDays || 0) - (b.idleDays || 0));
+}
+
 function renderLane(lane, records) {
-  const rows = records.map(renderRow).join('');
+  const sortedRecords = sortNewestFirst(records);
+  const rows = sortedRecords.map(renderRow).join('');
   const body =
-    records.length > 0
+    sortedRecords.length > 0
       ? `<div class="wbx-rows">${rows}</div>`
       : '';
-  // Sorts by idle time, not the lane's own default order (idle desc for
-  // action/stalled, recency for the rest) — a manual override for anyone
-  // who wants to work oldest-first or newest-first regardless of lane.
+  // The manual sort button still sorts by idle time — a toggle for anyone
+  // who wants to work oldest-first or newest-first regardless of the
+  // newest-first default below. Starts at "asc" (matching the default
+  // render order) so the first click flips it to oldest-first.
   // Skipped below one row: nothing to reorder.
   const sortBtn =
-    records.length > 1
-      ? `<button type="button" class="wbx-sort-btn" data-lane-sort="${lane.id}" data-dir="desc" data-active="0" title="Sort by idle time" aria-label="Sort ${escapeHtml(lane.title)} by idle time, currently oldest first"><span class="wbx-sort-icon" aria-hidden="true">↕</span></button>`
+    sortedRecords.length > 1
+      ? `<button type="button" class="wbx-sort-btn" data-lane-sort="${lane.id}" data-dir="asc" data-active="0" title="Sort by idle time" aria-label="Sort ${escapeHtml(lane.title)} by idle time, currently newest first"><span class="wbx-sort-icon" aria-hidden="true">↕</span></button>`
       : '';
-  const defaultOpen = lane.open && records.length ? '1' : '0';
+  const defaultOpen = lane.open && sortedRecords.length ? '1' : '0';
   return dedent`
     <details class="wbx-lane" id="wbx-lane-${lane.id}" style="border-left-color:${lane.stripe}" data-default-open="${defaultOpen}" ${defaultOpen === '1' ? 'open' : ''}>
       <summary>
@@ -429,7 +438,7 @@ function renderLaneIndex(records) {
 
 function renderImpact(impact, feed) {
   // Captions carry the scope explicitly because they don't all share
-  // one: the hero is quarter-scoped, "approved" and "need your action"
+  // one: the hero is quarter-scoped, "approved" and "the ball is here"
   // describe the board's state right now (not a time window), and the
   // last two are calendar-month scoped. That mix is deliberate — this
   // board answers "what's happening right now," not a running lifetime
@@ -438,7 +447,7 @@ function renderImpact(impact, feed) {
   // its own scope rather than relying on a shared, unstated one.
   const helpedTile = {
     n: `${impact.helpedShipThisMonth}`,
-    c: 'contributions you helped ship this month',
+    c: 'contributions that got help shipping this month',
   };
   // Server-rendered fallback is always the absolute build time — a static
   // page can be viewed long after generation, so "just now" would go stale
@@ -460,7 +469,7 @@ function renderImpact(impact, feed) {
       <div class="wbx-tiles">
         <div class="wbx-tile wbx-tile--hero"><span class="n">${impact.shippedThisQuarter}</span><span class="c">changes shipped in ${currentQuarterLabel()}</span></div>
         <div class="wbx-tile wbx-tile--good"><span class="n">${impact.approvedLanding}</span><span class="c">approved &amp; heading to merge — on the board now</span></div>
-        <div class="wbx-tile wbx-tile--hot"><span class="n">${impact.needAction}</span><span class="c">need your action now</span></div>
+        <div class="wbx-tile wbx-tile--hot"><span class="n">${impact.needAction}</span><span class="c">items where the ball is here</span></div>
         <div class="wbx-tile"><span class="n">${helpedTile.n}</span><span class="c">${helpedTile.c}</span></div>
         <div class="wbx-tile"><span class="n">${impact.projectsThisMonth}</span><span class="c">projects across ${impact.organizationsThisMonth} organization${impact.organizationsThisMonth === 1 ? '' : 's'} this month</span></div>
       </div>
@@ -507,8 +516,8 @@ async function createWorkbenchHtml({ records, impact, feed }) {
       ? dedent`
         <div class="wbx-empty">
           <div class="g">✓</div>
-          <h2 style="font-size:1.25rem;font-weight:800;margin-top:8px;color:var(--t-ink)">Your court is clear.</h2>
-          <p style="max-width:44ch;margin:10px auto 0;font-size:.9rem">No open tasks locally, and the tracker has nothing waiting on you.</p>
+          <h2 style="font-size:1.25rem;font-weight:800;margin-top:8px;color:var(--t-ink)">The court is clear.</h2>
+          <p style="max-width:44ch;margin:10px auto 0;font-size:.9rem">No open tasks locally, and the tracker has nothing pending.</p>
         </div>`
       : `<div class="wbx-lanes">${LANES.map((lane) =>
           renderLane(lane, records.filter((r) => r.lane === lane.id))
@@ -536,6 +545,7 @@ async function createWorkbenchHtml({ records, impact, feed }) {
             <header class="mt-16 mb-10">
               <p style="font-family:ui-monospace,monospace;font-size:.75rem;letter-spacing:.14em;text-transform:uppercase;color:var(--t-ink-3)">active workbench</p>
               <h1 class="text-4xl sm:text-5xl font-extrabold mt-2 mb-4" style="color:var(--t-brand);letter-spacing:-.01em">Organized by what happens next</h1>
+              <p style="max-width:60ch;color:var(--t-ink-2);font-size:.92rem">This page is the complete working board behind the summary at <a href="https://adiati.com/oss-portfolio/workbench/" target="_blank" rel="noopener noreferrer" style="color:var(--t-brand)">adiati.com</a>, published in full so that summary can be checked against it.</p>
             </header>
             ${renderImpact(impact, feed)}
             ${humanRecords.length > 0 ? renderLaneIndex(records) : ''}
@@ -723,4 +733,4 @@ async function createWorkbenchHtml({ records, impact, feed }) {
   console.log(`Generated Workbench page at ${outputPath}`);
 }
 
-module.exports = { createWorkbenchHtml, LANES };
+module.exports = { createWorkbenchHtml, LANES, sortNewestFirst };

--- a/scripts/generators/markdown/community-markdown-generator.js
+++ b/scripts/generators/markdown/community-markdown-generator.js
@@ -217,13 +217,17 @@ function repoCell(record) {
   return bits.join('<br>');
 }
 
-/** Mirrors renderRow's nextBits, in the same order: actions first (add
- * milestone, then the next step), then the context notes. */
+/** Mirrors renderRow's nextBits, in the same order: actions first (add the
+ * milestone), then why the row is held, then the next step, then the context
+ * notes. */
 function nextCell(record) {
   const bits = [];
-  if (record.pendingLabelMissing)
-    bits.push(`**Add ${mdEscapeCell(record.pendingLabelMissing)} label**`);
   if (record.milestoneMissing) bits.push('**Add milestone**');
+  // Why the row is parked. The wording comes from config via the merge engine,
+  // never from this file, so both generators say the same thing.
+  for (const reason of record.waitingReasons || []) {
+    if (reason) bits.push(mdEscapeCell(reason));
+  }
   if (record.nextStep) bits.push(mdEscapeCell(record.nextStep));
   if (record.approval && record.approval.by) {
     const dismissedNote = record.approval.dismissed ? ' — dismissed after update' : '';

--- a/scripts/generators/markdown/community-markdown-generator.js
+++ b/scripts/generators/markdown/community-markdown-generator.js
@@ -1,7 +1,7 @@
 const fs = require('fs/promises');
 const path = require('path');
 const { BASE_DIR } = require('../../config/config');
-const { LANES } = require('../html/workbench-html-generator');
+const { LANES, sortNewestFirst } = require('../html/workbench-html-generator');
 const { THEME } = require('../../config/constants');
 const { mdEscapeCell, mdEscapeLinkText } = require('./md-escape');
 const {
@@ -171,7 +171,8 @@ const stripHash = (hex) =>
  * (badges render on GitHub's light chrome regardless of the viewer's OS
  * theme). Waiting intentionally matches Approved: both render with
  * `--t-positive` in workbench.html's PILL_CLASS (wbx-pill--wait / --ok) —
- * "waiting" here means your part is done, not that something is wrong.
+ * "waiting" here means that side of the work is done, not that something
+ * is wrong.
  */
 const BALL_COLOR = {
   'Take Action': stripHash(THEME.semantic.caution.light.text),
@@ -257,14 +258,15 @@ function taskCell(record) {
 
 /** One `<details>` block per lane — title/explain/open/order all come from the shared LANES config. */
 function renderLaneSection(lane, records) {
-  let section = `<details${lane.open && records.length > 0 ? ' open' : ''}>\n`;
-  section += `  <summary><h3 style="display: inline-block; cursor: pointer;">${LANE_ICON[lane.id]} ${lane.title} (${records.length})</h3></summary>\n\n`;
+  const sortedRecords = sortNewestFirst(records);
+  let section = `<details${lane.open && sortedRecords.length > 0 ? ' open' : ''}>\n`;
+  section += `  <summary><h3 style="display: inline-block; cursor: pointer;">${LANE_ICON[lane.id]} ${lane.title} (${sortedRecords.length})</h3></summary>\n\n`;
   section += `  <sub>${lane.explain}</sub>\n\n`;
 
-  if (records.length > 0) {
+  if (sortedRecords.length > 0) {
     section += `  | Status | Repo | Task | Next |\n`;
     section += `  | :--- | :--- | :--- | :--- |\n`;
-    records.forEach((record) => {
+    sortedRecords.forEach((record) => {
       section += `  | ${statusCell(record)} | ${repoCell(record)} | ${taskCell(record)} | ${nextCell(record)} |\n`;
     });
     section += `\n`;
@@ -287,15 +289,15 @@ function renderImpactSection(impact, feed) {
     impact.contributorsHelpedThisMonth > 0
       ? [
           `${impact.contributorsHelpedThisMonth}`,
-          `contributors' work you've helped ship this month`,
+          `contributors' work that got help shipping this month`,
         ]
-      : [`${impact.helpedShipThisMonth}`, `contributions you helped ship this month`];
+      : [`${impact.helpedShipThisMonth}`, `contributions that got help shipping this month`];
 
   let md = `## 📊 Active across open source — live maintainer & contribution activity\n\n`;
   md += `| Metric | Activity |\n| :--- | :--- |\n`;
   md += `| 🚀 **${impact.shippedThisQuarter}** | changes shipped this quarter |\n`;
   md += `| ✅ **${impact.approvedLanding}** | approved & heading to merge |\n`;
-  md += `| 🔥 **${impact.needAction}** | need your action now |\n`;
+  md += `| 🔥 **${impact.needAction}** | items where the ball is here |\n`;
   md += `| 🤝 **${helpedTile[0]}** | ${helpedTile[1]} |\n`;
   md += `| 🌐 **${impact.projectsThisMonth}** | projects across ${impact.organizationsThisMonth} organization${impact.organizationsThisMonth === 1 ? '' : 's'} this month |\n\n`;
 
@@ -327,6 +329,7 @@ async function createWorkbenchMarkdown({ records, impact, feed }) {
 
   let md = `# Active Workbench\n\n`;
   md += `Live maintainer and contribution activity, organized by what happens next.\n\n`;
+  md += `This page is the complete working board behind the summary at [adiati.com](https://adiati.com/oss-portfolio/workbench/), published in full so that summary can be checked against it.\n\n`;
   md += renderImpactSection(impact, feed);
 
   // "Approved is not done": every ready-lane row still needs a final review,
@@ -334,8 +337,8 @@ async function createWorkbenchMarkdown({ records, impact, feed }) {
   const humanRecords = records.filter((r) => r.lane !== 'bot');
 
   if (humanRecords.length === 0) {
-    md += `## ✅ Your court is clear.\n\n`;
-    md += `No open tasks locally, and the tracker has nothing waiting on you.\n\n`;
+    md += `## ✅ The court is clear.\n\n`;
+    md += `No open tasks locally, and the tracker has nothing pending.\n\n`;
   } else {
     LANES.forEach((lane) => {
       md += renderLaneSection(

--- a/scripts/services/workbench-data.js
+++ b/scripts/services/workbench-data.js
@@ -1,0 +1,76 @@
+const path = require('path');
+const fs = require('fs/promises');
+
+/**
+ * data/workbench.json — the published workbench contract.
+ *
+ * WHAT IT IS
+ * ----------
+ * The classified workbench model — lane, ball, next step, holds, approval
+ * verdict, chips — written out as data on every run, next to the raw
+ * ongoing-*.json files.
+ *
+ * It exists so other projects (adiati.com) can READ the verdict instead of
+ * re-deriving it from the raw files. The classifier in workbench-merge.js is
+ * the single source of truth; a second implementation elsewhere drifts, and
+ * every rule change then has to be made twice.
+ *
+ * This file is a PUBLISHED CONTRACT, not an internal cache. Other projects
+ * read it. Do not reshape it casually.
+ *
+ * HOW IT IS BUILT
+ * ---------------
+ * Straight from the same in-memory model the HTML and markdown generators
+ * render from (`loadMergedWorkbench()` in workbench-merge.js). Nothing here
+ * recomputes, re-classifies or re-sorts anything. If this file and the
+ * rendered Workbench page could disagree, the whole point is lost.
+ *
+ * WHAT IS IN IT
+ * -------------
+ *   schemaVersion  integer, currently 1 (see the versioning rule below)
+ *   generatedAt    ISO timestamp of the run that wrote the file
+ *   feed           tracker feed status: fetchedAt, degraded, reason — so a
+ *                  consumer can tell a stale run from a fresh one
+ *   impact         the aggregates from computeImpact()
+ *   records        the merged records, in the order the generators get them
+ *                  (lane order, then most-urgent first)
+ *
+ * Records carry conclusions, not evidence: no raw comment bodies, no review
+ * arrays, no PR bodies. A consumer that needs the evidence should read the
+ * raw ongoing-*.json files, not this one.
+ *
+ * VERSIONING RULE
+ * ---------------
+ * `schemaVersion` MUST be incremented whenever a field is REMOVED or its
+ * MEANING CHANGES. Adding a new field is not a breaking change and must not
+ * bump the version — consumers ignore fields they do not know.
+ */
+const SCHEMA_VERSION = 1;
+
+/**
+ * Serializes the already-merged workbench model. Takes the exact object
+ * `loadMergedWorkbench()` returned — no re-derivation.
+ */
+function buildWorkbenchData(model, now = new Date()) {
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    generatedAt: now.toISOString(),
+    feed: {
+      fetchedAt: model.feed?.fetchedAt || null,
+      degraded: Boolean(model.feed?.degraded),
+      reason: model.feed?.reason || null,
+    },
+    impact: model.impact,
+    records: model.records,
+  };
+}
+
+/** Writes data/workbench.json from the merged model used by the generators. */
+async function writeWorkbenchData(model, { dataDir = 'data', now } = {}) {
+  const file = path.join(dataDir, 'workbench.json');
+  const payload = buildWorkbenchData(model, now || new Date());
+  await fs.writeFile(file, JSON.stringify(payload, null, 2), 'utf8');
+  return file;
+}
+
+module.exports = { SCHEMA_VERSION, buildWorkbenchData, writeWorkbenchData };

--- a/scripts/services/workbench-merge.js
+++ b/scripts/services/workbench-merge.js
@@ -1080,12 +1080,27 @@ function laneFor(record, me, botPingSignal, signals) {
   const turn = deriveTurn(record, me, botPingSignal, signals);
   if (turn.lane === 'action') return turn;
 
+  // Rule 3b — a draft with linked work outstanding is not idle by choice: it is
+  // waiting on someone else's PR by design, and "nudge or close" is not a
+  // decision that can be made from this side. Scoped to the SHAPE (draft +
+  // unresolved linked code PR), not to any one project — right now only Mautic
+  // docs PRs happen to look like this, but the rule must not become a repo
+  // check. Rule 3a above already peels off a merged or closed linked code PR
+  // into its own action step, so an untouched linkedCodePr reaching this line
+  // is either genuinely still open, or — on a tracker-only row — of unknown
+  // state, since that path carries no linkedCodePrState at all. A tracker-only
+  // draft whose linked code PR was quietly closed unmerged therefore stays
+  // quiet here instead of being flagged. That's a missed prompt on a private
+  // tool, not a false claim on a public page, and it's not worth an extra API
+  // call to close.
+  const draftBlockedOnLinkedWork = record.isDraft && Boolean(linkedCodePr);
+
   // Waiting on someone else, and untouched for a month — fold it away. The
   // contextual signals the turn logic derived have to survive the demotion:
   // botPing is the only one deriveLane owns (approval and reviewedNote already
   // live on the record), and without it a stalled row loses its explanation of
   // who it's actually waiting on.
-  if (idleDays >= STALLED_AFTER_DAYS) {
+  if (idleDays >= STALLED_AFTER_DAYS && !draftBlockedOnLinkedWork) {
     return {
       lane: 'stalled',
       ball: 'Stale',

--- a/scripts/services/workbench-merge.js
+++ b/scripts/services/workbench-merge.js
@@ -1004,7 +1004,7 @@ function laneFor(record, me, botPingSignal, signals) {
       nextStep:
         age >= REMIND_AFTER_DAYS
           ? `Assigned ${age}d ago, no PR yet — start the work`
-          : 'Assigned to you, no PR yet — start the work',
+          : 'Assigned, no PR yet — start the work',
     };
   }
 
@@ -1104,8 +1104,8 @@ function directPingStep(record, signals) {
   if (signals.mention && signals.mention.by) {
     const { by, days } = signals.mention;
     return days == null
-      ? `${by} mentioned you — reply`
-      : `${by} mentioned you ${days}d ago — reply`;
+      ? `Mentioned by ${by} — reply`
+      : `Mentioned by ${by} ${days}d ago — reply`;
   }
   if (
     record.relationship === 'reviewing' &&
@@ -1252,7 +1252,7 @@ function turnReading(record, me, signals) {
       return {
         lane: 'waiting',
         ball: 'Waiting',
-        nextStep: `You reviewed ${sinceMyReply}d ago — author hasn't replied`,
+        nextStep: `Reviewed ${sinceMyReply}d ago — author hasn't replied`,
       };
     }
     if (isAuthor) {
@@ -1310,8 +1310,8 @@ function turnReading(record, me, signals) {
       lane: 'waiting',
       ball: 'Waiting',
       nextStep: signals.waitingOn
-        ? `You replied ${sinceMyReply}d ago — waiting on ${signals.waitingOn}`
-        : `You replied ${sinceMyReply}d ago`,
+        ? `Replied ${sinceMyReply}d ago — waiting on ${signals.waitingOn}`
+        : `Replied ${sinceMyReply}d ago`,
     };
   }
   if (actorIsBot) {

--- a/scripts/services/workbench-merge.js
+++ b/scripts/services/workbench-merge.js
@@ -350,6 +350,13 @@ function daysBetween(from, to) {
   return (to - new Date(from)) / (1000 * 60 * 60 * 24);
 }
 
+/** Later of two ISO date strings, tolerating either being absent. */
+function latestDate(a, b) {
+  if (!a) return b || null;
+  if (!b) return a;
+  return new Date(a) >= new Date(b) ? a : b;
+}
+
 function sameLogin(a, b) {
   const x = String(a || '').toLowerCase();
   const y = String(b || '').toLowerCase();
@@ -1421,7 +1428,18 @@ function mergeWorkbench({
     const upstream = key && tracker[key] ? tracker[key] : null;
     if (upstream) matchedKeys.add(key);
 
-    const effectiveDate = local.lastSubstantiveDate || local.updatedAt || local.createdAt;
+    // A docs PR and its linked code PR are one piece of work, so idle time
+    // counts activity on either. lastSubstantiveDate/updatedAt/createdAt stays
+    // the docs-side date — lastSubstantiveDate in particular is the last
+    // genuine event (a commit or review), deliberately more precise than a raw
+    // updated_at that bots and label edits bump — codeUpdatedAt is only added
+    // as one more candidate, whichever side is later wins.
+    // codeUpdatedAt IS a raw updated_at on the code PR, so a bot comment there
+    // can make the pair look active too. The upstream tracker's own staleness
+    // rule reads the same field, so this matches its behaviour, and the error
+    // direction is safe: it under-reports staleness, never over-reports it.
+    const docsDate = local.lastSubstantiveDate || local.updatedAt || local.createdAt;
+    const effectiveDate = latestDate(docsDate, upstream ? upstream.codeUpdatedAt : null);
     const idleDays = effectiveDate ? Math.max(0, daysBetween(effectiveDate, nowDate)) : 0;
     const linkedCodePr = extractLinkedCodePr(local.body, local.repo);
     const signals = deriveSignals(local, upstream, me, nowDate);
@@ -1491,7 +1509,7 @@ function mergeWorkbench({
     const approval = deriveApproval(null, signals.activity, approvalContext(repo));
     const reviewRequest = deriveReviewRequest(signals.activity, me);
     const reviewedNote = deriveReviewedNote(signals.activity, approval, me);
-    const effectiveDate = upstream.docsUpdatedAt || null;
+    const effectiveDate = latestDate(upstream.docsUpdatedAt, upstream.codeUpdatedAt);
     const idleDays = effectiveDate ? Math.max(0, daysBetween(effectiveDate, nowDate)) : 0;
 
     const record = {
@@ -1532,6 +1550,12 @@ function mergeWorkbench({
         docsCommentCount: (upstream.rawDocsComments || []).length,
       },
       idleDays,
+      // The docs PR's OWN last-updated date, deliberately not `effectiveDate`.
+      // idleDays is the field that reasons about two PRs at once; this one
+      // answers "when did this row last change", and a reader — including
+      // data/workbench.json's consumers — would fairly read it that way. It is
+      // also what the recency sort below orders on, alongside `local.updatedAt`
+      // on the matched path, so both paths must mean the same thing by it.
       updatedAt: upstream.docsUpdatedAt || null,
       linkedPr: null,
     };

--- a/scripts/services/workbench-merge.js
+++ b/scripts/services/workbench-merge.js
@@ -12,6 +12,11 @@
  *   - approval    { state, by, noteSince } — "approved" starts a checklist,
  *                 it does not end one
  *   - nextStep    plain-language remaining action (required for action/ready)
+ *   - waitingReasons
+ *                 plain-language strings — why this row is NOT in the action
+ *                 lane when something definitive is holding it there (today:
+ *                 a blocked merge state). Empty on action rows. The wording
+ *                 comes from config, never a renderer.
  *   - linkedCodePr / upstream signals from the tracker cache
  *   - idleDays    how long a row has sat untouched; shown on the pill and
  *                 drives the 30d stalled fold. "Escalate" is reserved for the
@@ -46,6 +51,16 @@ const TRACKER_RAW_URL =
   'https://raw.githubusercontent.com/adiati98/mautic-docs-prs-tracker/main/data/pr-cache.json';
 const TRACKER_CACHE_FILE = path.join('data', 'tracker-cache.json');
 
+/**
+ * The docs team roster, in the same public repo the tracker feed comes from.
+ * `educationTeam` is an array of GitHub logins. The roster belongs to that
+ * team and changes without reference to this tool, so it is fetched every
+ * build rather than copied into this codebase.
+ */
+const ROSTER_RAW_URL =
+  'https://raw.githubusercontent.com/adiati98/mautic-docs-prs-tracker/main/maintainers.json';
+const ROSTER_CACHE_FILE = path.join('data', 'tracker-roster-cache.json');
+
 const STALLED_AFTER_DAYS = 30;
 const REMIND_AFTER_DAYS = 7;
 
@@ -60,11 +75,10 @@ function loadDocsWorkflow() {
     const list = (key) => (config[key] || []).map((r) => String(r).toLowerCase()).filter(Boolean);
     return {
       milestoneRepos: list('milestoneRepos'),
-      pendingLabelRepos: list('pendingLabelRepos'),
-      pendingLabel: String(config.pendingLabel || '').trim(),
+      mergeBlockedReason: String(config.mergeBlockedReason || '').trim(),
     };
   } catch (e) {
-    return { milestoneRepos: [], pendingLabelRepos: [], pendingLabel: '' };
+    return { milestoneRepos: [], mergeBlockedReason: '' };
   }
 }
 
@@ -85,12 +99,6 @@ function matchesRepoList(repo, list) {
  */
 function tracksMilestones(repo) {
   return matchesRepoList(repo, DOCS_WORKFLOW.milestoneRepos);
-}
-
-/** Whether `repo` marks docs PRs as pending their code PR with a label. */
-function usesPendingLabel(repo) {
-  if (!DOCS_WORKFLOW.pendingLabel) return false;
-  return matchesRepoList(repo, DOCS_WORKFLOW.pendingLabelRepos);
 }
 
 // ---------------------------------------------------------------------------
@@ -165,6 +173,82 @@ async function fetchTrackerFeed({ url = TRACKER_RAW_URL, timeoutMs = 10000 } = {
       fetchedAt: null,
       degraded: true,
       reason: `live fetch failed (${err.message}); no cached feed available`,
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Docs team roster: fetch → validate → cache → degrade
+// ---------------------------------------------------------------------------
+
+/** A valid roster is an object carrying an `educationTeam` array. */
+function isValidRosterShape(data) {
+  if (!data || typeof data !== 'object' || Array.isArray(data)) return false;
+  return Array.isArray(data.educationTeam);
+}
+
+function normalizeRoster(data) {
+  return data.educationTeam.map((s) => String(s).trim().toLowerCase()).filter(Boolean);
+}
+
+async function readRosterCacheFile() {
+  try {
+    const raw = await fs.readFile(ROSTER_CACHE_FILE, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (parsed && isValidRosterShape(parsed.data)) return parsed;
+  } catch (e) {
+    /* no usable cache */
+  }
+  return null;
+}
+
+/**
+ * Fetches the docs team roster with the same degradation discipline as the
+ * tracker feed:
+ *   live fetch OK  → { educationTeam, fetchedAt, degraded: false }
+ *   fetch fails    → last cached copy, degraded: true, reason
+ *   no cache       → EMPTY roster, degraded: true, reason
+ *
+ * The last line is the critical one. An empty roster switches the
+ * outside-approval rule off entirely (see approvalIsDecisive), so a file that
+ * failed to download behaves exactly like the code did before this rule
+ * existed: every approval counts. A fetch failure must never read as a
+ * judgement about anyone's content.
+ */
+async function fetchTeamRoster({ url = ROSTER_RAW_URL, timeoutMs = 10000 } = {}) {
+  try {
+    const res = await axios.get(url, { timeout: timeoutMs, responseType: 'json' });
+    if (!isValidRosterShape(res.data)) {
+      throw new Error('roster shape changed (schema drift)');
+    }
+    const fetchedAt = new Date().toISOString();
+    try {
+      await fs.mkdir(path.dirname(ROSTER_CACHE_FILE), { recursive: true });
+      await fs.writeFile(ROSTER_CACHE_FILE, JSON.stringify({ fetchedAt, data: res.data }), 'utf8');
+    } catch (e) {
+      /* cache write is best-effort */
+    }
+    return {
+      educationTeam: normalizeRoster(res.data),
+      fetchedAt,
+      degraded: false,
+      reason: null,
+    };
+  } catch (err) {
+    const cached = await readRosterCacheFile();
+    if (cached) {
+      return {
+        educationTeam: normalizeRoster(cached.data),
+        fetchedAt: cached.fetchedAt || null,
+        degraded: true,
+        reason: `live fetch failed (${err.message}); using cached roster`,
+      };
+    }
+    return {
+      educationTeam: [],
+      fetchedAt: null,
+      degraded: true,
+      reason: `live fetch failed (${err.message}); no cached roster — every approval counts`,
     };
   }
 }
@@ -340,7 +424,7 @@ function emptySignals() {
     noReviewerAssigned: false,
     conflict: null,
     milestoneMissing: false,
-    pendingLabelMissing: null,
+    mergeBlocked: false,
   };
 }
 
@@ -357,6 +441,7 @@ function emptySignals() {
  *   noReviewerAssigned  ready, non-draft, nobody asked to look
  *   conflict            ONLY when the merge state is definitively dirty
  *   milestoneMissing    milestone-tracking repo, no milestone set
+ *   mergeBlocked        ONLY when the merge state is definitively blocked
  *
  * Wrapped so a drifted or malformed record produces no signals instead of a
  * throw — the merge must never fail the build.
@@ -497,54 +582,90 @@ function buildSignals(local, upstream, me, now) {
     activity.reviews.length === 0 &&
     local.hasFormalReview !== true;
 
-  // ONLY a definitively dirty merge state counts. GitHub reports `unknown`
-  // (and this field reports null) while it is still computing mergeability, so
-  // anything that isn't literally "dirty" stays silent rather than guessing —
-  // and there is nothing to retry, the next build reads a fresh value anyway.
-  if (String(local?.mergeableState || '').toLowerCase() === 'dirty') {
+  // Only DEFINITIVE merge states count. GitHub reports `unknown` (and this
+  // field reports null) while it is still computing mergeability, so a value
+  // that isn't one of the two read here stays silent rather than being guessed
+  // at — and there is nothing to retry, the next build reads a fresh value
+  // anyway. That deliberate rule is unchanged; `blocked` joins `dirty` because
+  // GitHub states it just as definitively, not because we infer it.
+  //
+  //   dirty    the branch conflicts with its base — the AUTHOR must rebase
+  //   blocked  branch protection isn't satisfied (required reviews missing,
+  //            required checks failing or still running) — nobody can merge
+  //            this yet, so it is not a job waiting on anyone here
+  const mergeState = String(local?.mergeableState || '').toLowerCase();
+  if (mergeState === 'dirty') {
     signals.conflict = { base: local.baseRef || null };
   }
+  // Gated on the reason being configured: the rule may only move a row when it
+  // can also print WHY on that row. Blank the reason in config and the rule is
+  // off, rather than silently relocating rows with nothing to show for it.
+  signals.mergeBlocked = Boolean(DOCS_WORKFLOW.mergeBlockedReason) && mergeState === 'blocked';
 
   signals.milestoneMissing = hasPrDetail && tracksMilestones(local?.repo) && !local.milestone;
 
-  // A DRAFT docs PR is by definition still pending something, so in projects
-  // that track that with a label it should be carrying one. Draft-gated on
-  // purpose, matching the upstream tracker: once the PR is ready for review
-  // the label is a judgement call about the linked code PR, not a lapse.
-  //
-  // Read live from the PR's own labels every build — never a stored flag — so
-  // adding the label on GitHub clears the chip on the next run with nothing to
-  // reset by hand. Unlike the milestone this needs no hasPrDetail gate: every
-  // PR record already carries its labels, so an empty list is a real answer.
-  //
-  // Carries the LABEL NAME when it's missing (null otherwise) so the chip can
-  // name it — the label is configurable per project, so hardcoding the wording
-  // in the renderers would silently lie for any repo that renames it.
-  const labelMissing =
-    Boolean(local) &&
-    local.isDraft === true &&
-    usesPendingLabel(local.repo) &&
-    !(Array.isArray(local.labels) ? local.labels : []).some(
-      (l) => String(l).toLowerCase() === DOCS_WORKFLOW.pendingLabel.toLowerCase()
-    );
-  signals.pendingLabelMissing = labelMissing ? DOCS_WORKFLOW.pendingLabel : null;
-
-  // A DRAFT docs PR is by definition still pending something, so in projects
-  // that track that with a label it should be carrying one. Draft-gated on
-  // purpose, matching the upstream tracker: once the PR is ready for review
-  // the label is a judgement call about the linked code PR, not a lapse.
-  // Unlike the milestone this reads a field every PR record already has, so
-  // there's no hasPrDetail gate — an empty label list is a real answer.
-
   return signals;
+}
+
+/**
+ * Everyone who APPROVED this row, from either side of the join. Dismissed
+ * reviews are deliberately excluded: a dismissed approval is not a standing
+ * verdict on the content, so it must not be counted as one either way.
+ */
+function collectApprovers(local, activity) {
+  const logins = [];
+  if (local && (local.reviewState === 'APPROVED' || local.status === 'APPROVED') && local.approvedBy) {
+    logins.push(String(local.approvedBy).trim());
+  }
+  for (const r of activity && Array.isArray(activity.reviews) ? activity.reviews : []) {
+    if (r.state === 'APPROVED' && r.login) logins.push(r.login);
+  }
+  return logins.filter(Boolean);
+}
+
+/**
+ * Whether an approval on this row means the CONTENT has been checked.
+ *
+ * An operator approving a docs PR from inside the education team vouches for
+ * wording and style — not for whether the content is accurate. Only an
+ * approval from OUTSIDE that team (the code PR's author, or another outside
+ * reviewer) means the work has genuinely been verified. Routing an in-team
+ * approval into the "approved, heading to merge" lane overstates the claim,
+ * and that lane is published, so the overstatement is public.
+ *
+ * FOUR ways this returns true — i.e. behaves exactly as the code did before
+ * the rule existed. Each one is deliberate:
+ *
+ *   - the repo is outside the tracker's scope. An education-team approval
+ *     means nothing in an unrelated org, and applying the rule everywhere
+ *     would quietly demote approvals from projects it was never about.
+ *   - the roster is empty. That is what a failed fetch with no cached copy
+ *     looks like (see fetchTeamRoster), and a download failure must never be
+ *     dressed up as a judgement about someone's content.
+ *   - nobody identifiable approved — e.g. only a DISMISSED review survives,
+ *     which names an approver but carries no standing approval. Unknown is
+ *     not the same as in-team, so the row keeps the lane it has today.
+ *   - at least one approver is from outside the team. One outside check is
+ *     enough; the content has been looked at by someone who can vouch for it.
+ */
+function approvalIsDecisive(approvers, { educationTeam = [], inTrackerScope = false } = {}) {
+  if (!inTrackerScope) return true;
+  if (!educationTeam.length) return true;
+  if (!approvers.length) return true;
+  return approvers.some((login) => !educationTeam.some((member) => sameLogin(member, login)));
 }
 
 /**
  * Latest approval visible from either side of the join, plus whether any
  * substantive (non-bot) comment landed AFTER that approval — the "note since
  * approval — take a look" signal.
+ *
+ * `context` carries the docs-team roster and whether this row's repo is one
+ * the tracker covers; together they decide `verified` — see approvalIsDecisive.
+ * Omit it and every approval is treated as decisive, which is what an absent
+ * or unfetchable roster must look like.
  */
-function deriveApproval(local, activity) {
+function deriveApproval(local, activity, context = {}) {
   let state = null;
   let by = null;
   let approvedAt = null;
@@ -599,7 +720,12 @@ function deriveApproval(local, activity) {
     );
   }
 
-  return { state, by, approvedAt, noteSince, dismissed, dismissedAt };
+  // Who approved is recorded either way — the row still shows "approved by X"
+  // as context. `verified` only decides whether that approval is allowed to
+  // route the row into the "approved, heading to merge" lane.
+  const verified = approvalIsDecisive(collectApprovers(local, activity), context);
+
+  return { state, by, approvedAt, noteSince, dismissed, dismissedAt, verified };
 }
 
 /**
@@ -712,48 +838,146 @@ function deriveBotPing(activity, local, me) {
 // ---------------------------------------------------------------------------
 
 /**
+ * The "nobody can move this yet" holds on a row, as plain-language strings.
+ *
+ * The wording comes from config (contents/docs-workflow-repos.js), never from
+ * a renderer: it is a judgement about what a GitHub state means to a reader,
+ * and both generators have to say the same thing.
+ */
+function holdsFor(signals) {
+  const holds = [];
+  if (signals.mergeBlocked) {
+    holds.push(DOCS_WORKFLOW.mergeBlockedReason);
+  }
+  return holds;
+}
+
+/**
+ * Whether something on this row names the OWNER specifically, rather than the
+ * board inferring "your turn" from whoever moved last. A hold never overrides
+ * one of these — being asked by name survives the PR being unmergeable:
+ *
+ *   - an @-mention of you nobody has heard back on, including one from an
+ *     allow-listed bot
+ *   - a review request aimed at you. This one matters most: `blocked` very
+ *     often means the missing requirement is an approving review, and if you
+ *     are the requested reviewer then YOU are the block. Demoting that would
+ *     hide exactly the work this board exists to surface.
+ *   - changes requested on a PR of yours and still unanswered — a blocked
+ *     merge state is the CONSEQUENCE of that, not a separate excuse
+ *   - the linked code PR having merged or closed, which is decisive
+ *   - a note left after approval, and missing housekeeping (a milestone is
+ *     owed whatever the merge is waiting on)
+ *   - assigned issues, which have no merge state and no PR to park
+ */
+function hasNamedAsk(record, signals, botPingSignal) {
+  if (record.relationship === 'assigned issue') return true;
+  if (signals.mention) return true;
+  if (botPingSignal && botPingSignal.mentionsMe) return true;
+  if (record.reviewRequest || record.status === 'Request review') return true;
+  if (
+    (record.relationship === 'authored' || record.relationship === 'co-authoring') &&
+    signals.changesRequested
+  ) {
+    return true;
+  }
+  if (record.linkedCodePrState === 'merged' || record.linkedCodePrState === 'closed') return true;
+  if (record.approval && record.approval.noteSince) return true;
+  if (signals.milestoneMissing) return true;
+  return false;
+}
+
+/**
+ * Where a held row lands: the WAITING lane, and nowhere else.
+ *
+ * "Needs your action" asserts a job is owed to the owner, and while GitHub
+ * reports the merge blocked that assertion is false — the row is parked on
+ * required reviews or required checks, neither of which the owner can clear by
+ * working on this row. Waiting on others already reads *your part is done —
+ * awaiting review, or blocked on a linked code PR*, which is these rows
+ * exactly.
+ *
+ * Three deliberate limits:
+ *
+ *   - It only ever moves rows OUT of the action lane. Nothing is promoted, and
+ *     ready / waiting / stalled / bot rows keep the lane they have today. Where
+ *     a signal doesn't clearly say otherwise, the row stays where it was.
+ *   - It never fires against a named ask (see hasNamedAsk).
+ *   - A demoted row stops at waiting and is NOT folded on to stalled, however
+ *     old it is. The stalled fold is collapsed by default and reads *decide:
+ *     nudge or close*; a row we just established is held on something outside
+ *     the owner's control must not be hidden behind that. Rows that were
+ *     already stalled stay stalled — they simply gain the reason chip.
+ *
+ * The instruction the row used to carry is dropped rather than reworded: it
+ * asserted an action that isn't owed. The hold's own reason chip replaces it,
+ * so the row still says why it is sitting there.
+ */
+function applyHold(placed, record, signals, botPingSignal) {
+  if (placed.lane !== 'action') return placed;
+  if (hasNamedAsk(record, signals, botPingSignal)) return placed;
+  return { ...placed, lane: 'waiting', ball: 'Watching', nextStep: null };
+}
+
+/**
  * Assigns lane, ball label, and nextStep for one merged record.
  *
  * Precedence, first match wins:
  *   1 bot lane          2 assigned issue        3 approval states
  *   3a linked code PR   4 direct ping at me      5 changes requested
  *   6 conflicts         7 turn-based fallback    8 stalled fold
+ *   9 definitive holds
  *
- * 1–3, 3a, and 8 live here; 4–7 live in deriveTurn. Rule 3a only fires for a
- * merged or closed-unmerged linked code PR — an open or unknown (null) state
- * falls straight through to the turn-based reading unchanged. Rules 4–6 only ever choose the
- * WORDING — the lane and ball a row lands in are decided by the turn logic and
- * by the staleness fold exactly as before.
+ * 1–3, 3a, and 8 live in laneFor; 4–7 live in deriveTurn. Rule 3a only fires
+ * for a merged or closed-unmerged linked code PR — an open or unknown (null)
+ * state falls straight through to the turn-based reading unchanged. Rules 4–6
+ * only ever choose the WORDING — the lane and ball a row lands in are decided
+ * by the turn logic and by the staleness fold exactly as before.
+ *
+ * Rule 9 runs after all of that, and only ever SUBTRACTS: a row the ladder put
+ * in the action lane is moved to waiting when something definitive says no
+ * action is owed yet (see applyHold). It cannot promote, and it cannot fire
+ * against a signal that named the owner.
  *
  * The missing-milestone reminder is deliberately NOT in that ladder: it appends
  * (see withMilestone), so it can never win a place in the order and can never
  * be crowded out of one either.
  *
- * Staleness runs LAST, and only over rows the turn logic left with someone
- * else. Age is not evidence that a row is dead — it's evidence of how overdue
- * it is — so it can never override whose turn it is. Ordering it before the
- * turn logic is what used to bury live work in a folded lane reading "nudge or
- * close": a review whose author replied 40 days ago, a review request aimed at
- * you 45 days ago, and your own PR carrying month-old maintainer feedback all
- * read as "stale" when every one of them was waiting on YOU. Assigned issues
- * were carved out of that rule first (an issue you haven't started has nobody
- * touching it, so it always ages past the threshold); this generalizes the
- * carve-out to every path where the ball is yours. Age still shows: the row
+ * Staleness runs LAST among 1–8, and only over rows the turn logic left with
+ * someone else. Age is not evidence that a row is dead — it's evidence of how
+ * overdue it is — so it can never override whose turn it is. Ordering it before
+ * the turn logic is what used to bury live work in a folded lane reading "nudge
+ * or close": a review whose author replied 40 days ago, a review request aimed
+ * at you 45 days ago, and your own PR carrying month-old maintainer feedback
+ * all read as "stale" when every one of them was waiting on YOU. Assigned
+ * issues were carved out of that rule first (an issue you haven't started has
+ * nobody touching it, so it always ages past the threshold); this generalizes
+ * the carve-out to every path where the ball is yours. Age still shows: the row
  * carries idleDays (rendered on the pill), and the action lane sorts
  * oldest-first.
  */
 function deriveLane(record, me, botPingSignal = null, signals = emptySignals()) {
-  const result = laneFor(record, me, botPingSignal, signals);
-  // Surfaced as their own fields, never spliced into nextStep, so renderers
-  // can draw them as separate chips — the way the upstream docs-PR tracker
-  // renders "Add milestone" and "Add <label> label" as chips alongside (and
-  // ahead of) the review chip rather than folding them into one sentence.
-  // The bot lane is folded away precisely so it carries no instructions.
-  const quiet = result.lane === 'bot';
+  const placed = laneFor(record, me, botPingSignal, signals);
+  // The bot lane is folded away precisely so it carries no instructions — and,
+  // by the same token, no explanations either.
+  const quiet = placed.lane === 'bot';
+  const holds = quiet ? [] : holdsFor(signals);
+  const result = holds.length ? applyHold(placed, record, signals, botPingSignal) : placed;
+
+  // Surfaced as its own field, never spliced into nextStep, so renderers can
+  // draw it as a separate chip — the way the upstream docs-PR tracker renders
+  // "Add milestone" as a chip alongside (and ahead of) the review chip rather
+  // than folding it into one sentence.
   return {
     ...result,
     milestoneMissing: signals.milestoneMissing && !quiet,
-    pendingLabelMissing: quiet ? null : signals.pendingLabelMissing || null,
+    // Shown wherever the hold is actually holding the row — which is every
+    // lane except action. Lane placement alone doesn't say WHY a row moved,
+    // and a board published so its conclusions can be checked has to show its
+    // reasoning. Suppressed on action rows on purpose: there a named ask won,
+    // so the hold's reason would sit next to, and contradict, the instruction
+    // printed beside it.
+    waitingReasons: result.lane === 'action' ? [] : holds,
   };
 }
 
@@ -802,6 +1026,22 @@ function laneFor(record, me, botPingSignal, signals) {
         lane: 'action',
         ball: 'Approved',
         nextStep: 'Note since approval — take a look, then merge',
+      };
+    }
+    // An approval from inside the education team vouches for wording and
+    // style, not for whether the content is right — so it cannot carry the row
+    // into the "approved, heading to merge" lane on its own. That lane is one
+    // of only two published on the live site, so the overstatement is public.
+    //
+    // Placed AFTER the two branches above on purpose. A dismissed approval is
+    // not counted for verification at all (see collectApprovers), and a note
+    // left after the approval is a real ask the owner owes whoever wrote it —
+    // neither may be swallowed by this. The approver is still named on the row.
+    if (approval.verified === false) {
+      return {
+        lane: 'waiting',
+        ball: 'Waiting',
+        nextStep: 'Approved by the education team — waiting on an outside review',
       };
     }
     const codeStillOpen = Boolean(linkedCodePr) || Boolean(upstream && upstream.codeUpdatedAt);
@@ -929,8 +1169,8 @@ function deriveTurn(record, me, botPingSignal = null, signals = emptySignals()) 
 }
 
 /**
- * Missing housekeeping — a milestone, or the pending-PR label on a draft — is
- * YOUR move, so the row cannot sit in a lane that means the opposite. "Waiting
+ * Missing housekeeping — a milestone — is YOUR move, so the row cannot sit in
+ * a lane that means the opposite. "Waiting
  * on others" reads *your part is done — awaiting review*, and "Stalled" reads
  * *needs a decision: nudge or close*; both are false while something is still
  * owed, and Stalled additionally folds the row shut so the chip goes unread.
@@ -953,7 +1193,7 @@ function deriveTurn(record, me, botPingSignal = null, signals = emptySignals()) 
  * the merge.
  */
 function promoteForHousekeeping(turn, signals) {
-  if (!signals.milestoneMissing && !signals.pendingLabelMissing) return turn;
+  if (!signals.milestoneMissing) return turn;
   if (turn.lane !== 'waiting') return turn;
   return { ...turn, lane: 'action', ball: 'Take Action' };
 }
@@ -1123,6 +1363,10 @@ function waitingOnReviewStep(signals) {
  *                                 (see fetchTrackerTitleInfo). Never required —
  *                                 an absent key just keeps today's null-title
  *                                 fallback.
+ * @param {object} [input.roster]  { educationTeam: [login] } from
+ *                                 fetchTeamRoster. Never required — an absent
+ *                                 or empty roster treats every approval as
+ *                                 decisive, exactly as before the rule existed.
  * @returns {{ records: Array, feed: object }}
  */
 function mergeWorkbench({
@@ -1134,10 +1378,30 @@ function mergeWorkbench({
   username,
   now,
   titles = {},
+  roster = {},
 }) {
   const me = String(username || GITHUB_USERNAME || '').toLowerCase();
   const nowDate = now || new Date();
   const tracker = (feed && feed.data) || {};
+
+  const educationTeam = (Array.isArray(roster.educationTeam) ? roster.educationTeam : [])
+    .map((s) => String(s).trim().toLowerCase())
+    .filter(Boolean);
+
+  // Which repos the tracker actually covers, read off the feed's own keys
+  // rather than listed here. That keeps the outside-approval rule scoped to
+  // the projects it is about without this repo holding a second copy of the
+  // tracker's repo list — and when the feed degrades to empty, the scope is
+  // empty too, so every approval counts exactly as it does today.
+  const trackerRepos = new Set(
+    Object.keys(tracker)
+      .map((key) => key.split('#')[0].toLowerCase())
+      .filter(Boolean)
+  );
+  const approvalContext = (repo) => ({
+    educationTeam,
+    inTrackerScope: trackerRepos.has(String(repo || '').toLowerCase()),
+  });
 
   const locals = [
     ...prs.map((r) => ({ ...r, relationship: 'authored' })),
@@ -1161,7 +1425,7 @@ function mergeWorkbench({
     const idleDays = effectiveDate ? Math.max(0, daysBetween(effectiveDate, nowDate)) : 0;
     const linkedCodePr = extractLinkedCodePr(local.body, local.repo);
     const signals = deriveSignals(local, upstream, me, nowDate);
-    const approval = deriveApproval(local, signals.activity);
+    const approval = deriveApproval(local, signals.activity, approvalContext(local.repo));
     const reviewRequest = deriveReviewRequest(signals.activity, me);
     const reviewedNote = deriveReviewedNote(signals.activity, approval, me);
     const botPingSignal = deriveBotPing(signals.activity, local, me);
@@ -1189,7 +1453,7 @@ function mergeWorkbench({
       botPing: null,
       // Set by deriveLane. Always present so renderers can rely on them.
       milestoneMissing: false,
-      pendingLabelMissing: null,
+      waitingReasons: [],
       linkedCodePr: linkedCodePr
         ? { ref: linkedCodePr, hasActivity: Boolean(upstream && upstream.codeUpdatedAt) }
         : null,
@@ -1222,7 +1486,8 @@ function mergeWorkbench({
     const [repo, number] = key.split('#');
     const titleInfo = titles[key] || null;
     const signals = deriveSignals(null, upstream, me, nowDate);
-    const approval = deriveApproval(null, signals.activity);
+    // A tracker-only row is in the tracker's scope by definition.
+    const approval = deriveApproval(null, signals.activity, approvalContext(repo));
     const reviewRequest = deriveReviewRequest(signals.activity, me);
     const reviewedNote = deriveReviewedNote(signals.activity, approval, me);
     const effectiveDate = upstream.docsUpdatedAt || null;
@@ -1252,7 +1517,7 @@ function mergeWorkbench({
       // derived — kept present and null for a uniform record contract.
       botPing: null,
       milestoneMissing: false,
-      pendingLabelMissing: null,
+      waitingReasons: [],
       linkedCodePr: titleInfo?.linkedCodePr
         ? { ref: titleInfo.linkedCodePr, hasActivity: Boolean(upstream.codeUpdatedAt) }
         : upstream.codeUpdatedAt
@@ -1410,7 +1675,7 @@ async function readJsonOr(fallback, file) {
 }
 
 /** Loads local records + tracker feed and returns the full merged model. */
-async function loadMergedWorkbench({ dataDir = 'data', fetchOptions } = {}) {
+async function loadMergedWorkbench({ dataDir = 'data', fetchOptions, rosterOptions } = {}) {
   const [tasks, issues, prs, coauthored, contributions] = await Promise.all([
     readJsonOr([], path.join(dataDir, 'ongoing-tasks.json')),
     readJsonOr([], path.join(dataDir, 'ongoing-issues.json')),
@@ -1418,7 +1683,10 @@ async function loadMergedWorkbench({ dataDir = 'data', fetchOptions } = {}) {
     readJsonOr([], path.join(dataDir, 'ongoing-coauthored-prs.json')),
     readJsonOr({}, path.join(dataDir, 'all-contributions.json')),
   ]);
-  const feed = await fetchTrackerFeed(fetchOptions);
+  const [feed, roster] = await Promise.all([
+    fetchTrackerFeed(fetchOptions),
+    fetchTeamRoster(rosterOptions),
+  ]);
 
   // Only tracker-only rows need the title enrichment fetch — a row already
   // covered by a local record carries its own title, so re-fetching it would
@@ -1436,6 +1704,7 @@ async function loadMergedWorkbench({ dataDir = 'data', fetchOptions } = {}) {
     coauthored,
     feed,
     titles,
+    roster,
   });
   const impact = computeImpact(records, contributions);
   return { records, impact, feed: feedMeta };
@@ -1443,8 +1712,11 @@ async function loadMergedWorkbench({ dataDir = 'data', fetchOptions } = {}) {
 
 module.exports = {
   TRACKER_RAW_URL,
+  ROSTER_RAW_URL,
   fetchTrackerFeed,
+  fetchTeamRoster,
   isValidTrackerShape,
+  isValidRosterShape,
   taskKey,
   extractLinkedCodePr,
   extractIssueRefs,
@@ -1452,7 +1724,6 @@ module.exports = {
   normalizeActivity,
   deriveSignals,
   tracksMilestones,
-  usesPendingLabel,
   deriveApproval,
   deriveReviewRequest,
   deriveReviewedNote,

--- a/scripts/services/workbench-merge.js
+++ b/scripts/services/workbench-merge.js
@@ -1436,6 +1436,7 @@ function mergeWorkbench({
       title: local.title || null,
       url: local.url || null,
       repo: local.repo || null,
+      number: local.number ?? null,
       relationship: local.relationship,
       labels: local.labels || [],
       isDraft: local.isDraft === true,
@@ -1499,6 +1500,7 @@ function mergeWorkbench({
       title: titleInfo?.title || null,
       url: `https://github.com/${repo}/pull/${number}`,
       repo,
+      number: Number.isNaN(Number(number)) ? null : Number(number),
       relationship: 'reviewing',
       labels: [],
       // The tracker cache stores activity arrays, not PR state, so draft

--- a/scripts/services/workbench-merge.test.js
+++ b/scripts/services/workbench-merge.test.js
@@ -2919,7 +2919,6 @@ run(
   }
 );
 
-
 // ===========================================================================
 // Tracker-only idleDays: docs PR and code PR move on separate clocks, so
 // staleness must look at whichever one moved last.
@@ -3111,6 +3110,114 @@ run(
     const r = records.find((x) => x.key === 'x/y#912');
     assert.equal(r.source, 'local');
     assert.ok(Math.abs(r.idleDays - 6) < 0.01, `idleDays was ${r.idleDays}`);
+  }
+);
+
+// ===========================================================================
+// Draft with linked work outstanding: never stale, regardless of project
+// ===========================================================================
+
+// DLW1. Draft with an unmerged (open) linked code PR, idle 40d → not stale.
+// It falls through to the normal turn-based reading instead of "nudge or
+// close" — no decision is possible from this side.
+run(
+  'DLW1 · draft with unmerged linked code PR, idle 40d → not stale',
+  {
+    tasks: [
+      local({
+        repo: 'x/y',
+        number: 920,
+        isDraft: true,
+        author: 'authorX',
+        lastActor: 'someoneElse',
+        updatedAt: daysAgo(40),
+        lastSubstantiveDate: daysAgo(40),
+        body: 'Docs for https://github.com/x/y-code/pull/5000',
+      }),
+    ],
+  },
+  ({ records }) => {
+    const r = records.find((x) => x.key === 'x/y#920');
+    assert.notEqual(r.lane, 'stalled', `lane was ${r.lane}`);
+    assert.notEqual(r.ball, 'Stale');
+  }
+);
+
+// DLW2. Draft with NO linked code PR, idle 30+d → still stale. This is
+// genuinely parked work with nothing blocking it, so the carve-out must not
+// catch it.
+run(
+  'DLW2 · draft with no linked code PR, idle 35d → still stale',
+  {
+    tasks: [
+      local({
+        repo: 'x/y',
+        number: 921,
+        isDraft: true,
+        author: 'authorX',
+        lastActor: 'someoneElse',
+        updatedAt: daysAgo(35),
+        lastSubstantiveDate: daysAgo(35),
+        body: null,
+      }),
+    ],
+  },
+  ({ records }) => {
+    const r = records.find((x) => x.key === 'x/y#921');
+    assert.equal(r.lane, 'stalled', `lane was ${r.lane}`);
+    assert.ok(/nudge or close/.test(r.nextStep), r.nextStep);
+  }
+);
+
+// DLW3. Draft whose linked code PR has MERGED → rule 3a's existing verdict
+// still wins; the new draft carve-out never gets a chance to apply, and never
+// needs to.
+run(
+  'DLW3 · draft whose linked code PR merged → normal linkedCodePrState rules apply',
+  {
+    tasks: [
+      local({
+        repo: 'x/y',
+        number: 922,
+        isDraft: true,
+        author: 'authorX',
+        lastActor: 'someoneElse',
+        updatedAt: daysAgo(40),
+        lastSubstantiveDate: daysAgo(40),
+        body: 'Docs for https://github.com/x/y-code/pull/5001',
+        linkedCodePrState: 'merged',
+      }),
+    ],
+  },
+  ({ records }) => {
+    const r = records.find((x) => x.key === 'x/y#922');
+    assert.equal(r.lane, 'action');
+    assert.equal(r.nextStep, 'Code PR merged — review the docs now');
+  }
+);
+
+// DLW4. Non-draft with an open linked code PR, idle 40d → the carve-out is
+// scoped to drafts only; a ready-for-review row still stales normally.
+run(
+  'DLW4 · non-draft with linked code PR, idle 40d → unaffected, still stales',
+  {
+    tasks: [
+      local({
+        repo: 'x/y',
+        number: 923,
+        isDraft: false,
+        author: 'authorX',
+        lastActor: 'someoneElse',
+        updatedAt: daysAgo(40),
+        lastSubstantiveDate: daysAgo(40),
+        body: 'Docs for https://github.com/x/y-code/pull/5002',
+      }),
+    ],
+  },
+  ({ records }) => {
+    const r = records.find((x) => x.key === 'x/y#923');
+    assert.equal(r.lane, 'stalled', `lane was ${r.lane}`);
+    assert.ok(/nudge or close/.test(r.nextStep), r.nextStep);
   }
 );
 

--- a/scripts/services/workbench-merge.test.js
+++ b/scripts/services/workbench-merge.test.js
@@ -1551,10 +1551,14 @@ run(
   }
 );
 
-// G8c. null (and any non-dirty state) means UNKNOWN, not clean and not
-// conflicted. Emit nothing — there is nothing to retry, the next build reads a
-// fresh value anyway.
-for (const state of [null, 'unknown', 'blocked', 'behind', 'clean']) {
+// G8c. Only `dirty` is a conflict. Every other state read here means UNKNOWN
+// as far as conflicts go — not clean and not conflicted — so emit nothing;
+// there is nothing to retry, the next build reads a fresh value anyway.
+//
+// `blocked` is deliberately absent from this list. It is not a conflict either,
+// but it is not inert: it is its own definitive signal, read in § H below. It
+// still never produces a rebase step, which § H2c re-asserts from that side.
+for (const state of [null, 'unknown', 'behind', 'clean']) {
   run(
     `G8c · mergeableState ${JSON.stringify(state)} → no conflict step`,
     {
@@ -1994,160 +1998,356 @@ run(
 );
 
 // ===========================================================================
-// Pending-PR label (§ L) — the second Mautic docs housekeeping rule, scoped by
-// its own repo list. Ported from the upstream tracker's
-// needs-label-and-milestone category, which prompts for the label on DRAFTS:
-// a draft docs PR is by definition still pending something. Once it is ready
-// for review, whether the label belongs is a judgement call about the linked
-// code PR, not a lapse — so the prompt stops.
+// Definitive holds (§ H) — mergeable_state was already fetched on every run
+// and read only half-way: it only ever acted on `dirty`. `blocked` says branch
+// protection isn't satisfied — required reviews missing, required checks
+// failing or still running — so nobody can merge the PR yet.
+//
+// That is not a reason to hide a row, so nothing is dropped: a held row moves
+// from "Needs your action" to "Waiting on others" and carries the reason with
+// it. The wording is read from contents/docs-workflow-repos.js so both
+// generators say the same thing.
 // ===========================================================================
 
-const PENDING_LABEL = 'pending-pr-merge';
+const DOCS_WORKFLOW_CONFIG = require('../../contents/docs-workflow-repos');
+const BLOCKED_REASON = DOCS_WORKFLOW_CONFIG.mergeBlockedReason;
 
-function draftRow(overrides) {
+/** A docs PR the ladder would otherwise put in the action lane: you're the
+ * reviewer, the author moved last. Milestone set on purpose — a missing one is
+ * a real job the owner owes, and § H must not be tested through it. */
+function heldCandidate(overrides) {
   return local({
     repo: 'mautic/user-documentation',
-    lastActor: ME,
-    author: ME,
-    isDraft: true,
+    lastActor: 'writerA',
+    author: 'writerA',
+    status: 'Review in progress',
+    isDraft: false,
     ...detail({ milestone: 'Q3 docs' }),
     ...overrides,
   });
 }
 
-// L1. Draft in a listed repo, label absent → chip, and the row is promoted the
-// same way a missing milestone promotes it.
+const AUTHOR_REPLIED_STEP = 'Author replied — review the latest changes';
+
+// H0 · the control. Same row, no blocked state → action lane, exactly as
+// today. Every H case below differs from this by one field only.
 run(
-  'L1 · draft without the label → flagged and promoted',
-  { prs: [draftRow({ number: 6101, labels: [] })] },
+  'H0 · control — no hold → action lane, unchanged',
+  { tasks: [heldCandidate({ number: 6201 })] },
   ({ records }) => {
-    assert.equal(records[0].pendingLabelMissing, PENDING_LABEL, records[0].pendingLabelMissing);
     assert.equal(records[0].lane, 'action', `lane was ${records[0].lane}`);
-    assert.equal(records[0].ball, 'Take Action');
-    assert.equal(records[0].nextStep, 'Draft — finish and mark ready', records[0].nextStep);
+    assert.equal(records[0].nextStep, AUTHOR_REPLIED_STEP, records[0].nextStep);
+    assert.deepEqual(records[0].waitingReasons, []);
   }
 );
 
-// L2. THE CLEARING CASE — the prompt is a live read of the PR's own labels
-// every build, never a stored flag. Add the label on GitHub and the chip is
-// gone on the next run, with nothing to reset by hand; the row drops back out
-// of the action lane too, since nothing is owed any more. Same fixture as L1
-// apart from the label, so the label is provably the only thing doing it.
+// H2 · mergeable_state blocked → out of the action lane, and the row names the
+// reason in words.
 run(
-  'L2 · adding the label clears the chip and the promotion',
-  { prs: [draftRow({ number: 6102, labels: [PENDING_LABEL] })] },
-  ({ records }) => {
-    assert.equal(records[0].pendingLabelMissing, null, records[0].pendingLabelMissing);
-    assert.equal(records[0].lane, 'waiting', 'nothing owed → back where it was');
-    assert.equal(records[0].ball, 'Waiting');
-  }
-);
-
-// L2b. Matched case-insensitively — GitHub label casing varies by who made it.
-run(
-  'L2b · label match ignores case',
-  { prs: [draftRow({ number: 6103, labels: ['Pending-PR-Merge'] })] },
-  ({ records }) => {
-    assert.equal(records[0].pendingLabelMissing, null, records[0].pendingLabelMissing);
-  }
-);
-
-// L2c. …and it is the RIGHT label that clears it, not merely having labels.
-run(
-  'L2c · unrelated labels do not clear the prompt',
-  { prs: [draftRow({ number: 6104, labels: ['needs-backport', 'content-approved'] })] },
-  ({ records }) => {
-    assert.equal(records[0].pendingLabelMissing, PENDING_LABEL, records[0].pendingLabelMissing);
-  }
-);
-
-// L3. Not a draft → no prompt, however the labels look. Once a PR is ready for
-// review the label is a judgement call, not a lapse.
-run(
-  'L3 · ready-for-review PR without the label → silent',
-  {
-    prs: [
-      local({
-        repo: 'mautic/user-documentation',
-        number: 6105,
-        lastActor: ME,
-        author: ME,
-        isDraft: false,
-        labels: [],
-        ...detail({ requestedReviewers: ['escopecz'], milestone: 'Q3 docs' }),
-      }),
-    ],
-  },
-  ({ records }) => {
-    assert.equal(records[0].pendingLabelMissing, null, records[0].pendingLabelMissing);
-  }
-);
-
-// L4. A draft in a repo that isn't on the list → silent. Same shape, only the
-// repo differs — the scope is the list, never the data.
-run(
-  'L4 · draft in a non-listed repo → silent',
-  { prs: [draftRow({ repo: 'someorg/app', number: 6106, labels: [], ...detail() })] },
-  ({ records }) => {
-    assert.equal(records[0].pendingLabelMissing, null, records[0].pendingLabelMissing);
-    assert.equal(records[0].lane, 'waiting', 'nothing owed → no promotion');
-  }
-);
-
-// L5. Both housekeeping rules at once — two independent fields, neither
-// crowding out the other nor the row's own instruction.
-run(
-  'L5 · label and milestone both missing → both fields set, step untouched',
-  {
-    prs: [
-      draftRow({
-        repo: 'mautic/developer-documentation-new',
-        number: 6107,
-        labels: ['needs-backport'],
-        ...detail({ milestone: null }),
-      }),
-    ],
-  },
-  ({ records }) => {
-    assert.equal(records[0].pendingLabelMissing, PENDING_LABEL);
-    assert.equal(records[0].milestoneMissing, true);
-    assert.equal(records[0].nextStep, 'Draft — finish and mark ready', records[0].nextStep);
-    assert.ok(!/label|milestone/i.test(records[0].nextStep), 'neither leaks into the prose');
-  }
-);
-
-// L6. Bot rows stay clean — the lane is folded away precisely so it carries no
-// instructions, and the upstream tracker exempts Dependabot for the same reason.
-run(
-  'L6 · never on the bot lane',
+  'H2 · mergeableState blocked → waiting lane, reason named in words',
   {
     tasks: [
       local({
+        repo: 'someorg/app',
+        number: 6205,
+        lastActor: 'writerA',
+        author: 'writerA',
+        status: 'Review in progress',
+        ...detail({ mergeableState: 'blocked' }),
+      }),
+    ],
+  },
+  ({ records }) => {
+    const r = records[0];
+    assert.equal(r.lane, 'waiting', `lane was ${r.lane}`);
+    assert.equal(r.ball, 'Watching');
+    assert.equal(r.nextStep, null, r.nextStep);
+    assert.deepEqual(r.waitingReasons, [BLOCKED_REASON]);
+    assert.ok(BLOCKED_REASON, 'the reason must be configured, not left to the renderers');
+  }
+);
+
+// H2b · THE RULE THAT DID NOT CHANGE. Only values GitHub states definitively
+// are acted on; `unknown` (and the null this field reports while GitHub is
+// still computing) is never guessed at, and neither is any other state.
+for (const state of [null, 'unknown', 'behind', 'clean', 'unstable', 'draft']) {
+  run(
+    `H2b · mergeableState ${JSON.stringify(state)} → nothing inferred, lane untouched`,
+    {
+      tasks: [
+        local({
+          repo: 'someorg/app',
+          number: 6206,
+          lastActor: 'writerA',
+          author: 'writerA',
+          status: 'Review in progress',
+          ...detail({ mergeableState: state }),
+        }),
+      ],
+    },
+    ({ records }) => {
+      assert.equal(records[0].lane, 'action', `lane was ${records[0].lane}`);
+      assert.deepEqual(records[0].waitingReasons, []);
+    }
+  );
+}
+
+// H2c · The two definitive states are read separately and neither swallowed
+// the other: `dirty` still means conflicts and only conflicts, and `blocked`
+// still never produces a rebase step (the § G8c case, from this side).
+run(
+  'H2c · dirty is still the conflict signal, not a hold',
+  {
+    prs: [
+      local({
+        repo: 'someorg/app',
+        number: 6207,
+        lastActor: 'reviewerQ',
+        author: ME,
+        hasFormalReview: true,
+        ...detail({ mergeableState: 'dirty', baseRef: 'main' }),
+      }),
+    ],
+  },
+  ({ records }) => {
+    assert.equal(records[0].nextStep, 'Conflicts with main — rebase needed', records[0].nextStep);
+    assert.deepEqual(records[0].waitingReasons, []);
+  }
+);
+
+run(
+  'H2d · blocked never produces a rebase step',
+  {
+    prs: [
+      local({
+        repo: 'someorg/app',
+        number: 6226,
+        lastActor: 'reviewerQ',
+        author: ME,
+        hasFormalReview: true,
+        ...detail({ mergeableState: 'blocked', baseRef: 'main' }),
+      }),
+    ],
+  },
+  ({ records }) => {
+    assert.ok(!/rebase|onflict/.test(records[0].nextStep || ''), records[0].nextStep);
+    assert.equal(records[0].lane, 'waiting', `lane was ${records[0].lane}`);
+    assert.deepEqual(records[0].waitingReasons, [BLOCKED_REASON]);
+  }
+);
+
+// ---------------------------------------------------------------------------
+// H4 · A hold never buries a request that named the owner. Each case below is
+// a held row that STAYS in the action lane — and shows no reason chip, since
+// "required checks or reviews not met" printed next to "reply to X" would
+// contradict it.
+// ---------------------------------------------------------------------------
+
+function assertNotHeld(record, step) {
+  assert.equal(record.lane, 'action', `lane was ${record.lane}`);
+  assert.deepEqual(record.waitingReasons, [], 'no contradictory reason on an action row');
+  if (step) assert.equal(record.nextStep, step, record.nextStep);
+}
+
+run(
+  'H4a · an @-mention of you outranks the hold',
+  {
+    tasks: [
+      heldCandidate({
+        number: 6209,
+        ...detail({
+          milestone: 'Q3 docs',
+          mergeableState: 'blocked',
+          comments: [{ login: 'writerA', createdAt: daysAgo(1), mentions: [ME] }],
+        }),
+      }),
+    ],
+  },
+  ({ records }) => assertNotHeld(records[0], 'writerA mentioned you 1d ago — reply')
+);
+
+// The one that matters most for `blocked`: the missing requirement is very
+// often an approving review, and if you are the requested reviewer then YOU
+// are the block. Demoting this would hide the work the board exists to show.
+run(
+  'H4b · a review request aimed at you outranks the hold',
+  {
+    tasks: [
+      heldCandidate({
+        number: 6210,
+        status: 'Request review',
+        ...detail({ milestone: 'Q3 docs', mergeableState: 'blocked' }),
+      }),
+    ],
+  },
+  ({ records }) => assertNotHeld(records[0], 'Review requested — review it')
+);
+
+run(
+  'H4c · unanswered changes requested on your own PR outrank the hold',
+  {
+    prs: [
+      local({
         repo: 'mautic/user-documentation',
-        number: 6108,
+        number: 6211,
+        lastActor: 'reviewerQ',
+        author: ME,
+        ...detail({
+          milestone: 'Q3 docs',
+          mergeableState: 'blocked',
+          reviews: [{ login: 'reviewerQ', state: 'CHANGES_REQUESTED', submittedAt: daysAgo(2) }],
+        }),
+      }),
+    ],
+  },
+  ({ records }) =>
+    assertNotHeld(records[0], 'Changes requested by reviewerQ — address the feedback')
+);
+
+// The linked code PR having merged is decisive: the docs are actionable now,
+// whatever the merge state says.
+run(
+  'H4d · a merged linked code PR outranks the hold',
+  {
+    tasks: [
+      heldCandidate({
+        number: 6212,
+        linkedCodePrState: 'merged',
+        ...detail({ milestone: 'Q3 docs', mergeableState: 'blocked' }),
+      }),
+    ],
+  },
+  ({ records }) => assertNotHeld(records[0], 'Code PR merged — review the docs now')
+);
+
+// A milestone is owed whatever the merge is waiting on, so the housekeeping
+// promotion survives — and its own chip is unaffected.
+run(
+  'H4e · missing housekeeping outranks the hold',
+  {
+    tasks: [
+      heldCandidate({
+        number: 6213,
+        ...detail({ milestone: null, mergeableState: 'blocked' }),
+      }),
+    ],
+  },
+  ({ records }) => {
+    assert.equal(records[0].lane, 'action', `lane was ${records[0].lane}`);
+    assert.equal(records[0].milestoneMissing, true);
+    assert.deepEqual(records[0].waitingReasons, []);
+  }
+);
+
+// ---------------------------------------------------------------------------
+// H6 · Lane discipline — the hold only ever subtracts from the action lane.
+// ---------------------------------------------------------------------------
+
+// A held row stops at "Waiting on others" and is NOT folded on to Stalled,
+// however old it is. Stalled is collapsed by default and reads "nudge or
+// close"; a row parked on something outside the owner's control must stay
+// visible instead of being hidden behind that.
+run(
+  'H6a · a held row stops at waiting, never folds on to stalled',
+  {
+    tasks: [
+      heldCandidate({
+        number: 6217,
+        updatedAt: daysAgo(90),
+        lastSubstantiveDate: daysAgo(90),
+        ...detail({ milestone: 'Q3 docs', mergeableState: 'blocked' }),
+      }),
+    ],
+  },
+  ({ records }) => {
+    assert.ok(records[0].idleDays >= 30, `idleDays was ${records[0].idleDays}`);
+    assert.equal(records[0].lane, 'waiting', `lane was ${records[0].lane}`);
+    assert.deepEqual(records[0].waitingReasons, [BLOCKED_REASON]);
+  }
+);
+
+// A row that was ALREADY stalled keeps that lane — the hold never moves rows
+// between non-action lanes — but it gains the reason, so the fold no longer
+// says "nudge or close" without saying what it is waiting on.
+run(
+  'H6b · an already-stalled row keeps its lane and gains the reason',
+  {
+    tasks: [
+      heldCandidate({
+        number: 6218,
+        lastActor: 'thirdparty',
+        updatedAt: daysAgo(90),
+        lastSubstantiveDate: daysAgo(90),
+        ...detail({ milestone: 'Q3 docs', mergeableState: 'blocked' }),
+      }),
+    ],
+  },
+  ({ records }) => {
+    assert.equal(records[0].lane, 'stalled', `lane was ${records[0].lane}`);
+    assert.deepEqual(records[0].waitingReasons, [BLOCKED_REASON]);
+  }
+);
+
+// An approved row is never demoted either: "bring it home" is a different
+// claim from "your move", and the Approved pill carries information the
+// waiting lane would throw away.
+run(
+  'H6c · an approved row keeps the ready lane and gains the reason',
+  {
+    tasks: [
+      heldCandidate({
+        number: 6219,
+        reviewState: 'APPROVED',
+        approvedBy: 'maintainerZ',
+        ...detail({
+          milestone: 'Q3 docs',
+          mergeableState: 'blocked',
+          reviews: [{ login: 'maintainerZ', state: 'APPROVED', submittedAt: daysAgo(1) }],
+        }),
+      }),
+    ],
+  },
+  ({ records }) => {
+    assert.equal(records[0].lane, 'ready', `lane was ${records[0].lane}`);
+    assert.equal(records[0].ball, 'Approved');
+    assert.deepEqual(records[0].waitingReasons, [BLOCKED_REASON]);
+  }
+);
+
+// H6d · Bot rows stay clean. The lane is folded away precisely so it carries
+// neither instructions nor explanations.
+run(
+  'H6d · never on the bot lane',
+  {
+    tasks: [
+      heldCandidate({
+        number: 6220,
         user: { login: 'dependabot[bot]' },
         author: 'dependabot[bot]',
         title: 'Bump lodash from 4 to 5',
-        isDraft: true,
-        labels: [],
-        ...detail({ milestone: null }),
+        ...detail({ milestone: 'Q3 docs', mergeableState: 'blocked' }),
       }),
     ],
   },
   ({ records }) => {
     assert.equal(records[0].lane, 'bot');
-    assert.equal(records[0].pendingLabelMissing, null);
-    assert.equal(records[0].milestoneMissing, false);
+    assert.deepEqual(records[0].waitingReasons, []);
   }
 );
 
-// L7. Present on every record, so renderers never guard for undefined.
+// H7 · Present on every record as an array of strings, tracker-only rows
+// included, so both generators can loop over it without guarding for
+// undefined.
 run(
-  'L7 · the field is present on every record',
+  'H7 · the field is an array on every record',
   {
-    prs: [local({ repo: 'someorg/app', number: 6109, lastActor: ME, author: ME })],
+    prs: [local({ repo: 'someorg/app', number: 6221, lastActor: ME, author: ME })],
+    tasks: [
+      heldCandidate({ number: 6222, ...detail({ milestone: 'Q3 docs', mergeableState: 'blocked' }) }),
+    ],
+    issues: [local({ repo: 'mautic/user-documentation', number: 6223 })],
     tracker: {
-      'mautic/user-documentation#6110': {
+      'mautic/user-documentation#6224': {
         docsUpdatedAt: daysAgo(3),
         rawDocsReviews: [],
         rawDocsComments: [],
@@ -2156,14 +2356,256 @@ run(
   },
   ({ records }) => {
     for (const r of records) {
-      assert.ok('pendingLabelMissing' in r, `missing on ${r.key}`);
-      assert.ok(
-        r.pendingLabelMissing === null || typeof r.pendingLabelMissing === 'string',
-        `bad type on ${r.key}: ${typeof r.pendingLabelMissing}`
-      );
+      assert.ok(Array.isArray(r.waitingReasons), `not an array on ${r.key}`);
+      for (const reason of r.waitingReasons) {
+        assert.equal(typeof reason, 'string', `a non-string reason on ${r.key}`);
+        assert.ok(reason, `a reason with nothing to say on ${r.key}`);
+      }
     }
+    // An assigned issue has no merge state to read.
+    const issue = records.find((r) => r.relationship === 'assigned issue');
+    assert.deepEqual(issue.waitingReasons, []);
+    // A tracker-only row carries no local merge state to read either.
+    const trackerOnly = records.find((r) => r.source === 'tracker');
+    assert.deepEqual(trackerOnly.waitingReasons, []);
   }
 );
+
+// ===========================================================================
+// Outside verification of approvals (§ V)
+//
+// An approval from inside the education team is not the same as the content
+// being verified. An operator approving a docs PR vouches for wording and
+// style, not for whether the content is accurate — only an approval from
+// OUTSIDE that team (the code PR's author, or another outside reviewer) means
+// the work has genuinely been checked.
+//
+// The roster is `educationTeam` in maintainers.json at the root of the same
+// public tracker repo this project already reads its feed from, fetched with
+// the same degradation discipline. The logins are never written down here:
+// the roster belongs to the team and changes without reference to this tool.
+// ===========================================================================
+
+const ROSTER = { educationTeam: ['insider1', 'INSIDER2'] };
+
+/** A tracker feed covering the docs repo, which is what puts a row inside the
+ * rule's scope: the scope is read off the feed's own keys, never listed here. */
+function trackerCovering(repo, number = 9001) {
+  return {
+    [`${repo}#${number}`]: {
+      docsUpdatedAt: daysAgo(3),
+      rawDocsReviews: [],
+      rawDocsComments: [],
+    },
+  };
+}
+
+/** An approved docs PR you are reviewing, approved by `approvedBy`. */
+function approvedRow(approvedBy, overrides = {}) {
+  return local({
+    repo: 'mautic/user-documentation',
+    number: 6301,
+    lastActor: approvedBy,
+    author: 'writerA',
+    reviewState: 'APPROVED',
+    approvedBy,
+    ...detail({
+      milestone: 'Q3 docs',
+      reviews: [{ login: approvedBy, state: 'APPROVED', submittedAt: daysAgo(1) }],
+    }),
+    ...overrides,
+  });
+}
+
+// V1 · approved from INSIDE the team → not decisive. The row leaves the
+// "approved, heading to merge" lane, which is one of only two lanes published
+// on the live site, and says what it is actually waiting for. The approver is
+// still named on the row.
+run(
+  'V1 · an education-team approval is not decisive',
+  {
+    tasks: [approvedRow('insider1')],
+    tracker: trackerCovering('mautic/user-documentation'),
+    roster: ROSTER,
+  },
+  ({ records }) => {
+    const r = records.find((x) => x.key === 'mautic/user-documentation#6301');
+    assert.equal(r.lane, 'waiting', `lane was ${r.lane}`);
+    assert.equal(r.ball, 'Waiting');
+    assert.equal(r.approval.verified, false);
+    assert.equal(r.approval.by, 'insider1', 'who approved is still recorded');
+    assert.equal(
+      r.nextStep,
+      'Approved by the education team — waiting on an outside review',
+      r.nextStep
+    );
+  }
+);
+
+// V1b · roster logins are matched case-insensitively, the way every other
+// login comparison in this engine is.
+run(
+  'V1b · roster matching ignores case',
+  {
+    tasks: [approvedRow('Insider2')],
+    tracker: trackerCovering('mautic/user-documentation'),
+    roster: ROSTER,
+  },
+  ({ records }) => {
+    const r = records.find((x) => x.key === 'mautic/user-documentation#6301');
+    assert.equal(r.approval.verified, false);
+    assert.equal(r.lane, 'waiting', `lane was ${r.lane}`);
+  }
+);
+
+// V2 · approved from OUTSIDE the team → decisive, exactly as today. The
+// content has been checked by someone who can vouch for it.
+run(
+  'V2 · an outside approval is decisive',
+  {
+    tasks: [approvedRow('outsiderX')],
+    tracker: trackerCovering('mautic/user-documentation'),
+    roster: ROSTER,
+  },
+  ({ records }) => {
+    const r = records.find((x) => x.key === 'mautic/user-documentation#6301');
+    assert.equal(r.lane, 'ready', `lane was ${r.lane}`);
+    assert.equal(r.ball, 'Approved');
+    assert.equal(r.approval.verified, true);
+  }
+);
+
+// V2b · one outside approval is enough, even alongside an in-team one.
+run(
+  'V2b · an outside approval alongside an in-team one still counts',
+  {
+    tasks: [
+      approvedRow('insider1', {
+        ...detail({
+          milestone: 'Q3 docs',
+          reviews: [
+            { login: 'insider1', state: 'APPROVED', submittedAt: daysAgo(2) },
+            { login: 'outsiderX', state: 'APPROVED', submittedAt: daysAgo(1) },
+          ],
+        }),
+      }),
+    ],
+    tracker: trackerCovering('mautic/user-documentation'),
+    roster: ROSTER,
+  },
+  ({ records }) => {
+    const r = records.find((x) => x.key === 'mautic/user-documentation#6301');
+    assert.equal(r.approval.verified, true);
+    assert.equal(r.lane, 'ready', `lane was ${r.lane}`);
+  }
+);
+
+// V3 · THE DEGRADATION CASE. The roster failed to fetch and no cached copy
+// exists, so it arrives empty — and every approval is decisive, exactly as the
+// code behaved before this rule existed. A file that failed to download must
+// never look like a judgement about someone's content.
+run(
+  'V3 · no roster (fetch failed, no cache) → every approval is decisive',
+  {
+    tasks: [approvedRow('insider1')],
+    tracker: trackerCovering('mautic/user-documentation'),
+    roster: { educationTeam: [] },
+  },
+  ({ records }) => {
+    const r = records.find((x) => x.key === 'mautic/user-documentation#6301');
+    assert.equal(r.lane, 'ready', `lane was ${r.lane}`);
+    assert.equal(r.ball, 'Approved');
+    assert.equal(r.approval.verified, true);
+  }
+);
+
+// V3b · the roster argument omitted entirely behaves the same way.
+run(
+  'V3b · no roster argument at all → every approval is decisive',
+  {
+    tasks: [approvedRow('insider1')],
+    tracker: trackerCovering('mautic/user-documentation'),
+  },
+  ({ records }) => {
+    const r = records.find((x) => x.key === 'mautic/user-documentation#6301');
+    assert.equal(r.lane, 'ready', `lane was ${r.lane}`);
+    assert.equal(r.approval.verified, true);
+  }
+);
+
+// V4 · SCOPE. The same in-team login approving in a repo the tracker does not
+// cover changes nothing: an education-team approval means nothing in an
+// unrelated org, and applying the rule everywhere would quietly demote
+// approvals from projects it was never about.
+run(
+  'V4 · an approval outside the tracker\'s repos is unaffected',
+  {
+    tasks: [approvedRow('insider1', { repo: 'someorg/app', number: 6302, ...detail({
+      reviews: [{ login: 'insider1', state: 'APPROVED', submittedAt: daysAgo(1) }],
+    }) })],
+    tracker: trackerCovering('mautic/user-documentation'),
+    roster: ROSTER,
+  },
+  ({ records }) => {
+    const r = records.find((x) => x.key === 'someorg/app#6302');
+    assert.equal(r.lane, 'ready', `lane was ${r.lane}`);
+    assert.equal(r.approval.verified, true);
+  }
+);
+
+// V4b · A note left AFTER an in-team approval is still a real ask the owner
+// owes whoever wrote it, so it keeps the action lane. The verification rule
+// only ever removes the "approved, heading to merge" claim — it must not
+// swallow a request that named the owner.
+run(
+  'V4b · a note since the approval still outranks the verification rule',
+  {
+    tasks: [
+      approvedRow('insider1', {
+        ...detail({
+          milestone: 'Q3 docs',
+          reviews: [{ login: 'insider1', state: 'APPROVED', submittedAt: daysAgo(2) }],
+          comments: [{ login: 'writerA', createdAt: daysAgo(1) }],
+        }),
+      }),
+    ],
+    tracker: trackerCovering('mautic/user-documentation'),
+    roster: ROSTER,
+  },
+  ({ records }) => {
+    const r = records.find((x) => x.key === 'mautic/user-documentation#6301');
+    assert.equal(r.lane, 'action', `lane was ${r.lane}`);
+    assert.equal(r.nextStep, 'Note since approval — take a look, then merge', r.nextStep);
+    assert.equal(r.approval.verified, false, 'the approval is still not decisive');
+  }
+);
+
+// V5 · A DISMISSED approval names an approver but is not a standing verdict on
+// the content, so it is not counted either way — the row keeps the "re-request
+// the review" reading it has today.
+run(
+  'V5 · a dismissed approval keeps its re-request reading',
+  {
+    tasks: [
+      approvedRow('insider1', {
+        reviewState: null,
+        approvedBy: null,
+        ...detail({
+          milestone: 'Q3 docs',
+          reviews: [{ login: 'insider1', state: 'DISMISSED', submittedAt: daysAgo(1) }],
+        }),
+      }),
+    ],
+    tracker: trackerCovering('mautic/user-documentation'),
+    roster: ROSTER,
+  },
+  ({ records }) => {
+    const r = records.find((x) => x.key === 'mautic/user-documentation#6301');
+    assert.equal(r.lane, 'ready', `lane was ${r.lane}`);
+    assert.equal(r.nextStep, 'Re-request review from insider1', r.nextStep);
+  }
+);
+
 
 // ===========================================================================
 // Idle wording (§ I) — nextStep states the reason plainly at any age. Age

--- a/scripts/services/workbench-merge.test.js
+++ b/scripts/services/workbench-merge.test.js
@@ -726,7 +726,7 @@ run(
     assert.equal(r.ball, 'Take Action');
     assert.equal(
       r.nextStep,
-      'promptless-for-oss mentioned you 1d ago — reply',
+      'Mentioned by promptless-for-oss 1d ago — reply',
       `nextStep was: ${r.nextStep}`
     );
     assert.ok(!r.botPing, 'no botPing when the bot pinged me');
@@ -1140,7 +1140,7 @@ function detail(overrides = {}) {
 
 // G1. Reviewing, you moved last → the row can finally say why it's parked.
 run(
-  'G1 · reviewing, I reviewed last → "You reviewed Nd ago — author hasn\'t replied"',
+  'G1 · reviewing, I reviewed last → "Reviewed Nd ago — author hasn\'t replied"',
   {
     tasks: [
       local({
@@ -1158,7 +1158,7 @@ run(
     assert.equal(r.upstream, null);
     assert.equal(r.lane, 'waiting');
     assert.equal(r.ball, 'Waiting');
-    assert.equal(r.nextStep, "You reviewed 4d ago — author hasn't replied", r.nextStep);
+    assert.equal(r.nextStep, "Reviewed 4d ago — author hasn't replied", r.nextStep);
   }
 );
 
@@ -1294,7 +1294,7 @@ run(
 
 // G3. Your own PR, you spoke last → say when, and who owes you.
 run(
-  'G3 · authored, I replied last → "You replied Nd ago — waiting on LOGIN"',
+  'G3 · authored, I replied last → "Replied Nd ago — waiting on LOGIN"',
   {
     prs: [
       local({
@@ -1312,7 +1312,7 @@ run(
   ({ records }) => {
     const r = records[0];
     assert.equal(r.lane, 'waiting');
-    assert.equal(r.nextStep, 'You replied 3d ago — waiting on maintainerZ', r.nextStep);
+    assert.equal(r.nextStep, 'Replied 3d ago — waiting on maintainerZ', r.nextStep);
   }
 );
 
@@ -1343,7 +1343,7 @@ run(
   ({ records }) => {
     const r = records[0];
     assert.equal(r.lane, 'waiting');
-    assert.equal(r.nextStep, 'You replied 10d ago — waiting on andersonjeccel', r.nextStep);
+    assert.equal(r.nextStep, 'Replied 10d ago — waiting on andersonjeccel', r.nextStep);
   }
 );
 
@@ -1422,7 +1422,7 @@ run(
 
 // G6. A direct @-mention outranks the turn reading — being named is being asked.
 run(
-  'G6 · @-mention of me → "LOGIN mentioned you Nd ago — reply"',
+  'G6 · @-mention of me → "Mentioned by LOGIN Nd ago — reply"',
   {
     tasks: [
       local({
@@ -1439,7 +1439,7 @@ run(
   ({ records }) => {
     const r = records[0];
     assert.equal(r.lane, 'action', 'lane still comes from the turn reading');
-    assert.equal(r.nextStep, 'writerA mentioned you 2d ago — reply', r.nextStep);
+    assert.equal(r.nextStep, 'Mentioned by writerA 2d ago — reply', r.nextStep);
   }
 );
 
@@ -1464,7 +1464,7 @@ run(
     ],
   },
   ({ records }) => {
-    assert.ok(!/mentioned you/.test(records[0].nextStep || ''), records[0].nextStep);
+    assert.ok(!/^Mentioned by/.test(records[0].nextStep || ''), records[0].nextStep);
   }
 );
 
@@ -1612,7 +1612,7 @@ run(
   ({ records }) => {
     assert.equal(
       records[0].nextStep,
-      'reviewerQ mentioned you 1d ago — reply',
+      'Mentioned by reviewerQ 1d ago — reply',
       records[0].nextStep
     );
   }
@@ -1644,7 +1644,7 @@ run(
   ({ records }) => {
     assert.equal(
       records[0].nextStep,
-      'You replied 2d ago — waiting on escopecz',
+      'Replied 2d ago — waiting on escopecz',
       records[0].nextStep
     );
   }
@@ -1693,7 +1693,7 @@ run(
     assertMilestone(records[0], true);
     assert.equal(
       records[0].nextStep,
-      'You replied 2d ago — waiting on escopecz',
+      'Replied 2d ago — waiting on escopecz',
       records[0].nextStep
     );
   }
@@ -1718,7 +1718,7 @@ run(
     assertMilestone(records[0], false);
     assert.equal(
       records[0].nextStep,
-      'You replied 2d ago — waiting on escopecz',
+      'Replied 2d ago — waiting on escopecz',
       records[0].nextStep
     );
   }
@@ -2163,7 +2163,7 @@ run(
       }),
     ],
   },
-  ({ records }) => assertNotHeld(records[0], 'writerA mentioned you 1d ago — reply')
+  ({ records }) => assertNotHeld(records[0], 'Mentioned by writerA 1d ago — reply')
 );
 
 // The one that matters most for `blocked`: the missing requirement is very
@@ -2670,7 +2670,7 @@ run(
   ({ records }) => {
     assert.equal(
       records[0].nextStep,
-      "You reviewed 20d ago — author hasn't replied",
+      "Reviewed 20d ago — author hasn't replied",
       records[0].nextStep
     );
     assert.ok(!/idle 20d/.test(records[0].nextStep), 'no "20d ago · idle 20d"');

--- a/scripts/services/workbench-merge.test.js
+++ b/scripts/services/workbench-merge.test.js
@@ -2919,6 +2919,201 @@ run(
   }
 );
 
+
+// ===========================================================================
+// Tracker-only idleDays: docs PR and code PR move on separate clocks, so
+// staleness must look at whichever one moved last.
+// ===========================================================================
+
+// TID1. Docs PR moved recently, code PR is stale → idleDays follows docs.
+run(
+  'TID1 · tracker-only, docs newer than code → idleDays from docs date',
+  {
+    tracker: {
+      'mautic/user-documentation#900': {
+        docsUpdatedAt: daysAgo(2),
+        codeUpdatedAt: daysAgo(83),
+        rawDocsReviews: [],
+        rawDocsComments: [],
+      },
+    },
+  },
+  ({ records }) => {
+    const r = records.find((x) => x.key === 'mautic/user-documentation#900');
+    assert.ok(Math.abs(r.idleDays - 2) < 0.01, `idleDays was ${r.idleDays}`);
+    assert.notEqual(r.lane, 'stalled', `lane was ${r.lane}`);
+  }
+);
+
+// TID1b. The combined clock feeds idleDays and STOPS THERE. `updatedAt` stays
+// the docs PR's own date on both record paths, because it answers a different
+// question ("when did this row last change") and is published in
+// data/workbench.json, where a consumer would read it that way. Pinned as a
+// test because the two fields sit on adjacent lines and the wrong one is an
+// easy, silent thing to reach for.
+run(
+  'TID1b · tracker-only, updatedAt stays the docs date even when code is newer',
+  {
+    tracker: {
+      'mautic/user-documentation#902': {
+        docsUpdatedAt: daysAgo(83),
+        codeUpdatedAt: daysAgo(1),
+        rawDocsReviews: [],
+        rawDocsComments: [],
+      },
+    },
+  },
+  ({ records }) => {
+    const r = records.find((x) => x.key === 'mautic/user-documentation#902');
+    assert.equal(r.updatedAt, r.upstream.docsUpdatedAt, `updatedAt was ${r.updatedAt}`);
+    assert.notEqual(r.updatedAt, r.upstream.codeUpdatedAt, 'updatedAt must not follow the code PR');
+    assert.ok(Math.abs(r.idleDays - 1) < 0.01, `idleDays was ${r.idleDays}`);
+  }
+);
+
+// TID2. Code PR moved recently, docs PR is stale → idleDays follows code, not
+// docs. This is the bug: previously idleDays only ever looked at docsUpdatedAt,
+// so a pair whose code PR moved today still reported 83 days idle.
+run(
+  'TID2 · tracker-only, code newer than docs → idleDays from code date',
+  {
+    tracker: {
+      'mautic/user-documentation#901': {
+        docsUpdatedAt: daysAgo(83),
+        codeUpdatedAt: daysAgo(1),
+        rawDocsReviews: [],
+        rawDocsComments: [],
+      },
+    },
+  },
+  ({ records }) => {
+    const r = records.find((x) => x.key === 'mautic/user-documentation#901');
+    assert.ok(Math.abs(r.idleDays - 1) < 0.01, `idleDays was ${r.idleDays}`);
+    assert.notEqual(r.lane, 'stalled', `lane was ${r.lane}`);
+  }
+);
+
+// TID3. codeUpdatedAt absent → idleDays falls back to docsUpdatedAt alone.
+run(
+  'TID3 · tracker-only, codeUpdatedAt missing → idleDays from docs date',
+  {
+    tracker: {
+      'mautic/user-documentation#902': {
+        docsUpdatedAt: daysAgo(5),
+        codeUpdatedAt: null,
+        rawDocsReviews: [],
+        rawDocsComments: [],
+      },
+    },
+  },
+  ({ records }) => {
+    const r = records.find((x) => x.key === 'mautic/user-documentation#902');
+    assert.ok(Math.abs(r.idleDays - 5) < 0.01, `idleDays was ${r.idleDays}`);
+  }
+);
+
+// TID4. Both dates absent → idleDays stays 0, matching the pre-existing
+// no-date fallback (a missing date is not the same as "idle forever").
+run(
+  'TID4 · tracker-only, both dates missing → idleDays is 0',
+  {
+    tracker: {
+      'mautic/user-documentation#903': {
+        docsUpdatedAt: null,
+        codeUpdatedAt: null,
+        rawDocsReviews: [],
+        rawDocsComments: [],
+      },
+    },
+  },
+  ({ records }) => {
+    const r = records.find((x) => x.key === 'mautic/user-documentation#903');
+    assert.equal(r.idleDays, 0, `idleDays was ${r.idleDays}`);
+  }
+);
+
+// TID5. Matched local+tracker row: lastSubstantiveDate is more recent than
+// codeUpdatedAt → the local, more-precise date still wins.
+run(
+  'TID5 · matched pair, lastSubstantiveDate newer than code → local date wins',
+  {
+    tasks: [
+      local({
+        repo: 'mautic/user-documentation',
+        number: 910,
+        lastSubstantiveDate: daysAgo(2),
+        updatedAt: daysAgo(2),
+      }),
+    ],
+    tracker: {
+      'mautic/user-documentation#910': {
+        docsUpdatedAt: daysAgo(2),
+        codeUpdatedAt: daysAgo(40),
+        rawDocsReviews: [],
+        rawDocsComments: [],
+      },
+    },
+  },
+  ({ records }) => {
+    const r = records.find((x) => x.key === 'mautic/user-documentation#910');
+    assert.equal(r.source, 'local+tracker');
+    assert.ok(Math.abs(r.idleDays - 2) < 0.01, `idleDays was ${r.idleDays}`);
+  }
+);
+
+// TID6. Matched local+tracker row: codeUpdatedAt is more recent than
+// lastSubstantiveDate → the code PR's activity pulls the row out of stalled,
+// same as the tracker-only path.
+run(
+  'TID6 · matched pair, code newer than lastSubstantiveDate → code date wins, leaves stalled',
+  {
+    tasks: [
+      local({
+        repo: 'mautic/user-documentation',
+        number: 911,
+        lastSubstantiveDate: daysAgo(83),
+        updatedAt: daysAgo(83),
+      }),
+    ],
+    tracker: {
+      'mautic/user-documentation#911': {
+        docsUpdatedAt: daysAgo(83),
+        codeUpdatedAt: daysAgo(1),
+        rawDocsReviews: [],
+        rawDocsComments: [],
+      },
+    },
+  },
+  ({ records }) => {
+    const r = records.find((x) => x.key === 'mautic/user-documentation#911');
+    assert.equal(r.source, 'local+tracker');
+    assert.ok(Math.abs(r.idleDays - 1) < 0.01, `idleDays was ${r.idleDays}`);
+    assert.notEqual(r.lane, 'stalled', `lane was ${r.lane}`);
+  }
+);
+
+// TID7. Matched row with no tracker entry (source 'local', upstream null) →
+// codeUpdatedAt has nothing to read, idleDays falls back to the local chain
+// exactly as before. Guards against a null-upstream crash.
+run(
+  'TID7 · local-only row, no tracker entry → idleDays from local chain, no crash',
+  {
+    tasks: [
+      local({
+        repo: 'x/y',
+        number: 912,
+        lastSubstantiveDate: daysAgo(6),
+        updatedAt: daysAgo(6),
+      }),
+    ],
+  },
+  ({ records }) => {
+    const r = records.find((x) => x.key === 'x/y#912');
+    assert.equal(r.source, 'local');
+    assert.ok(Math.abs(r.idleDays - 6) < 0.01, `idleDays was ${r.idleDays}`);
+  }
+);
+
 // ===========================================================================
 // UTC period boundaries
 // ===========================================================================

--- a/scripts/src/main.js
+++ b/scripts/src/main.js
@@ -49,6 +49,7 @@ const { createWorkbenchHtml } = require('../generators/html/workbench-html-gener
 const { createRedirectStubs } = require('../generators/html/redirect-stub-generator');
 const { createGlossaryHtml } = require('../generators/html/glossary-html-generator');
 const { loadMergedWorkbench } = require('../services/workbench-merge');
+const { writeWorkbenchData } = require('../services/workbench-data');
 const skillsData = require('../../contents/skills');
 const recognitionsData = require('../../contents/recognitions');
 // Milestone sources — keys must match MILESTONE_SOURCES in
@@ -498,6 +499,12 @@ async function main() {
     if (workbenchModel.feed.degraded) {
       console.warn(`Workbench tracker feed degraded: ${workbenchModel.feed.reason}`);
     }
+
+    // Publish the classified model as data, from the same in-memory object the
+    // generators below render from. See services/workbench-data.js for the
+    // contract — other projects read this file.
+    const workbenchDataFile = await writeWorkbenchData(workbenchModel, { dataDir });
+    console.log(`Saved merged workbench model to ${workbenchDataFile}.`);
 
     // 4. Generate landing page (index.html)
     console.log('Generating landing page...');


### PR DESCRIPTION
## Description

The Workbench was making several claims that were not true, one of them on a page that is already public. This corrects them, and publishes the classified model as data so a second implementation of the same rules can be retired.

**Approvals now check who approved.** An approval from inside the docs Education Team vouches for wording and style, not for whether the content is accurate. Only an approval from outside that team — the code PR's author, or another outside reviewer — means the work has genuinely been checked. Previously any approval routed a row to "approved, heading to merge", which is one of only two lanes published on adiati.com, so the claim was overstated in public. The team roster is read from the docs-PR tracker project, cached, and degrades safely: if it cannot be fetched and no cached copy exists, every approval stays decisive exactly as before. A download failure must never look like a content judgement.

**The `pending-pr-merge` label rule is removed.** The upstream tracker now signals "waiting on the code PR" with draft state instead of a hand-added label, and removed its own prompt to add one. Ours was asking for a label the workflow no longer uses.

**Staleness counts both sides of a docs/code pair.** A docs PR and its linked code PR sat on separate clocks, so a pair whose code PR moved the same morning could still report months of idle time and be flagged for a nudge-or-close decision. One row read "Idle 83d" against a code PR that had moved hours earlier. Both record paths now take the later of the two dates. On the matched path the existing `lastSubstantiveDate` chain is kept and the code date added as one more candidate rather than replacing it, since `lastSubstantiveDate` is the last genuine event and a raw `updated_at` is bumped by bots and label edits.

**A draft with unresolved linked work is never stale.** That shape means waiting on someone else by design, and no nudge-or-close decision is possible from the docs side. Scoped to the shape, not to any repo list. Drafts with nothing blocking them still go stale normally.

Eleven rows left the stalled lane as a result, from 27 to 16. Three long-parked personal drafts stayed exactly where they were, which is the distinction that matters.

**The Workbench page is now written for a reader.** It kept all five lanes and every row on purpose — it is the complete board the summary on adiati.com is derived from, and publishing it whole is what lets that summary be checked. But it was written in the second person, as notes to self, which reads as a confession to a stranger. It now describes situations instead, says what the page is, and links to the summary.

**`data/workbench.json` is new, and is a published contract.** It carries the classified model — lane, ball, next step, holds, approval verdict — built from the same in-memory model the pages render from, so the data and the page cannot disagree. adiati.com currently reimplements this classification in about 1,250 lines of TypeScript; this is what lets that be deleted. It carries a `schemaVersion`: adding a field is safe, removing one or changing its meaning is not.

### Notes

- Generated output under `contributions/` and `data/` is left to the scheduled job, matching how this branch's earlier commits were made.
- There is no CI running the test suite. This branch takes it to 141 cases covering rules that are subtle and easy to break quietly. Worth a follow-up.
